### PR TITLE
Refactor: Parameterize AbstractConfig{X0} and remove unwrap_state (Po…

### DIFF
--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -25,7 +25,7 @@ include(joinpath(@__DIR__, "default.jl"))
 # Module exports
 # ==============================================================================
 
-export AbstractTag, AbstractConfig, PointConfig, TrajectoryConfig, tspan, initial_condition, unwrap_state
+export AbstractTag, AbstractConfig, PointConfig, TrajectoryConfig, tspan, initial_condition
 export TimeDependence, Autonomous, NonAutonomous
 export VariableDependence, Fixed, NonFixed
 export ODEParameters

--- a/src/Common/configs.jl
+++ b/src/Common/configs.jl
@@ -6,6 +6,12 @@ Abstract configuration type for integration problems.
 Marker type for dispatch on configuration objects. Concrete subtypes define
 specific integration scenarios (e.g., point-to-point, trajectory, costate).
 
+The type parameter `X0` encodes the type of the initial condition:
+- `X0 <: Number` for scalar initial conditions
+- `X0 <: AbstractVector` for vector initial conditions
+
+This enables compile-time dispatch on scalar vs vector cases without runtime type tests.
+
 # Interface Requirements
 
 All subtypes must implement:
@@ -24,7 +30,7 @@ true
 
 See also: [`CTFlows.Common.PointConfig`](@ref), [`CTFlows.Common.TrajectoryConfig`](@ref)
 """
-abstract type AbstractConfig end
+abstract type AbstractConfig{X0} end
 
 """
 $(TYPEDSIGNATURES)
@@ -36,7 +42,7 @@ Extract the time span from an `AbstractConfig`.
 
 See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.PointConfig`](@ref), [`CTFlows.Common.TrajectoryConfig`](@ref).
 """
-function tspan(c::AbstractConfig)
+function tspan(c::AbstractConfig{X0}) where {X0}
     throw(Exceptions.NotImplemented(
         "AbstractConfig tspan method not implemented";
         required_method = "tspan(c::$(typeof(c)))",
@@ -71,7 +77,7 @@ PointConfig
 
 See also: [`CTFlows.Common.TrajectoryConfig`](@ref)
 """
-struct PointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfig
+struct PointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfig{X0}
     t0::T0
     x0::X0
     tf::TF
@@ -130,7 +136,7 @@ TrajectoryConfig
 
 See also: [`CTFlows.Common.PointConfig`](@ref)
 """
-struct TrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfig
+struct TrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfig{X0}
     tspan::TS
     x0::X0
 end
@@ -169,14 +175,18 @@ $(TYPEDSIGNATURES)
 
 Extract the initial condition from an `AbstractConfig`.
 
-Returns the initial state as a vector. If the stored initial condition is a scalar,
-it is wrapped in a vector for consistency.
+Returns the initial condition. For scalar configurations (`X0 <: Number`),
+wraps in a vector for consistency with ODE solver expectations. For vector
+configurations, returns the vector unchanged.
+
+This uses compile-time dispatch on the type parameter `X0` to avoid runtime
+type tests.
 
 # Arguments
-- `c::AbstractConfig`: The configuration.
+- `c::AbstractConfig{<:Number}`: Scalar configuration.
 
 # Returns
-- `AbstractVector`: The initial condition as a vector.
+- `AbstractVector`: The initial condition wrapped in a vector.
 
 # Example
 \`\`\`julia-repl
@@ -186,6 +196,33 @@ julia> config = PointConfig(0.0, 1.0, 1.0)  # scalar x0
 
 julia> initial_condition(config)
 [1.0]
+\`\`\`
+
+See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.PointConfig`](@ref).
+"""
+function initial_condition(c::AbstractConfig{<:Number})
+    return [c.x0]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract the initial condition from an `AbstractConfig`.
+
+Returns the initial condition as a vector for vector configurations.
+
+This uses compile-time dispatch on the type parameter `X0` to avoid runtime
+type tests.
+
+# Arguments
+- `c::AbstractConfig`: Vector configuration.
+
+# Returns
+- `AbstractVector`: The initial condition vector.
+
+# Example
+\`\`\`julia-repl
+julia> using CTFlows.Common
 
 julia> config = PointConfig(0.0, [1.0, 0.0], 1.0)  # vector x0
 
@@ -196,29 +233,7 @@ julia> initial_condition(config)
 See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.PointConfig`](@ref).
 """
 function initial_condition(c::AbstractConfig)
-    return c.x0 isa Number ? [c.x0] : c.x0
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Unwrap a state vector to match the original configuration type.
-
-If the config's `x0` is a `Number`, this unwraps the length-1 vector that was
-introduced by scalar-promotion at ODE problem construction time. Otherwise,
-returns the state vector unchanged.
-
-# Arguments
-- `c::AbstractConfig`: The configuration to check for scalar promotion.
-- `state`: The state vector to unwrap.
-
-# Returns
-- `Union{Number, AbstractVector}`: The unwrapped state (scalar if config was scalar, vector otherwise).
-
-See also: [`CTFlows.Common.initial_condition`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
-"""
-function unwrap_state(c::AbstractConfig, state)
-    return c.x0 isa Number ? state[1] : state
+    return c.x0
 end
 
 # =============================================================================

--- a/src/Solutions/building.jl
+++ b/src/Solutions/building.jl
@@ -3,22 +3,46 @@ $(TYPEDSIGNATURES)
 
 Default implementation for `PointConfig` — return the final state.
 
-If the config's `x0` is a `Number`, this unwraps the length-1 vector that was
-introduced by the scalar-promotion at ODE problem construction time using
-[`CTFlows.Common.unwrap_state`](@ref).
+For scalar configurations (`X0 <: Number`), unwraps the length-1 vector that was
+introduced by scalar-promotion at ODE problem construction time. For vector
+configurations, returns the state vector unchanged.
+
+This uses compile-time dispatch on the configuration's type parameter `X0`
+to avoid runtime type tests.
 
 # Arguments
 - `result::AbstractIntegrationResult`: The integration result.
 - `sys::Systems.VectorFieldSystem`: The vector field system.
-- `config::Common.PointConfig`: The point configuration.
+- `config::Common.PointConfig{<:Real, <:Number, <:Real}`: Scalar point configuration.
 
 # Returns
-- `Union{Number, AbstractVector}`: The final state (scalar if config was scalar, vector otherwise).
+- `Number`: The unwrapped scalar final state.
 
-See also: [`CTFlows.Solutions.AbstractIntegrationResult`](@ref), [`CTFlows.Common.unwrap_state`](@ref).
+See also: [`CTFlows.Solutions.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function build_solution(result::AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.PointConfig{<:Real, <:Number, <:Real})
+    return final_state(result)[1]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Default implementation for `PointConfig` — return the final state.
+
+For vector configurations, returns the state vector unchanged.
+
+# Arguments
+- `result::AbstractIntegrationResult`: The integration result.
+- `sys::Systems.VectorFieldSystem`: The vector field system.
+- `config::Common.PointConfig`: Vector point configuration.
+
+# Returns
+- `AbstractVector`: The final state vector.
+
+See also: [`CTFlows.Solutions.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
 """
 function build_solution(result::AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.PointConfig)
-    return Common.unwrap_state(config, final_state(result))
+    return final_state(result)
 end
 
 """

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -72,14 +72,6 @@ function test_common_module()
                 ic = Common.initial_condition(config)
                 Test.@test ic == [1.0]
             end
-
-            Test.@testset "unwrap_state is exported" begin
-                Test.@test isdefined(Common, :unwrap_state)
-                config = Common.PointConfig(0.0, [1.0], 1.0)
-                state = [2.0]
-                unwrapped = Common.unwrap_state(config, state)
-                Test.@test unwrapped == [2.0]
-            end
         end
 
         # ====================================================================

--- a/test/suite/common/test_configs.jl
+++ b/test/suite/common/test_configs.jl
@@ -15,15 +15,18 @@ const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING :
 Fake config type for testing the AbstractConfig contract.
 Does not implement tspan to trigger NotImplemented error.
 """
-struct FakeConfig <: Common.AbstractConfig end
+struct FakeConfig{X0} <: Common.AbstractConfig{X0}
+    x0::X0
+end
 
 """
 Fake config type that implements the tspan contract.
 Used to test contract implementation without relying on concrete types.
 """
-struct FakeConfigWithTspan <: Common.AbstractConfig
+struct FakeConfigWithTspan{X0} <: Common.AbstractConfig{X0}
     t0::Float64
     tf::Float64
+    x0::X0
 end
 
 function Common.tspan(c::FakeConfigWithTspan)
@@ -51,6 +54,7 @@ function test_configs()
                 ic = Common.initial_condition(config)
                 Test.@test ic isa AbstractVector
                 Test.@test ic == [1.0]
+                Test.@test typeof(config) == Common.PointConfig{Float64, Float64, Float64}  # X0 <: Number
             end
 
             Test.@testset "initial_condition handles vector" begin
@@ -58,6 +62,7 @@ function test_configs()
                 ic = Common.initial_condition(config)
                 Test.@test ic isa AbstractVector
                 Test.@test ic == [1.0, 0.0]
+                Test.@test typeof(config) <: Common.PointConfig{Float64, <:AbstractVector, Float64}  # X0 is vector
             end
 
             Test.@testset "initial_condition with TrajectoryConfig scalar" begin
@@ -72,26 +77,6 @@ function test_configs()
                 ic = Common.initial_condition(config)
                 Test.@test ic isa AbstractVector
                 Test.@test ic == [1.0, 0.0]
-            end
-
-            Test.@testset "unwrap_state is exported" begin
-                Test.@test isdefined(Common, :unwrap_state)
-            end
-
-            Test.@testset "unwrap_state handles scalar" begin
-                config = Common.PointConfig(0.0, 1.0, 1.0)
-                state = [2.0]
-                unwrapped = Common.unwrap_state(config, state)
-                Test.@test unwrapped isa Number
-                Test.@test unwrapped == 2.0
-            end
-
-            Test.@testset "unwrap_state handles vector" begin
-                config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
-                state = [2.0, 0.0]
-                unwrapped = Common.unwrap_state(config, state)
-                Test.@test unwrapped isa AbstractVector
-                Test.@test unwrapped == [2.0, 0.0]
             end
 
             Test.@testset "AbstractConfig is exported" begin
@@ -138,7 +123,7 @@ function test_configs()
 
         Test.@testset "tspan Contract" begin
             Test.@testset "AbstractConfig tspan throws NotImplemented" begin
-                config = FakeConfig()
+                config = FakeConfig(1.0)
                 Test.@test_throws Exceptions.NotImplemented Common.tspan(config)
             end
 
@@ -157,7 +142,7 @@ function test_configs()
             end
 
             Test.@testset "Fake config with tspan contract" begin
-                config = FakeConfigWithTspan(0.5, 2.5)
+                config = FakeConfigWithTspan(0.5, 2.5, 1.0)
                 ts = Common.tspan(config)
                 Test.@test ts == (0.5, 2.5)
             end

--- a/test/suite/solutions/test_building_solutions.jl
+++ b/test/suite/solutions/test_building_solutions.jl
@@ -41,6 +41,7 @@ function test_building_solutions()
                 
                 output = Solutions.build_solution(result, sys, config)
                 Test.@test output == [0.5, 1.0]
+                Test.@test typeof(config) <: Common.PointConfig{Float64, <:AbstractVector, Float64}
             end
 
             Test.@testset "scalar initial condition unwraps length-1 vector" begin
@@ -50,6 +51,7 @@ function test_building_solutions()
                 
                 output = Solutions.build_solution(result, sys, config)
                 Test.@test output == 1.5
+                Test.@test typeof(config) == Common.PointConfig{Float64, Float64, Float64}
             end
         end
 


### PR DESCRIPTION
…int 6)

- Parameterize AbstractConfig{X0} to enable compile-time dispatch on scalar vs vector initial conditions
- Update initial_condition with compile-time dispatch (X0 <: Number vs X0)
- Remove unwrap_state function completely from codebase
- Remove unwrap_state from exports in Common.jl
- Update build_solution with direct dispatch for PointConfig (no unwrap_state call)
- Update PointConfig and TrajectoryConfig to inherit from AbstractConfig{X0}
- Update tspan stub signature to include type parameter
- Update tests to verify compile-time dispatch behavior and remove unwrap_state tests
- All 598 tests passing