### PR TITLE
Rename default functions and update parameter names

### DIFF
--- a/.extras/vector_field.jl
+++ b/.extras/vector_field.jl
@@ -27,49 +27,49 @@ println("-" ^ 80)
 
 # Using keyword constructor with defaults
 vf_default = Data.VectorField(x -> -x)
-println("Default constructor (autonomous=true, variable=false):")
+println("Default constructor (is_autonomous=true, is_variable=false):")
 display(vf_default)
 
 # Autonomous Fixed - depends only on state x
 println("\n--- Scalar case ---")
-vf_scalar = Data.VectorField(x -> -2x; autonomous=true, variable=false)
+vf_scalar = Data.VectorField(x -> -2x; is_autonomous=true, is_variable=false)
 println("Scalar: vf(3.0) = ", vf_scalar(3.0))
 display(vf_scalar)
 
 println("\n--- Vector case ---")
-vf_vector = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_vector = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 println("Vector: vf([1.0, 2.0]) = ", vf_vector([1.0, 2.0]))
 display(vf_vector)
 
 println("\n--- Matrix case ---")
-vf_matrix = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_matrix = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 x0_matrix = [1.0 2.0; 3.0 4.0]
 println("Matrix: vf(x0_matrix) = ", vf_matrix(x0_matrix))
 display(vf_matrix)
 
 # NonAutonomous Fixed - depends on time t and state x
 println("\n--- NonAutonomous cases ---")
-vf_nonautonomous_fixed = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+vf_nonautonomous_fixed = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
 println("NonAutonomous Fixed (vector): vf(2.0, [1.0, 2.0]) = ", vf_nonautonomous_fixed(2.0, [1.0, 2.0]))
 
 # Autonomous NonFixed - depends on state x and variable v
-vf_autonomous_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+vf_autonomous_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
 println("Autonomous NonFixed (vector): vf([1.0, 2.0], 0.5) = ", vf_autonomous_nonfixed([1.0, 2.0], 0.5))
 
 # NonAutonomous NonFixed - depends on time t, state x, and variable v
-vf_nonautonomous_nonfixed = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+vf_nonautonomous_nonfixed = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
 println("NonAutonomous NonFixed (vector): vf(2.0, [1.0, 2.0], 0.5) = ", vf_nonautonomous_nonfixed(2.0, [1.0, 2.0], 0.5))
 
 # Using keyword constructor with explicit flags
-vf_kw_autonomous = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_kw_autonomous = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 println("\nKeyword constructor with explicit flags:")
 display(vf_kw_autonomous)
 
-vf_kw_nonautonomous = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+vf_kw_nonautonomous = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
 println("NonAutonomous via keyword:")
 display(vf_kw_nonautonomous)
 
-vf_kw_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+vf_kw_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
 println("NonFixed via keyword:")
 display(vf_kw_nonfixed)
 
@@ -87,21 +87,21 @@ println("  time_dependence(sys) = ", Common.time_dependence(sys_af))
 println("  variable_dependence(sys) = ", Common.variable_dependence(sys_af))
 
 println("\n--- NonAutonomous Fixed ---")
-vf_naf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+vf_naf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
 sys_naf = Systems.VectorFieldSystem(vf_naf)
 println("System from NonAutonomous Fixed VectorField:")
 println("  time_dependence(sys) = ", Common.time_dependence(sys_naf))
 println("  variable_dependence(sys) = ", Common.variable_dependence(sys_naf))
 
 println("\n--- Autonomous NonFixed ---")
-vf_anf = Data.VectorField((x, v) -> v .* x; autonomous=true, variable=true)
+vf_anf = Data.VectorField((x, v) -> v .* x; is_autonomous=true, is_variable=true)
 sys_anf = Systems.VectorFieldSystem(vf_anf)
 println("System from Autonomous NonFixed VectorField:")
 println("  time_dependence(sys) = ", Common.time_dependence(sys_anf))
 println("  variable_dependence(sys) = ", Common.variable_dependence(sys_anf))
 
 println("\n--- NonAutonomous NonFixed ---")
-vf_nanf = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+vf_nanf = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
 sys_nanf = Systems.VectorFieldSystem(vf_nanf)
 println("System from NonAutonomous NonFixed VectorField:")
 println("  time_dependence(sys) = ", Common.time_dependence(sys_nanf))
@@ -142,7 +142,7 @@ println("-" ^ 80)
 
 println("\n--- build_flow from system and integrator ---")
 println("Step 1: Build system from VectorField")
-vf_flow = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_flow = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 sys_flow = Systems.build_system(vf_flow)
 println("System: ", typeof(sys_flow))
 
@@ -157,16 +157,16 @@ println("  system(flow) = ", typeof(Flows.system(flow_from_build)))
 println("  integrator(flow) = ", typeof(Flows.integrator(flow_from_build)))
 
 println("\n--- Flow constructor from VectorField ---")
-println("Direct construction: Flow(vf, id=:sciml; opts...)")
-flow_direct = Flows.Flow(vf_flow, :sciml; reltol=1e-8)
+println("Direct construction: Flow(vf; opts...)")
+flow_direct = Flows.Flow(vf_flow; reltol=1e-8)
 println("Flow: ", typeof(flow_direct))
 println("  system(flow) = ", typeof(Flows.system(flow_direct)))
 println("  integrator(flow) = ", typeof(Flows.integrator(flow_direct)))
 Flows.integrator(flow_direct)
 
 println("\n--- NonFixed flow construction ---")
-vf_nonfixed_flow = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
-flow_nonfixed = Flows.Flow(vf_nonfixed_flow, :sciml)
+vf_nonfixed_flow = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
+flow_nonfixed = Flows.Flow(vf_nonfixed_flow)
 println("NonFixed Flow: ", typeof(flow_nonfixed))
 println("  variable_dependence(system(flow)) = ", Common.variable_dependence(Flows.system(flow_nonfixed)))
 
@@ -182,7 +182,7 @@ using OrdinaryDiffEqTsit5
 
 println("\n--- Vector case pipeline (Fixed) ---")
 println("Step 1: Create VectorField")
-vf_vector = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_vector = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 display(vf_vector)
 println("Call: vf([1.0, 2.0]) = ", vf_vector([1.0, 2.0]))
 
@@ -200,12 +200,12 @@ println("\nStep 4: Integration via call()")
 println("\n  4a. call(flow, config) with PointConfig")
 flow = Flows.Flow(sys_vector, integrator)
 config_point = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
-result_point = Flows.call(flow, config_point)
+result_point = Flows.call(flow, config_point; variable=nothing, unsafe=false)
 println("    result = ", result_point)
 
 println("\n  4b. call(flow, config) with TrajectoryConfig")
 config_traj = Common.TrajectoryConfig((0.0, 1.0), [1.0, 2.0])
-result_traj = Flows.call(flow, config_traj)
+result_traj = Flows.call(flow, config_traj; variable=nothing, unsafe=false)
 println("    result type: ", typeof(result_traj))
 println("    result is VectorFieldSolution: ", result_traj isa Solutions.VectorFieldSolution)
 display(result_traj)
@@ -221,39 +221,39 @@ result_direct = flow(0.0, [1.0, 2.0], 1.0)
 println("    flow(0.0, [1.0, 2.0], 1.0) = ", result_direct)
 
 println("\n--- NonFixed case (with variable) ---")
-vf_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+vf_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
 println("VectorField (NonFixed):")
 display(vf_nonfixed)
 
 sys_nonfixed = Systems.build_system(vf_nonfixed)
 flow_nonfixed = Flows.Flow(sys_nonfixed, integrator)
 config_nonfixed = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
-result_nonfixed = Flows.call(flow_nonfixed, config_nonfixed; variable=0.5)
+result_nonfixed = Flows.call(flow_nonfixed, config_nonfixed; variable=0.5, unsafe=false)
 println("Result with variable=0.5: ", result_nonfixed)
 
 println("\n  Direct flow callable with variable:")
-result_direct_nonfixed = flow_nonfixed(0.0, [1.0, 2.0], 1.0; variable=0.5)
+result_direct_nonfixed = flow_nonfixed(0.0, [1.0, 2.0], 1.0; variable=0.5, unsafe=false)
 println("    flow(0.0, [1.0, 2.0], 1.0; variable=0.5) = ", result_direct_nonfixed)
 
 println("\n--- Scalar case ---")
-vf_scalar = Data.VectorField(x -> -2x; autonomous=true, variable=false)
+vf_scalar = Data.VectorField(x -> -2x; is_autonomous=true, is_variable=false)
 println("Scalar VectorField:")
 display(vf_scalar)
 sys_scalar = Systems.build_system(vf_scalar)
 flow_scalar = Flows.Flow(sys_scalar, integrator)
 config_scalar = Common.PointConfig(0.0, 3.0, 1.0)
-result_scalar = Flows.call(flow_scalar, config_scalar)
+result_scalar = Flows.call(flow_scalar, config_scalar; variable=nothing, unsafe=false)
 println("  Result: ", result_scalar, " (scalar)")
 
 println("\n--- Matrix case ---")
-vf_matrix = Data.VectorField(x -> -x; autonomous=true, variable=false)
+vf_matrix = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
 x0_matrix = [1.0 2.0; 3.0 4.0]
 println("Matrix VectorField:")
 display(vf_matrix)
 sys_matrix = Systems.build_system(vf_matrix)
 flow_matrix = Flows.Flow(sys_matrix, integrator)
 config_matrix = Common.PointConfig(0.0, x0_matrix, 1.0)
-result_matrix = Flows.call(flow_matrix, config_matrix)
+result_matrix = Flows.call(flow_matrix, config_matrix; variable=nothing, unsafe=false)
 println("  Result: ", result_matrix, " (matrix)")
 
 # =============================================================================
@@ -290,5 +290,5 @@ println("  2. The CTFlowsSciMLExt extension will be automatically activated")
 println("  3. Then you can use:")
 println("     integrator = Integrators.SciML()")
 println("     flow = Flows.Flow(system, integrator)")
-println("     result = Flows.call(flow, config)")
+println("     result = Flows.call(flow, config; variable=nothing, unsafe=false)")
 println("     result = flow(t0, x0, tf)  # direct callable, builds config internally")

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -32,6 +32,6 @@ export ODEParameters
 export has_time_dependence_trait, has_variable_dependence_trait
 export time_dependence, variable_dependence
 export is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable
-export __autonomous, __variable, __unsafe
+export __is_autonomous, __is_variable, __variable, __unsafe
 
 end # module Common

--- a/src/Common/default.jl
+++ b/src/Common/default.jl
@@ -10,7 +10,7 @@ Default value for autonomous flag in time-dependent object constructors.
 Returns `true` by default, meaning objects do not explicitly depend on time
 unless specified otherwise.
 """
-__autonomous()::Bool = true
+__is_autonomous()::Bool = true
 
 """
 $(TYPEDSIGNATURES)
@@ -20,7 +20,17 @@ Default value for variable flag in time-dependent object constructors.
 Returns `false` by default, meaning objects have fixed parameters unless
 specified otherwise.
 """
-__variable()::Bool = false
+__is_variable()::Bool = false
+
+"""
+$(TYPEDSIGNATURES)
+
+Default value for variable parameter in user-facing API calls.
+
+Returns `nothing` by default, meaning the variable parameter is optional
+unless required by the system's trait (e.g., NonFixed systems).
+"""
+__variable() = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/src/Data/vector_field.jl
+++ b/src/Data/vector_field.jl
@@ -43,8 +43,8 @@ Construct a `VectorField` with trait flags.
 
 # Arguments
 - `f::Function`: The vector-field function.
-- `autonomous::Bool`: If true, system is autonomous (default: `Common.__autonomous()`).
-- `variable::Bool`: If true, system depends on variable parameters (default: `Common.__variable()`).
+- `is_autonomous::Bool`: If true, system is autonomous (default: `Common.__is_autonomous()`).
+- `is_variable::Bool`: If true, system depends on variable parameters (default: `Common.__is_variable()`).
 
 # Returns
 - `VectorField`: A VectorField with appropriate traits.
@@ -53,13 +53,13 @@ Construct a `VectorField` with trait flags.
 \`\`\`julia-repl
 julia> using CTFlows.Systems, CTFlows.Common
 
-julia> vf = VectorField(x -> -x)  # Uses defaults: autonomous=true, variable=false
+julia> vf = VectorField(x -> -x)  # Uses defaults: is_autonomous=true, is_variable=false
 VectorField
   time_dependence: Autonomous
   variable_dependence: Fixed
   function: var"#1"
 
-julia> vf = VectorField((t, x) -> t .* x; autonomous=false)
+julia> vf = VectorField((t, x) -> t .* x; is_autonomous=false)
 VectorField
   time_dependence: NonAutonomous
   variable_dependence: Fixed
@@ -68,9 +68,9 @@ VectorField
 
 See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
 """
-function VectorField(f; autonomous::Bool = Common.__autonomous(), variable::Bool = Common.__variable())
-    TD = autonomous ? Autonomous : NonAutonomous
-    VD = variable ? NonFixed : Fixed
+function VectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
+    TD = is_autonomous ? Autonomous : NonAutonomous
+    VD = is_variable ? NonFixed : Fixed
     return VectorField{typeof(f), TD, VD}(f)
 end
 

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -8,8 +8,8 @@ This performs the integration and builds the solution.
 # Arguments
 - `flow::CTFlows.Flows.AbstractFlow`: The flow to solve.
 - `config::CTFlows.Common.AbstractConfig`: The integration configuration (e.g., `PointConfig`, `TrajectoryConfig`).
-- `variable=nothing`: The variable parameter value (required for NonFixed systems, optional for Fixed systems).
-- `unsafe=Common.__unsafe()`: If `true`, bypass ODE solver retcode checking; if `false`, throw `SolverFailure` on integration failure.
+- `variable`: The variable parameter value (required for NonFixed systems, optional for Fixed systems).
+- `unsafe`: If `true`, bypass ODE solver retcode checking; if `false`, throw `SolverFailure` on integration failure.
 
 # Returns
 - The packaged solution (type varies by config type).
@@ -19,12 +19,12 @@ This performs the integration and builds the solution.
 # Conceptual usage pattern
 flow = Flow(system, integrator)
 config = CTFlows.Common.TrajectoryConfig((0.0, 1.0), [1.0, 0.0])
-sol = call(flow, config)
+sol = call(flow, config; variable=nothing, unsafe=false)
 \`\`\`
 
 See also: [`CTFlows.Flows.AbstractFlow`](@ref), [`CTFlows.Integrators.build_problem`](@ref), [`CTFlows.Integrators.solve_problem`](@ref), [`CTFlows.Solutions.build_solution`](@ref).
 """
-function call(flow::Flows.AbstractFlow{TD, VD}, config::Common.AbstractConfig; variable=nothing, unsafe=Common.__unsafe()) where {TD<:Common.TimeDependence, VD<:Common.VariableDependence}
+function call(flow::Flows.AbstractFlow{TD, VD}, config::Common.AbstractConfig; variable, unsafe) where {TD<:Common.TimeDependence, VD<:Common.VariableDependence}
 
     # get system and integrator
     sys = system(flow)

--- a/src/Flows/flow.jl
+++ b/src/Flows/flow.jl
@@ -90,7 +90,7 @@ function (f::Flow)(
     t0::Real,
     x0,
     tf::Real;
-    variable=nothing,
+    variable=Common.__variable(),
     unsafe=Common.__unsafe(),
 )
     return call(f, Common.PointConfig(t0, x0, tf); variable=variable, unsafe=unsafe)
@@ -116,7 +116,7 @@ See also: [`CTFlows.Common.TrajectoryConfig`](@ref), [`CTFlows.Flows.call`](@ref
 function (f::Flow)(
     tspan::Tuple{Real, Real},
     x0;
-    variable=nothing,
+    variable=Common.__variable(),
     unsafe=Common.__unsafe(),
 )
     return call(f, Common.TrajectoryConfig(tspan, x0); variable=variable, unsafe=unsafe)

--- a/test/suite/common/test_default.jl
+++ b/test/suite/common/test_default.jl
@@ -18,12 +18,16 @@ function test_default()
         # ====================================================================
 
         Test.@testset "Default Value Functions" begin
-            Test.@testset "__autonomous returns true" begin
-                Test.@test Common.__autonomous() === true
+            Test.@testset "__is_autonomous returns true" begin
+                Test.@test Common.__is_autonomous() === true
             end
 
-            Test.@testset "__variable returns false" begin
-                Test.@test Common.__variable() === false
+            Test.@testset "__is_variable returns false" begin
+                Test.@test Common.__is_variable() === false
+            end
+
+            Test.@testset "__variable returns nothing" begin
+                Test.@test Common.__variable() === nothing
             end
 
             Test.@testset "__unsafe returns false" begin

--- a/test/suite/data/test_data_module.jl
+++ b/test/suite/data/test_data_module.jl
@@ -33,30 +33,30 @@ function test_data_module()
 
             Test.@testset "VectorField constructor is exported" begin
                 Test.@test isdefined(Data, :VectorField)
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 Test.@test vf isa Data.VectorField
             end
 
             Test.@testset "VectorField with Autonomous trait" begin
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 Test.@test Common.time_dependence(vf) === Common.Autonomous
                 Test.@test Common.variable_dependence(vf) === Common.Fixed
             end
 
             Test.@testset "VectorField with NonAutonomous trait" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 Test.@test Common.time_dependence(vf) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(vf) === Common.Fixed
             end
 
             Test.@testset "VectorField with NonFixed trait" begin
-                vf = Data.VectorField((x, v) -> x .* v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .* v; is_autonomous=true, is_variable=true)
                 Test.@test Common.time_dependence(vf) === Common.Autonomous
                 Test.@test Common.variable_dependence(vf) === Common.NonFixed
             end
 
             Test.@testset "VectorField with NonAutonomous and NonFixed traits" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .* v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .* v; is_autonomous=false, is_variable=true)
                 Test.@test Common.time_dependence(vf) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(vf) === Common.NonFixed
             end
@@ -78,18 +78,18 @@ function test_data_module()
             end
 
             Test.@testset "time_dependence function works with VectorField" begin
-                vf_aut = Data.VectorField(x -> x; autonomous=true)
+                vf_aut = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 Test.@test Common.time_dependence(vf_aut) === Common.Autonomous
 
-                vf_non = Data.VectorField((t, x) -> x; autonomous=false)
+                vf_non = Data.VectorField((t, x) -> x; is_autonomous=false, is_variable=false)
                 Test.@test Common.time_dependence(vf_non) === Common.NonAutonomous
             end
 
             Test.@testset "variable_dependence function works with VectorField" begin
-                vf_fixed = Data.VectorField(x -> x; variable=false)
+                vf_fixed = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 Test.@test Common.variable_dependence(vf_fixed) === Common.Fixed
 
-                vf_nonfixed = Data.VectorField((x, v) -> x .* v; variable=true)
+                vf_nonfixed = Data.VectorField((x, v) -> x .* v; is_autonomous=true, is_variable=true)
                 Test.@test Common.variable_dependence(vf_nonfixed) === Common.NonFixed
             end
         end
@@ -100,47 +100,47 @@ function test_data_module()
 
         Test.@testset "Call Signatures" begin
             Test.@testset "Autonomous Fixed signature" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 result = vf([1.0, 2.0])
                 Test.@test result ≈ [-1.0, -2.0]
             end
 
             Test.@testset "NonAutonomous Fixed signature" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 result = vf(2.0, [1.0, 2.0])
                 Test.@test result ≈ [2.0, 4.0]
             end
 
             Test.@testset "Autonomous NonFixed signature" begin
-                vf = Data.VectorField((x, v) -> x .* v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .* v; is_autonomous=true, is_variable=true)
                 result = vf([1.0, 2.0], 3.0)
                 Test.@test result ≈ [3.0, 6.0]
             end
 
             Test.@testset "NonAutonomous NonFixed signature" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .* v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .* v; is_autonomous=false, is_variable=true)
                 result = vf(2.0, [1.0, 2.0], 3.0)
                 Test.@test result ≈ [6.0, 12.0]
             end
 
             Test.@testset "Uniform (t, x, v) signature works for all traits" begin
                 # Autonomous Fixed - ignores t and v
-                vf1 = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf1 = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 result1 = vf1(0.0, [1.0, 2.0], nothing)
                 Test.@test result1 ≈ [-1.0, -2.0]
 
                 # NonAutonomous Fixed - ignores v
-                vf2 = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf2 = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 result2 = vf2(2.0, [1.0, 2.0], nothing)
                 Test.@test result2 ≈ [2.0, 4.0]
 
                 # Autonomous NonFixed - ignores t
-                vf3 = Data.VectorField((x, v) -> x .* v; autonomous=true, variable=true)
+                vf3 = Data.VectorField((x, v) -> x .* v; is_autonomous=true, is_variable=true)
                 result3 = vf3(0.0, [1.0, 2.0], 3.0)
                 Test.@test result3 ≈ [3.0, 6.0]
 
                 # NonAutonomous NonFixed - uses all
-                vf4 = Data.VectorField((t, x, v) -> t .* x .* v; autonomous=false, variable=true)
+                vf4 = Data.VectorField((t, x, v) -> t .* x .* v; is_autonomous=false, is_variable=true)
                 result4 = vf4(2.0, [1.0, 2.0], 3.0)
                 Test.@test result4 ≈ [6.0, 12.0]
             end

--- a/test/suite/data/test_vector_field.jl
+++ b/test/suite/data/test_vector_field.jl
@@ -19,7 +19,7 @@ function test_vector_field()
         # ====================================================================
 
         Test.@testset "Abstract Types" begin
-            vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+            vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
             Test.@test vf isa Data.VectorField
         end
 
@@ -36,19 +36,19 @@ function test_vector_field()
             end
 
             Test.@testset "keyword constructor with explicit flags" begin
-                vf_autonomous = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf_autonomous = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 Test.@test Common.time_dependence(vf_autonomous) === Common.Autonomous
                 Test.@test Common.variable_dependence(vf_autonomous) === Common.Fixed
 
-                vf_nonautonomous = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf_nonautonomous = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 Test.@test Common.time_dependence(vf_nonautonomous) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(vf_nonautonomous) === Common.Fixed
 
-                vf_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 Test.@test Common.time_dependence(vf_nonfixed) === Common.Autonomous
                 Test.@test Common.variable_dependence(vf_nonfixed) === Common.NonFixed
 
-                vf_full = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+                vf_full = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
                 Test.@test Common.time_dependence(vf_full) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(vf_full) === Common.NonFixed
             end
@@ -59,10 +59,10 @@ function test_vector_field()
         # ====================================================================
 
         Test.@testset "Trait Methods" begin
-            vf_aut = Data.VectorField(x -> x; autonomous=true, variable=false)
-            vf_nonaut = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
-            vf_fixed = Data.VectorField(x -> x; autonomous=true, variable=false)
-            vf_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+            vf_aut = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
+            vf_nonaut = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
+            vf_fixed = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
+            vf_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
 
             Test.@testset "has_time_dependence_trait returns true" begin
                 Test.@test Common.has_time_dependence_trait(vf_aut) === true
@@ -91,7 +91,7 @@ function test_vector_field()
 
         Test.@testset "Natural Call Signatures" begin
             Test.@testset "Autonomous Fixed - (x)" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(3.0) == -3.0
@@ -109,7 +109,7 @@ function test_vector_field()
             end
 
             Test.@testset "NonAutonomous Fixed - (t, x)" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(2.0, 3.0) == 6.0
@@ -127,7 +127,7 @@ function test_vector_field()
             end
 
             Test.@testset "Autonomous NonFixed - (x, v)" begin
-                vf = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(3.0, 0.5) == 3.5
@@ -145,7 +145,7 @@ function test_vector_field()
             end
 
             Test.@testset "NonAutonomous NonFixed - (t, x, v)" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(2.0, 3.0, 0.5) == 6.5
@@ -169,7 +169,7 @@ function test_vector_field()
 
         Test.@testset "Uniform Call Signature" begin
             Test.@testset "Autonomous Fixed ignores t and v" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(0.0, 3.0, 0.0) == -3.0
@@ -187,7 +187,7 @@ function test_vector_field()
             end
 
             Test.@testset "NonAutonomous Fixed uses t, ignores v" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(2.0, 3.0, 0.0) == 6.0
@@ -205,7 +205,7 @@ function test_vector_field()
             end
 
             Test.@testset "Autonomous NonFixed ignores t, uses v" begin
-                vf = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 
                 Test.@testset "scalar" begin
                     Test.@test vf(0.0, 3.0, 0.5) == 3.5
@@ -228,10 +228,10 @@ function test_vector_field()
         # ====================================================================
 
         Test.@testset "Common Trait Predicates" begin
-            vf_aut = Data.VectorField(x -> x; autonomous=true, variable=false)
-            vf_nonaut = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
-            vf_fixed = Data.VectorField(x -> x; autonomous=true, variable=false)
-            vf_nonfixed = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+            vf_aut = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
+            vf_nonaut = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
+            vf_fixed = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
+            vf_nonfixed = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
 
             Test.@testset "is_autonomous / is_nonautonomous" begin
                 Test.@test Common.is_autonomous(vf_aut) === true
@@ -253,7 +253,7 @@ function test_vector_field()
         # ====================================================================
 
         Test.@testset "Show Methods" begin
-            vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+            vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
             
             Test.@testset "Base.show (compact)" begin
                 io = IOBuffer()

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -167,7 +167,7 @@ function test_sciml_extension()
             Test.@testset "builds ODEProblem without variable" begin
                 # Create a simple system
                 sys = Systems.VectorFieldSystem(
-                    Data.VectorField(x -> -x; autonomous=true, variable=false)
+                    Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
 
                 config = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
@@ -184,7 +184,7 @@ function test_sciml_extension()
             Test.@testset "builds ODEProblem with variable parameter" begin
                 # Create a simple system that takes a variable
                 sys = Systems.VectorFieldSystem(
-                    Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                    Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 )
 
                 config = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
@@ -206,7 +206,7 @@ function test_sciml_extension()
         Test.@testset "Solving" begin
             # Create a simple system
             sys = Systems.VectorFieldSystem(
-                Data.VectorField(x -> -x; autonomous=true, variable=false)
+                Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
             )
 
             config = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
@@ -222,32 +222,36 @@ function test_sciml_extension()
             Test.@test result isa Solutions.AbstractIntegrationResult
         end
 
-        Test.@testset "SolverFailure on failed retcode" begin
-            # Create a simple ODE problem that will fail with maxiters=1
-            prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
-            integ = Integrators.SciML(maxiters=1)
+        redirect_stderr(devnull) do
+            Test.@testset "SolverFailure on failed retcode" begin
+                # Create a simple ODE problem that will fail with maxiters=1
+                prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
+                integ = Integrators.SciML(maxiters=1)
 
-            # Test that solve_problem throws SolverFailure when unsafe=false
-            Test.@test_throws Exceptions.SolverFailure Integrators.solve_problem(integ, prob; unsafe=false)
+                # Test that solve_problem throws SolverFailure when unsafe=false
+                Test.@test_throws Exceptions.SolverFailure Integrators.solve_problem(integ, prob; unsafe=false)
 
-            # Test the exception contains correct fields
-            try
-                Integrators.solve_problem(integ, prob; unsafe=false)
-            catch e
-                Test.@test e isa Exceptions.SolverFailure
-                Test.@test occursin("MaxIters", e.retcode)
-                Test.@test e.context == "SciML solve_problem"
+                # Test the exception contains correct fields
+                try
+                    Integrators.solve_problem(integ, prob; unsafe=false)
+                catch e
+                    Test.@test e isa Exceptions.SolverFailure
+                    Test.@test occursin("MaxIters", e.retcode)
+                    Test.@test e.context == "SciML solve_problem"
+                end
             end
         end
 
-        Test.@testset "unsafe=true bypasses retcode check" begin
-            # Create a simple ODE problem that will fail with maxiters=1
-            prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
-            integ = Integrators.SciML(maxiters=1)
+        redirect_stderr(devnull) do
+            Test.@testset "unsafe=true bypasses retcode check" begin
+                # Create a simple ODE problem that will fail with maxiters=1
+                prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
+                integ = Integrators.SciML(maxiters=1)
 
-            # With unsafe=true, should not throw even with bad retcode
-            result = Integrators.solve_problem(integ, prob; unsafe=true)
-            Test.@test result isa CTFlowsSciMLExt.SciMLIntegrationResult
+                # With unsafe=true, should not throw even with bad retcode
+                result = Integrators.solve_problem(integ, prob; unsafe=true)
+                Test.@test result isa CTFlowsSciMLExt.SciMLIntegrationResult
+            end
         end
 
         # ====================================================================
@@ -256,7 +260,7 @@ function test_sciml_extension()
 
         Test.@testset "Semantic Accessors" begin
             sys = Systems.VectorFieldSystem(
-                Data.VectorField(x -> -x; autonomous=true, variable=false)
+                Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
             )
 
             config = Common.TrajectoryConfig((0.0, 1.0), [1.0, 2.0])
@@ -283,7 +287,7 @@ function test_sciml_extension()
         Test.@testset "Full Workflow" begin
             Test.@testset "PointConfig workflow" begin
                 sys = Systems.VectorFieldSystem(
-                    Data.VectorField(x -> -x; autonomous=true, variable=false)
+                    Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
 
                 config = Common.PointConfig(0.0, 1.0, 1.0)
@@ -303,7 +307,7 @@ function test_sciml_extension()
 
             Test.@testset "TrajectoryConfig workflow" begin
                 sys = Systems.VectorFieldSystem(
-                    Data.VectorField(x -> -x; autonomous=true, variable=false)
+                    Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
 
                 config = Common.TrajectoryConfig((0.0, 1.0), [1.0, 2.0])

--- a/test/suite/flows/test_abstract_flow.jl
+++ b/test/suite/flows/test_abstract_flow.jl
@@ -231,7 +231,7 @@ function test_abstract_flow()
 
         Test.@testset "VectorField Flow Integration Tests" begin
             Test.@testset "Autonomous Fixed Flow" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 integ = :fake_integ
                 flow = FakeFlow(sys, integ)
@@ -245,7 +245,7 @@ function test_abstract_flow()
             end
 
             Test.@testset "NonAutonomous Fixed Flow" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 integ = :fake_integ
                 flow = FakeFlow(sys, integ)
@@ -259,7 +259,7 @@ function test_abstract_flow()
             end
 
             Test.@testset "Autonomous NonFixed Flow" begin
-                vf = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 sys = Systems.VectorFieldSystem(vf)
                 integ = :fake_integ
                 flow = FakeFlow(sys, integ)

--- a/test/suite/flows/test_building_flows.jl
+++ b/test/suite/flows/test_building_flows.jl
@@ -24,7 +24,7 @@ function test_building_flows()
 
         Test.@testset "Flow constructor from VectorField" begin
             Test.@testset "default constructor" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 flow = Flows.Flow(vf)
 
                 Test.@test flow isa Flows.Flow
@@ -34,7 +34,7 @@ function test_building_flows()
             end
 
             Test.@testset "with keyword options" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 flow = Flows.Flow(vf; reltol=1e-10)
 
                 Test.@test flow isa Flows.Flow
@@ -48,7 +48,7 @@ function test_building_flows()
 
         Test.@testset "Trait preservation" begin
             Test.@testset "Autonomous Fixed" begin
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 flow = Flows.Flow(vf)
                 
                 Test.@test Common.time_dependence(flow) === Common.Autonomous
@@ -56,7 +56,7 @@ function test_building_flows()
             end
 
             Test.@testset "NonAutonomous Fixed" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 flow = Flows.Flow(vf)
                 
                 Test.@test Common.time_dependence(flow) === Common.NonAutonomous
@@ -64,7 +64,7 @@ function test_building_flows()
             end
 
             Test.@testset "Autonomous NonFixed" begin
-                vf = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 flow = Flows.Flow(vf)
                 
                 Test.@test Common.time_dependence(flow) === Common.Autonomous
@@ -72,7 +72,7 @@ function test_building_flows()
             end
 
             Test.@testset "NonAutonomous NonFixed" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
                 flow = Flows.Flow(vf)
                 
                 Test.@test Common.time_dependence(flow) === Common.NonAutonomous
@@ -85,7 +85,7 @@ function test_building_flows()
         # ====================================================================
 
         Test.@testset "System and Integrator access" begin
-            vf = Data.VectorField(x -> 2 .* x; autonomous=true, variable=false)
+            vf = Data.VectorField(x -> 2 .* x; is_autonomous=true, is_variable=false)
             flow = Flows.Flow(vf)
             
             Test.@testset "system accessor returns correct system" begin
@@ -105,7 +105,7 @@ function test_building_flows()
 
         Test.@testset "Integration with build_system" begin
             Test.@testset "build_system is called internally" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 
                 # Build system directly
                 sys_direct = Systems.build_system(vf)

--- a/test/suite/flows/test_calling.jl
+++ b/test/suite/flows/test_calling.jl
@@ -109,7 +109,7 @@ function test_calling()
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
                 
                 # Execute
-                result = Flows.call(flow, config)
+                result = Flows.call(flow, config; variable=nothing, unsafe=false)
                 
                 # Verify all steps were called
                 Test.@test integ.build_problem_called === true
@@ -126,7 +126,7 @@ function test_calling()
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
                 
                 # Call with variable (should be accepted even for Fixed)
-                result = Flows.call(flow, config; variable=0.5)
+                result = Flows.call(flow, config; variable=0.5, unsafe=false)
                 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.solve_problem_called === true
@@ -139,7 +139,7 @@ function test_calling()
                 flow = FakeFlowForCalling{Common.Autonomous, Common.Fixed, typeof(sys), typeof(integ)}(sys, integ)
                 config = Common.TrajectoryConfig((0.0, 1.0), [1.0, 0.0])
 
-                result = Flows.call(flow, config)
+                result = Flows.call(flow, config; variable=nothing, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.solve_problem_called === true
@@ -153,7 +153,7 @@ function test_calling()
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
 
                 # Call with unsafe=true
-                result = Flows.call(flow, config; unsafe=true)
+                result = Flows.call(flow, config; variable=nothing, unsafe=true)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.solve_problem_called === true

--- a/test/suite/flows/test_flow.jl
+++ b/test/suite/flows/test_flow.jl
@@ -48,21 +48,21 @@ function Flows.integrator(flow::FakeFlow)
     return flow.integ
 end
 
-# Config-based callable - both Fixed and NonFixed accept variable=nothing, unsafe=false
-function (flow::FakeFlow)(config::Common.PointConfig; variable=nothing, unsafe=false)
+# Config-based callable - both Fixed and NonFixed require variable, unsafe
+function (flow::FakeFlow)(config::Common.PointConfig; variable, unsafe)
     return flow.integ.result
 end
 
-function (flow::FakeFlow)(config::Common.TrajectoryConfig; variable=nothing, unsafe=false)
+function (flow::FakeFlow)(config::Common.TrajectoryConfig; variable, unsafe)
     return flow.integ.result
 end
 
-# Positional callable - both Fixed and NonFixed accept variable=nothing, unsafe=false
-function (flow::FakeFlow)(t0, x0, tf; variable=nothing, unsafe=false)
+# Positional callable - both Fixed and NonFixed require variable, unsafe
+function (flow::FakeFlow)(t0, x0, tf; variable, unsafe)
     return flow.integ.result
 end
 
-function (flow::FakeFlow)(tspan::Tuple, x0; variable=nothing, unsafe=false)
+function (flow::FakeFlow)(tspan::Tuple, x0; variable, unsafe)
     return flow.integ.result
 end
 
@@ -126,38 +126,38 @@ function test_flow()
 
             Test.@testset "call with PointConfig" begin
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
-                result = flow(config)
+                result = flow(config; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with PointConfig and variable (ignored for Fixed)" begin
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
-                result = flow(config; variable = 0.5)
+                result = flow(config; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (t0, x0, tf)" begin
-                result = flow(0.0, [1.0, 0.0], 1.0)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (t0, x0, tf; variable) (ignored for Fixed)" begin
-                result = flow(0.0, [1.0, 0.0], 1.0; variable = 0.5)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (tspan, x0)" begin
-                result = flow((0.0, 1.0), [1.0, 0.0])
+                result = flow((0.0, 1.0), [1.0, 0.0]; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (tspan, x0; variable) (ignored for Fixed)" begin
-                result = flow((0.0, 1.0), [1.0, 0.0]; variable = 0.5)
+                result = flow((0.0, 1.0), [1.0, 0.0]; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with unsafe kwarg" begin
-                result = flow(0.0, [1.0, 0.0], 1.0; unsafe = true)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=nothing, unsafe=true)
                 Test.@test result === :solution
             end
         end
@@ -173,38 +173,38 @@ function test_flow()
 
             Test.@testset "call with PointConfig" begin
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
-                result = flow(config)
+                result = flow(config; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with PointConfig and variable" begin
                 config = Common.PointConfig(0.0, [1.0, 0.0], 1.0)
-                result = flow(config; variable = 0.5)
+                result = flow(config; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (t0, x0, tf)" begin
-                result = flow(0.0, [1.0, 0.0], 1.0)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (t0, x0, tf; variable)" begin
-                result = flow(0.0, [1.0, 0.0], 1.0; variable = 0.5)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (tspan, x0)" begin
-                result = flow((0.0, 1.0), [1.0, 0.0])
+                result = flow((0.0, 1.0), [1.0, 0.0]; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with (tspan, x0; variable)" begin
-                result = flow((0.0, 1.0), [1.0, 0.0]; variable = 0.5)
+                result = flow((0.0, 1.0), [1.0, 0.0]; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
 
             Test.@testset "call with unsafe kwarg" begin
-                result = flow(0.0, [1.0, 0.0], 1.0; unsafe = true)
+                result = flow(0.0, [1.0, 0.0], 1.0; variable=nothing, unsafe=true)
                 Test.@test result === :solution
             end
         end

--- a/test/suite/solutions/test_building_solutions.jl
+++ b/test/suite/solutions/test_building_solutions.jl
@@ -35,7 +35,7 @@ function test_building_solutions()
 
         Test.@testset "build_solution - PointConfig" begin
             Test.@testset "vector initial condition returns final state" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; autonomous=true, variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.PointConfig(0.0, [1.0, 2.0], 1.0)
                 
@@ -45,7 +45,7 @@ function test_building_solutions()
             end
 
             Test.@testset "scalar initial condition unwraps length-1 vector" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; autonomous=true, variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
                 result = FakeIntegrationResult([[3.0], [1.5]])
                 config = Common.PointConfig(0.0, 3.0, 1.0)
                 
@@ -61,7 +61,7 @@ function test_building_solutions()
 
         Test.@testset "build_solution - TrajectoryConfig" begin
             Test.@testset "returns VectorFieldSolution wrapping result" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; autonomous=true, variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.TrajectoryConfig((0.0, 1.0), [1.0, 2.0])
                 
@@ -70,7 +70,7 @@ function test_building_solutions()
             end
 
             Test.@testset "VectorFieldSolution contains correct result" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; autonomous=true, variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.TrajectoryConfig((0.0, 1.0), [1.0, 2.0])
                 

--- a/test/suite/systems/test_building_systems.jl
+++ b/test/suite/systems/test_building_systems.jl
@@ -21,35 +21,35 @@ function test_building_systems()
 
         Test.@testset "build_system" begin
             Test.@testset "build_system returns VectorFieldSystem" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.build_system(vf)
                 Test.@test sys isa Systems.VectorFieldSystem
                 Test.@test sys isa Systems.AbstractSystem
             end
 
             Test.@testset "build_system preserves traits - Autonomous Fixed" begin
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.build_system(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "build_system preserves traits - NonAutonomous Fixed" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys = Systems.build_system(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "build_system preserves traits - Autonomous NonFixed" begin
-                vf = Data.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 sys = Systems.build_system(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed
             end
 
             Test.@testset "build_system preserves traits - NonAutonomous NonFixed" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
                 sys = Systems.build_system(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed
@@ -62,14 +62,14 @@ function test_building_systems()
 
         Test.@testset "Integration with rhs" begin
             Test.@testset "built system has working rhs" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.build_system(vf)
                 rhs = Systems.rhs(sys)
                 Test.@test rhs isa Function
             end
 
             Test.@testset "built system rhs computes correctly" begin
-                vf = Data.VectorField(x -> 2 .* x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> 2 .* x; is_autonomous=true, is_variable=false)
                 sys = Systems.build_system(vf)
                 rhs = Systems.rhs(sys)
                 du = zeros(2)

--- a/test/suite/systems/test_systems_module.jl
+++ b/test/suite/systems/test_systems_module.jl
@@ -45,7 +45,7 @@ function test_systems_module()
 
             Test.@testset "VectorFieldSystem constructor is exported" begin
                 Test.@test isdefined(Systems, :VectorFieldSystem)
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test sys isa Systems.VectorFieldSystem
                 Test.@test sys isa Systems.AbstractSystem
@@ -62,7 +62,7 @@ function test_systems_module()
             end
 
             Test.@testset "rhs returns a callable function" begin
-                vf = Data.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 rhs = Systems.rhs(sys)
                 Test.@test isa(rhs, Function)
@@ -93,21 +93,21 @@ function test_systems_module()
             end
 
             Test.@testset "time_dependence function works with VectorFieldSystem" begin
-                vf_aut = Data.VectorField(x -> x; autonomous=true)
+                vf_aut = Data.VectorField(x -> x; is_autonomous=true)
                 sys_aut = Systems.VectorFieldSystem(vf_aut)
                 Test.@test Common.time_dependence(sys_aut) === Common.Autonomous
 
-                vf_non = Data.VectorField((t, x) -> x; autonomous=false)
+                vf_non = Data.VectorField((t, x) -> x; is_autonomous=false)
                 sys_non = Systems.VectorFieldSystem(vf_non)
                 Test.@test Common.time_dependence(sys_non) === Common.NonAutonomous
             end
 
             Test.@testset "variable_dependence function works with VectorFieldSystem" begin
-                vf_fixed = Data.VectorField(x -> x; variable=false)
+                vf_fixed = Data.VectorField(x -> x; is_variable=false)
                 sys_fixed = Systems.VectorFieldSystem(vf_fixed)
                 Test.@test Common.variable_dependence(sys_fixed) === Common.Fixed
 
-                vf_nonfixed = Data.VectorField((x, v) -> x .* v; variable=true)
+                vf_nonfixed = Data.VectorField((x, v) -> x .* v; is_variable=true)
                 sys_nonfixed = Systems.VectorFieldSystem(vf_nonfixed)
                 Test.@test Common.variable_dependence(sys_nonfixed) === Common.NonFixed
             end
@@ -119,28 +119,28 @@ function test_systems_module()
 
         Test.@testset "Trait Propagation" begin
             Test.@testset "Autonomous Fixed traits propagate" begin
-                vf = Data.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "NonAutonomous Fixed traits propagate" begin
-                vf = Data.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Data.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "Autonomous NonFixed traits propagate" begin
-                vf = Data.VectorField((x, v) -> x .* v; autonomous=true, variable=true)
+                vf = Data.VectorField((x, v) -> x .* v; is_autonomous=true, is_variable=true)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed
             end
 
             Test.@testset "NonAutonomous NonFixed traits propagate" begin
-                vf = Data.VectorField((t, x, v) -> t .* x .* v; autonomous=false, variable=true)
+                vf = Data.VectorField((t, x, v) -> t .* x .* v; is_autonomous=false, is_variable=true)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -19,7 +19,7 @@ function test_vector_field_system()
         # ====================================================================
 
         Test.@testset "Abstract Types" begin
-            vf = Systems.VectorField(x -> x; autonomous=true, variable=false)
+            vf = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
             sys = Systems.VectorFieldSystem(vf)
             Test.@test sys isa Systems.VectorFieldSystem
             Test.@test sys isa Systems.AbstractSystem
@@ -31,35 +31,35 @@ function test_vector_field_system()
 
         Test.@testset "Construction" begin
             Test.@testset "constructs from VectorField" begin
-                vf = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test sys isa Systems.VectorFieldSystem
                 Test.@test sys isa Systems.AbstractSystem
             end
 
             Test.@testset "trait propagation - Autonomous Fixed" begin
-                vf = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "trait propagation - NonAutonomous Fixed" begin
-                vf = Systems.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf = Systems.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.Fixed
             end
 
             Test.@testset "trait propagation - Autonomous NonFixed" begin
-                vf = Systems.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf = Systems.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.Autonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed
             end
 
             Test.@testset "trait propagation - NonAutonomous NonFixed" begin
-                vf = Systems.VectorField((t, x, v) -> t .* x .+ v; autonomous=false, variable=true)
+                vf = Systems.VectorField((t, x, v) -> t .* x .+ v; is_autonomous=false, is_variable=true)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.time_dependence(sys) === Common.NonAutonomous
                 Test.@test Common.variable_dependence(sys) === Common.NonFixed
@@ -72,14 +72,14 @@ function test_vector_field_system()
 
         Test.@testset "Contract Implementation" begin
             Test.@testset "rhs returns callable" begin
-                vf = Systems.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 rhs = Systems.rhs(sys)
                 Test.@test rhs isa Function
             end
 
             Test.@testset "rhs function has correct signature (du, u, p, t)" begin
-                vf = Systems.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 rhs = Systems.rhs(sys)
                 du = zeros(2)
@@ -92,7 +92,7 @@ function test_vector_field_system()
             end
 
             Test.@testset "rhs function fills du in place" begin
-                vf = Systems.VectorField(x -> -x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 rhs = Systems.rhs(sys)
                 du = zeros(2)
@@ -102,8 +102,8 @@ function test_vector_field_system()
             end
 
             Test.@testset "rhs function uses underlying VectorField" begin
-                vf1 = Systems.VectorField(x -> 2 .* x; autonomous=true, variable=false)
-                vf2 = Systems.VectorField(x -> 3 .* x; autonomous=true, variable=false)
+                vf1 = Systems.VectorField(x -> 2 .* x; is_autonomous=true, is_variable=false)
+                vf2 = Systems.VectorField(x -> 3 .* x; is_autonomous=true, is_variable=false)
                 sys1 = Systems.VectorFieldSystem(vf1)
                 sys2 = Systems.VectorFieldSystem(vf2)
                 rhs1 = Systems.rhs(sys1)
@@ -124,21 +124,21 @@ function test_vector_field_system()
 
         Test.@testset "Trait Methods" begin
             Test.@testset "time_dependence returns correct trait" begin
-                vf_aut = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf_aut = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys_aut = Systems.VectorFieldSystem(vf_aut)
                 Test.@test Common.time_dependence(sys_aut) === Common.Autonomous
 
-                vf_nonaut = Systems.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf_nonaut = Systems.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys_nonaut = Systems.VectorFieldSystem(vf_nonaut)
                 Test.@test Common.time_dependence(sys_nonaut) === Common.NonAutonomous
             end
 
             Test.@testset "variable_dependence returns correct trait" begin
-                vf_fixed = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf_fixed = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys_fixed = Systems.VectorFieldSystem(vf_fixed)
                 Test.@test Common.variable_dependence(sys_fixed) === Common.Fixed
 
-                vf_nonfixed = Systems.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf_nonfixed = Systems.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 sys_nonfixed = Systems.VectorFieldSystem(vf_nonfixed)
                 Test.@test Common.variable_dependence(sys_nonfixed) === Common.NonFixed
             end
@@ -150,36 +150,36 @@ function test_vector_field_system()
 
         Test.@testset "Common Trait Predicates" begin
             Test.@testset "has_time_dependence_trait returns true" begin
-                vf = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.has_time_dependence_trait(sys) === true
             end
 
             Test.@testset "has_variable_dependence_trait returns true" begin
-                vf = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 Test.@test Common.has_variable_dependence_trait(sys) === true
             end
 
             Test.@testset "is_autonomous / is_nonautonomous" begin
-                vf_aut = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf_aut = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys_aut = Systems.VectorFieldSystem(vf_aut)
                 Test.@test Common.is_autonomous(sys_aut) === true
                 Test.@test Common.is_nonautonomous(sys_aut) === false
 
-                vf_nonaut = Systems.VectorField((t, x) -> t .* x; autonomous=false, variable=false)
+                vf_nonaut = Systems.VectorField((t, x) -> t .* x; is_autonomous=false, is_variable=false)
                 sys_nonaut = Systems.VectorFieldSystem(vf_nonaut)
                 Test.@test Common.is_autonomous(sys_nonaut) === false
                 Test.@test Common.is_nonautonomous(sys_nonaut) === true
             end
 
             Test.@testset "is_variable / is_nonvariable" begin
-                vf_fixed = Systems.VectorField(x -> x; autonomous=true, variable=false)
+                vf_fixed = Systems.VectorField(x -> x; is_autonomous=true, is_variable=false)
                 sys_fixed = Systems.VectorFieldSystem(vf_fixed)
                 Test.@test Common.is_variable(sys_fixed) === false
                 Test.@test Common.is_nonvariable(sys_fixed) === true
 
-                vf_nonfixed = Systems.VectorField((x, v) -> x .+ v; autonomous=true, variable=true)
+                vf_nonfixed = Systems.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 sys_nonfixed = Systems.VectorFieldSystem(vf_nonfixed)
                 Test.@test Common.is_variable(sys_nonfixed) === true
                 Test.@test Common.is_nonvariable(sys_nonfixed) === false


### PR DESCRIPTION
- Rename __autonomous() to __is_autonomous() and __variable() to __is_variable()
- Add new __variable() function returning nothing for default parameter values
- Update VectorField constructor to use is_autonomous and is_variable parameter names
- Update Flow callable methods to use Common.__variable() as default
- Remove default values from internal call function (requires explicit variable and unsafe)
- Update all test files and example file to use new parameter names
- Add docstrings to all modified files
- Suppress SciMLBase warnings in test_sciml_extension.jl