### PR TITLE
Refactor: Introduce ODEParameters type to formalize SciML p slot

### DIFF
--- a/ext/CTFlowsSciMLExt.jl
+++ b/ext/CTFlowsSciMLExt.jl
@@ -289,7 +289,8 @@ Build an `ODEProblem` from a system and configuration.
 function Integrators.build_problem(integ::SciML, system::Systems.AbstractSystem, config::Common.AbstractConfig; variable)
     f! = Systems.rhs!(system)
     u0 = Common.initial_condition(config)
-    prob = ODEProblem(f!, u0, Common.tspan(config), variable)
+    p = Common.ODEParameters(variable)
+    prob = ODEProblem(f!, u0, Common.tspan(config), p)
     return prob
 end
 

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -18,6 +18,7 @@ import CTBase.Exceptions
 include(joinpath(@__DIR__, "abstract_tag.jl"))
 include(joinpath(@__DIR__, "configs.jl"))
 include(joinpath(@__DIR__, "traits.jl"))
+include(joinpath(@__DIR__, "ode_parameters.jl"))
 include(joinpath(@__DIR__, "default.jl"))
 
 # ==============================================================================
@@ -27,6 +28,7 @@ include(joinpath(@__DIR__, "default.jl"))
 export AbstractTag, AbstractConfig, PointConfig, TrajectoryConfig, tspan, initial_condition, unwrap_state
 export TimeDependence, Autonomous, NonAutonomous
 export VariableDependence, Fixed, NonFixed
+export ODEParameters
 export has_time_dependence_trait, has_variable_dependence_trait
 export time_dependence, variable_dependence
 export is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable

--- a/src/Common/ode_parameters.jl
+++ b/src/Common/ode_parameters.jl
@@ -1,0 +1,42 @@
+"""
+$(TYPEDEF)
+
+Wrapper type for parameters passed through SciML's `p` slot.
+
+This type formalizes the contract for what transits in the ODE problem's
+parameter slot. For CTFlows, the primary content is the variable parameter
+for `NonFixed` systems (or `nothing` for `Fixed` systems).
+
+The wrapper makes the contract explicit and extensible — additional fields
+can be added later (callbacks, extra data) without breaking existing code.
+
+# Fields
+- `variable::V`: The variable parameter (or `nothing` for `Fixed` systems).
+
+# Constructor Validation
+
+- `V` can be `Nothing` (for `Fixed` systems) or any concrete type (for `NonFixed`).
+- No validation is performed at construction — the system's `VariableDependence`
+  trait determines whether `variable` should be used.
+
+# Example
+\`\`\`julia
+using CTFlows.Common
+
+# Fixed system: variable is nothing
+params_fixed = ODEParameters(nothing)
+
+# NonFixed system: variable is a value
+params_nonfixed = ODEParameters(0.5)
+\`\`\`
+
+# Notes
+- This type is used exclusively by the SciML extension to wrap the variable
+  before passing it to `ODEProblem`.
+- The RHS closure reads `p.variable` to access the actual variable value.
+
+See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
+"""
+struct ODEParameters{V}
+    variable::V
+end

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -3,7 +3,8 @@ $(TYPEDEF)
 
 Concrete `AbstractSystem` wrapping a `VectorField`. The variable for
 `NonFixed` vector fields is **not** stored here; it is passed at flow-call
-time via the `variable` kwarg and threaded through `ODEProblem`'s `p` slot.
+time via the `variable` kwarg and threaded through `ODEProblem`'s `p` slot
+wrapped in a `Common.ODEParameters` struct.
 
 # Fields
 - `vf::VectorField{F, TD, VD}`: the underlying vector field.
@@ -26,7 +27,7 @@ VectorFieldSystem
   vector_field: VectorField{var"#1", Autonomous, Fixed}
 \`\`\`
 
-See also: [`CTFlows.Systems.AbstractSystem`](@ref), [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+See also: [`CTFlows.Systems.AbstractSystem`](@ref), [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """
 struct VectorFieldSystem{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, RHS<:Function} <: AbstractSystem{TD, VD}
     vf::Data.VectorField{F, TD, VD}
@@ -34,7 +35,7 @@ struct VectorFieldSystem{F<:Function, TD<:Common.TimeDependence, VD<:Common.Vari
 
     function VectorFieldSystem(vf::Data.VectorField{F, TD, VD}) where {F, TD, VD}
         rhs = function (du, u, p, t)
-            du .= vf(t, u, p)
+            du .= vf(t, u, p.variable)
             return nothing
         end
         return new{F, TD, VD, typeof(rhs)}(vf, rhs)
@@ -47,7 +48,8 @@ $(TYPEDSIGNATURES)
 In-place right-hand side for a `VectorFieldSystem`. Returns the pre-computed
 closure stored in the system, which has signature `(du, u, p, t) -> nothing` and
 uses the uniform `(t, x, v)` call on the underlying `VectorField`, where `p`
-carries the variable (or `nothing` for `Fixed` systems).
+is a `Common.ODEParameters` wrapper containing the variable (or `nothing`
+for `Fixed` systems).
 
 # Arguments
 - `sys::VectorFieldSystem`: The system for which to return the RHS function.
@@ -65,15 +67,17 @@ rhs = Systems.rhs!(sys)
 
 du = zeros(2)
 u = [1.0, 2.0]
-rhs(du, u, nothing, 0.0)
+p = Common.ODEParameters(nothing)
+rhs(du, u, p, 0.0)
 # du is now [-1.0, -2.0]
 \`\`\`
 
 # Notes
 - The closure is computed once at construction time for performance.
 - Multiple calls to `rhs!` return the same function object.
+- The closure reads `p.variable` to access the actual variable value.
 
-See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.AbstractSystem`](@ref).
+See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.AbstractSystem`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """
 function rhs!(sys::VectorFieldSystem)
     return sys.rhs

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -133,6 +133,28 @@ function test_common_module()
         end
 
         # ====================================================================
+        # ODEParameters Type
+        # ====================================================================
+
+        Test.@testset "ODEParameters Type" begin
+            Test.@testset "ODEParameters is exported" begin
+                Test.@test isdefined(Common, :ODEParameters)
+            end
+
+            Test.@testset "constructs with nothing" begin
+                params = Common.ODEParameters(nothing)
+                Test.@test params isa Common.ODEParameters
+                Test.@test params.variable === nothing
+            end
+
+            Test.@testset "constructs with value" begin
+                params = Common.ODEParameters(0.5)
+                Test.@test params isa Common.ODEParameters
+                Test.@test params.variable == 0.5
+            end
+        end
+
+        # ====================================================================
         # Trait Check Functions
         # ====================================================================
 

--- a/test/suite/common/test_ode_parameters.jl
+++ b/test/suite/common/test_ode_parameters.jl
@@ -1,0 +1,64 @@
+module TestODEParameters
+
+import Test
+import CTFlows.Common
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+# ==============================================================================
+# Test function
+# ==============================================================================
+
+function test_ode_parameters()
+    Test.@testset "ODEParameters Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # UNIT TESTS - Constructor
+        # ====================================================================
+
+        Test.@testset "Constructor" begin
+
+            Test.@testset "accepts nothing for Fixed systems" begin
+                params = Common.ODEParameters(nothing)
+                Test.@test params.variable === nothing
+            end
+
+            Test.@testset "accepts value for NonFixed systems" begin
+                params = Common.ODEParameters(0.5)
+                Test.@test params.variable == 0.5
+            end
+
+            Test.@testset "accepts vector for NonFixed systems" begin
+                params = Common.ODEParameters([1.0, 2.0])
+                Test.@test params.variable == [1.0, 2.0]
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Type parameters
+        # ====================================================================
+
+        Test.@testset "Type parameters" begin
+
+            Test.@testset "infers Nothing type" begin
+                params = Common.ODEParameters(nothing)
+                Test.@test params isa Common.ODEParameters{Nothing}
+            end
+
+            Test.@testset "infers Float64 type" begin
+                params = Common.ODEParameters(0.5)
+                Test.@test params isa Common.ODEParameters{Float64}
+            end
+
+            Test.@testset "infers Vector{Float64} type" begin
+                params = Common.ODEParameters([1.0, 2.0])
+                Test.@test params isa Common.ODEParameters{Vector{Float64}}
+            end
+        end
+    end
+end
+
+end # module
+
+test_ode_parameters() = TestODEParameters.test_ode_parameters()

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -177,7 +177,8 @@ function test_sciml_extension()
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
 
                 Test.@test prob isa SciMLBase.AbstractODEProblem
-                Test.@test prob.p === nothing
+                Test.@test prob.p isa Common.ODEParameters
+                Test.@test prob.p.variable === nothing
             end
             
             Test.@testset "builds ODEProblem with variable parameter" begin
@@ -193,7 +194,8 @@ function test_sciml_extension()
                 prob = Integrators.build_problem(integ, sys, config; variable=0.5)
 
                 Test.@test prob isa SciMLBase.AbstractODEProblem
-                Test.@test prob.p == 0.5
+                Test.@test prob.p isa Common.ODEParameters
+                Test.@test prob.p.variable == 0.5
             end
         end
 

--- a/test/suite/flows/test_calling.jl
+++ b/test/suite/flows/test_calling.jl
@@ -46,6 +46,7 @@ end
 # Implement named functions instead of callables
 function Integrators.build_problem(integ::FakeIntegratorForCalling, system::Systems.AbstractSystem, config::Common.AbstractConfig; variable=nothing)
     integ.build_problem_called = true
+    p = Common.ODEParameters(variable)
     integ.problem_result = :fake_ode_problem
     return integ.problem_result
 end

--- a/test/suite/integrators/test_abstract_integrator.jl
+++ b/test/suite/integrators/test_abstract_integrator.jl
@@ -37,6 +37,7 @@ end
 
 # Implement the two required callable signatures
 function Integrators.build_problem(integ::FakeIntegrator, system::Systems.AbstractSystem, config::Common.AbstractConfig; variable)
+    p = Common.ODEParameters(variable)
     return :fake_ode_problem
 end
 

--- a/test/suite/systems/test_building_systems.jl
+++ b/test/suite/systems/test_building_systems.jl
@@ -73,7 +73,8 @@ function test_building_systems()
                 sys = Systems.build_system(vf)
                 rhs = Systems.rhs!(sys)
                 du = zeros(2)
-                rhs(du, [1.0, 2.0], nothing, 0.0)
+                p = Common.ODEParameters(nothing)
+                rhs(du, [1.0, 2.0], p, 0.0)
                 Test.@test du ≈ [2.0, 4.0] atol=1e-10
             end
         end

--- a/test/suite/systems/test_systems_module.jl
+++ b/test/suite/systems/test_systems_module.jl
@@ -69,7 +69,8 @@ function test_systems_module()
 
                 du = zeros(2)
                 u = [1.0, 2.0]
-                rhs(du, u, nothing, 0.0)
+                p = Common.ODEParameters(nothing)
+                rhs(du, u, p, 0.0)
                 Test.@test du ≈ [-1.0, -2.0]
             end
         end

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -84,7 +84,7 @@ function test_vector_field_system()
                 rhs = Systems.rhs!(sys)
                 du = zeros(2)
                 u = [1.0, 2.0]
-                p = nothing
+                p = Common.ODEParameters(nothing)
                 t = 0.0
                 # Should not throw - signature is correct
                 rhs(du, u, p, t)
@@ -96,7 +96,8 @@ function test_vector_field_system()
                 sys = Systems.VectorFieldSystem(vf)
                 rhs = Systems.rhs!(sys)
                 du = zeros(2)
-                rhs(du, [1.0, 2.0], nothing, 0.0)
+                p = Common.ODEParameters(nothing)
+                rhs(du, [1.0, 2.0], p, 0.0)
                 Test.@test du ≈ [-1.0, -2.0] atol=1e-10
             end
 
@@ -109,8 +110,9 @@ function test_vector_field_system()
                 rhs2 = Systems.rhs!(sys2)
                 du1 = zeros(2)
                 du2 = zeros(2)
-                rhs1(du1, [1.0, 1.0], nothing, 0.0)
-                rhs2(du2, [1.0, 1.0], nothing, 0.0)
+                p = Common.ODEParameters(nothing)
+                rhs1(du1, [1.0, 1.0], p, 0.0)
+                rhs2(du2, [1.0, 1.0], p, 0.0)
                 Test.@test du1 ≈ [2.0, 2.0] atol=1e-10
                 Test.@test du2 ≈ [3.0, 3.0] atol=1e-10
             end


### PR DESCRIPTION
Add explicit ODEParameters{V} wrapper type in Common to formalize the contract for what transits through SciML's p slot, replacing the implicit nothing/value contract with a typed structure.

Changes:
- src/Common/ode_parameters.jl (new): Define ODEParameters{V} struct
- src/Common/Common.jl: Include and export ODEParameters
- src/Systems/vector_field_system.jl: Update RHS closure to use p.variable
- ext/CTFlowsSciMLExt.jl: Wrap variable in ODEParameters before ODEProblem
- test/suite/common/test_ode_parameters.jl (new): Tests for ODEParameters type
- test/suite/common/test_common_module.jl: Add export verification
- test/suite/extensions/test_sciml_extension.jl: Update assertions for ODEParameters
- test/suite/integrators/test_abstract_integrator.jl: Wrap variable in ODEParameters
- test/suite/flows/test_calling.jl: Wrap variable in ODEParameters
- test/suite/systems/test_building_systems.jl: Update rhs! calls
- test/suite/syste Add explicit ODEParameters{V} wrapper type in Common to formalize the contracfiefor what transits through SciML's p slot, replacing the implicit nothing/valu