### PR TITLE
Implement modular internalnorm for grid invariance under ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,20 +11,25 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [weakdeps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extensions]
+CTFlowsForwardDiffExt = ["ForwardDiff"]
 CTFlowsPlotsExt = ["Plots"]
-CTFlowsSciMLExt = ["OrdinaryDiffEqTsit5", "SciMLBase"]
+CTFlowsSciMLExt = ["DiffEqBase", "OrdinaryDiffEqTsit5", "SciMLBase"]
 
 [compat]
 Aqua = "0.8"
 CTBase = "0.18"
 CTSolvers = "0.4"
 CommonSolve = "0.2"
+DiffEqBase = "7"
 DocStringExtensions = "0.9"
+ForwardDiff = "0.10, 1"
 OrdinaryDiffEqTsit5 = "2"
 Plots = "1"
 RecipesBase = "1"
@@ -37,4 +42,4 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "Test"]
+test = ["Aqua", "DiffEqBase", "ForwardDiff", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "Test"]

--- a/ext/CTFlowsForwardDiffExt.jl
+++ b/ext/CTFlowsForwardDiffExt.jl
@@ -1,0 +1,80 @@
+"""
+    CTFlowsForwardDiffExt
+
+Package extension providing ForwardDiff-specific implementations for grid invariance (IND).
+Activated automatically when ForwardDiff is loaded together with CTFlows.
+
+This extension adds:
+- `deepvalue(x::ForwardDiff.Dual)` — Recursive extraction of primal values from nested duals
+- `real_norm(u::ForwardDiff.Dual, t)` — Internal norm for scalar dual numbers
+
+These functions extend the fallback implementations in `CTFlows.Common` to support ForwardDiff dual numbers.
+"""
+module CTFlowsForwardDiffExt
+
+import DocStringExtensions: TYPEDSIGNATURES
+import ForwardDiff
+
+using CTFlows: CTFlows
+using CTFlows.Common: Common
+
+# =============================================================================
+# deepvalue and real_norm — ForwardDiff-specific implementations
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Recursively extract the primal (real) value from a ForwardDiff dual number.
+
+Handles nested dual numbers for higher-order differentiation (e.g., second-order
+derivatives where the partials themselves are dual numbers). This extends the
+fallback `Common.deepvalue(x::Real)` to support ForwardDiff.
+
+# Arguments
+- `x::ForwardDiff.Dual`: A ForwardDiff dual number (possibly nested).
+
+# Returns
+- `Real`: The primal (Float64) part of the dual number.
+
+# Example
+```julia
+julia> using ForwardDiff
+
+julia> d1 = ForwardDiff.Dual{:Tag}(3.0, 1.0)
+Dual{:Tag}(3.0, 1.0)
+
+julia> CTFlowsForwardDiffExt.deepvalue(d1)
+3.0
+
+julia> d2 = ForwardDiff.Dual{:Tag2}(d1, d1)  # Nested dual
+Dual{:Tag2}(Dual{:Tag}(3.0, 1.0), Dual{:Tag}(3.0, 1.0))
+
+julia> CTFlowsForwardDiffExt.deepvalue(d2)
+3.0
+```
+
+See also: [`Common.deepvalue`](@ref), [`real_norm`](@ref)
+"""
+Common.deepvalue(x::ForwardDiff.Dual) = Common.deepvalue(ForwardDiff.value(x))
+
+"""
+$(TYPEDSIGNATURES)
+
+Compute the internal norm for a scalar ForwardDiff dual number using only its primal part.
+
+This extends the fallback `Common.real_norm(u::Real, t)` to support ForwardDiff dual numbers,
+ensuring grid invariance (IND) when integrating ODEs with dual numbers.
+
+# Arguments
+- `u::ForwardDiff.Dual`: A scalar dual number.
+- `t`: Time parameter (unused but required by SciML interface).
+
+# Returns
+- `Real`: The absolute value of the primal part.
+
+See also: [`Common.real_norm`](@ref), [`deepvalue`](@ref)
+"""
+Common.real_norm(u::ForwardDiff.Dual, t) = Common.real_norm(Common.deepvalue(u), t)
+
+end # module CTFlowsForwardDiffExt

--- a/ext/CTFlowsSciMLExt.jl
+++ b/ext/CTFlowsSciMLExt.jl
@@ -18,8 +18,50 @@ using CTFlows.Common: Common
 using CTFlows.Systems: Systems
 using CTFlows.Integrators: Integrators, SciML, SciMLTag
 using CTFlows.Solutions: Solutions
+using DiffEqBase: DiffEqBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, ODEProblem, Tsit5
 using SciMLBase: SciMLBase
+
+# =============================================================================
+# real_norm overload for SciML
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Compute the internal norm for adaptive step-size control using only the primal
+parts of dual numbers.
+
+This function ensures grid invariance (IND) when integrating ODEs with ForwardDiff
+dual numbers: the adaptive time grid chosen by the solver is identical whether
+integrating with real numbers or dual numbers. Without this, the step-size
+controller would make decisions based on dual values, breaking grid invariance.
+
+This implementation uses `Common.deepvalue` to extract primal parts and
+`DiffEqBase.ODE_DEFAULT_NORM` to compute the norm. When ForwardDiff is loaded,
+`Common.deepvalue` is extended to handle dual numbers via `CTFlowsForwardDiffExt`.
+
+# Arguments
+- `u::AbstractArray`: State vector (may contain dual numbers).
+- `t`: Time parameter (unused but required by SciML interface).
+
+# Returns
+- `Real`: The norm computed on the primal parts only.
+
+# Example
+```julia
+julia> using ForwardDiff
+
+julia> u_real = [1.0, 2.0, 3.0]
+julia> u_dual = ForwardDiff.Dual{:T}.(u_real, ones(3))
+
+julia> CTFlowsSciMLExt.real_norm(u_real, 0.0) ≈ CTFlowsSciMLExt.real_norm(u_dual, 0.0)
+true
+```
+
+See also: [`Common.deepvalue`](@ref), [`Common.real_norm`](@ref)
+"""
+Common.real_norm(u::AbstractArray, t) = DiffEqBase.ODE_DEFAULT_NORM(Common.deepvalue.(u), t)
 
 # =============================================================================
 # Strategies.metadata — option definitions for SciML
@@ -29,6 +71,9 @@ using SciMLBase: SciMLBase
 $(TYPEDSIGNATURES)
 
 Return metadata defining `SciML` options and their specifications.
+
+The `internalnorm` option defaults to `real_norm`, which extracts the primal (Float64)
+part of ForwardDiff dual numbers to ensure grid invariance (IND) when ForwardDiff is loaded.
 """
 function Strategies.metadata(::Type{SciML})
     return Strategies.StrategyMetadata(
@@ -217,6 +262,16 @@ function Strategies.metadata(::Type{SciML})
             type = Bool,
             default = Options.NotProvided,
             description = "Whether to force saving the final timepoint.",
+        ),
+        Strategies.OptionDefinition(;
+            name = :internalnorm,
+            type = Function,
+            default = Common.real_norm,
+            description = "Internal norm for adaptive step-size control. " *
+                          "Defaults to `real_norm`, which extracts the primal (Float64) " *
+                          "part of ForwardDiff dual numbers to ensure grid invariance (IND) " *
+                          "when ForwardDiff is loaded. Set to `DiffEqBase.ODE_DEFAULT_NORM` to use the SciML default.",
+            aliases = (:internal_norm, :norm),
         ),
     )
 end

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -2,6 +2,12 @@
     Common
 
 Shared utilities and types for CTFlows.
+
+This module provides fallback implementations for grid invariance (IND) support:
+- `deepvalue(x::Real)` — Base case for extracting primal values
+- `real_norm(u::Real, t)` — Base case for internal norm computation
+
+ForwardDiff-specific implementations are provided in `CTFlowsForwardDiffExt` when ForwardDiff is loaded.
 """
 module Common
 # ==============================================================================
@@ -20,6 +26,7 @@ include(joinpath(@__DIR__, "configs.jl"))
 include(joinpath(@__DIR__, "traits.jl"))
 include(joinpath(@__DIR__, "ode_parameters.jl"))
 include(joinpath(@__DIR__, "default.jl"))
+include(joinpath(@__DIR__, "internal_norm.jl"))
 
 # ==============================================================================
 # Module exports
@@ -33,5 +40,6 @@ export has_time_dependence_trait, has_variable_dependence_trait
 export time_dependence, variable_dependence
 export is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable
 export __is_autonomous, __is_variable, __variable, __unsafe
+export deepvalue, real_norm
 
 end # module Common

--- a/src/Common/internal_norm.jl
+++ b/src/Common/internal_norm.jl
@@ -1,0 +1,52 @@
+# =============================================================================
+# internal_norm — fallback implementations for grid invariance
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract the primal (real) value from a number. Base case for real numbers.
+
+This is a fallback implementation used when AD backends are not loaded.
+ForwardDiff-specific implementations are provided in `CTFlowsForwardDiffExt`.
+
+# Arguments
+- `x::Real`: A real number (e.g., `Float64`).
+
+# Returns
+- `Real`: The input value unchanged.
+
+# Example
+```julia
+julia> CTFlows.Common.deepvalue(3.14)
+3.14
+```
+
+See also: [`CTFlowsForwardDiffExt.deepvalue`](@extref)
+"""
+deepvalue(x::Real) = x
+
+"""
+$(TYPEDSIGNATURES)
+
+Compute the internal norm for a scalar real number.
+
+This is a fallback implementation used when AD backends are not loaded.
+ForwardDiff-specific implementations are provided in `CTFlowsForwardDiffExt`.
+
+# Arguments
+- `u::Real`: A scalar real number.
+- `t`: Time parameter (unused but required by SciML interface).
+
+# Returns
+- `Real`: The absolute value of the input.
+
+# Example
+```julia
+julia> CTFlows.Common.real_norm(3.0, 0.0)
+3.0
+```
+
+See also: [`CTFlowsForwardDiffExt.real_norm`](@extref)
+"""
+real_norm(u::Real, t) = abs(u)

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -230,6 +230,22 @@ function test_common_module()
                 Test.@test Common.TrajectoryConfig <: Common.AbstractConfig
             end
         end
+
+        # ====================================================================
+        # Internal Norm Functions
+        # ====================================================================
+
+        Test.@testset "Internal Norm Functions" begin
+            Test.@testset "deepvalue is exported" begin
+                Test.@test isdefined(Common, :deepvalue)
+                Test.@test Common.deepvalue(3.14) === 3.14
+            end
+
+            Test.@testset "real_norm is exported" begin
+                Test.@test isdefined(Common, :real_norm)
+                Test.@test Common.real_norm(3.0, 0.0) === 3.0
+            end
+        end
     end
 end
 

--- a/test/suite/common/test_internal_norm.jl
+++ b/test/suite/common/test_internal_norm.jl
@@ -1,0 +1,43 @@
+module TestInternalNorm
+
+import Test
+import CTFlows.Common: Common
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+function test_internal_norm()
+    Test.@testset "Internal Norm Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # UNIT TESTS - deepvalue
+        # ====================================================================
+
+        Test.@testset "deepvalue" begin
+            Test.@testset "deepvalue(x::Real) is identity" begin
+                Test.@test Common.deepvalue(1.0) === 1.0
+                Test.@test Common.deepvalue(2.5) === 2.5
+                Test.@test Common.deepvalue(-3.0) === -3.0
+                Test.@test Common.deepvalue(0.0) === 0.0
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - real_norm
+        # ====================================================================
+
+        Test.@testset "real_norm" begin
+            Test.@testset "real_norm(u::Real, t) is abs" begin
+                Test.@test Common.real_norm(3.0, 0.0) === 3.0
+                Test.@test Common.real_norm(-5.0, 0.0) === 5.0
+                Test.@test Common.real_norm(0.0, 0.0) === 0.0
+                Test.@test Common.real_norm(2.5, 1.0) === 2.5
+            end
+        end
+
+    end
+end
+
+end # module
+
+test_internal_norm() = TestInternalNorm.test_internal_norm()

--- a/test/suite/extensions/test_forwarddiff_extension.jl
+++ b/test/suite/extensions/test_forwarddiff_extension.jl
@@ -7,6 +7,7 @@ import CTFlows.Data: Data
 import CTFlows.Systems: Systems
 import CTFlows.Integrators: Integrators
 import CTFlows.Solutions: Solutions
+import CTFlows.Flows: Flows
 import CTSolvers.Strategies: Strategies
 
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, ODEProblem, Tsit5
@@ -155,6 +156,27 @@ function test_forwarddiff_extension()
             opts = Strategies.options_dict(integ)
             Test.@test haskey(opts, :internalnorm)
             Test.@test opts[:internalnorm] === Common.real_norm
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - Flow API grid invariance
+        # ====================================================================
+
+        Test.@testset "Flow API grid invariance" begin
+            # Simple ODE: ẋ = x
+            vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
+            flow = Flows.Flow(vf)
+
+            # Integration with real numbers
+            result_real = flow((0.0, 1.0), [1.0])
+            t_real = Solutions.times(result_real)
+
+            # Integration with Dual (Jacobian w.r.t. initial condition)
+            result_dual = flow((0.0, 1.0), ForwardDiff.Dual{:T}.([1.0], [1.0]))
+            t_dual = ForwardDiff.value.(Solutions.times(result_dual))
+
+            # Grids must be identical with real_norm (default)
+            Test.@test t_real == t_dual
         end
     end
 end

--- a/test/suite/extensions/test_forwarddiff_extension.jl
+++ b/test/suite/extensions/test_forwarddiff_extension.jl
@@ -1,0 +1,164 @@
+module TestForwardDiffExtension
+
+import Test
+import CTFlows: CTFlows
+import CTFlows.Common: Common
+import CTFlows.Data: Data
+import CTFlows.Systems: Systems
+import CTFlows.Integrators: Integrators
+import CTFlows.Solutions: Solutions
+import CTSolvers.Strategies: Strategies
+
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, ODEProblem, Tsit5
+using SciMLBase: SciMLBase
+using DiffEqBase: DiffEqBase
+using ForwardDiff: ForwardDiff
+
+const CTFlowsSciMLExt = Base.get_extension(CTFlows, :CTFlowsSciMLExt)
+const CTFlowsForwardDiffExt = Base.get_extension(CTFlows, :CTFlowsForwardDiffExt)
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+function test_forwarddiff_extension()
+    Test.@testset "ForwardDiff Extension Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+        
+        # ====================================================================
+        # Extension availability check
+        # ====================================================================
+
+        Test.@testset "Extension availability" begin
+            Test.@testset "CTFlowsSciMLExt is loaded" begin
+                Test.@test !isnothing(CTFlowsSciMLExt)
+            end
+
+            Test.@testset "CTFlowsForwardDiffExt availability" begin
+                if isnothing(CTFlowsForwardDiffExt)
+                    Test.@test_skip "ForwardDiff extension not loaded (ForwardDiff not installed)"
+                else
+                    Test.@test CTFlowsForwardDiffExt isa Module
+                end
+            end
+        end
+
+        # Skip ForwardDiff-specific tests if extension is not loaded
+        if isnothing(CTFlowsForwardDiffExt)
+            return
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Common fallbacks
+        # ====================================================================
+
+        Test.@testset "Common fallbacks" begin
+            Test.@testset "deepvalue(x::Real) is identity" begin
+                Test.@test Common.deepvalue(1.0) === 1.0
+                Test.@test Common.deepvalue(2.5) === 2.5
+            end
+
+            Test.@testset "real_norm(u::Real, t) is abs" begin
+                Test.@test Common.real_norm(3.0, 0.0) === 3.0
+                Test.@test Common.real_norm(-5.0, 0.0) === 5.0
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - deepvalue extraction (ForwardDiff)
+        # ====================================================================
+
+        Test.@testset "deepvalue extraction" begin
+            Test.@testset "order 1 — single Dual" begin
+                d1 = ForwardDiff.Dual{:Tag1}(3.0, 1.0)
+                Test.@test Common.deepvalue(d1) === 3.0
+
+                d1b = ForwardDiff.Dual{:Tag1}(5.5, 2.0, 3.0)
+                Test.@test Common.deepvalue(d1b) === 5.5
+            end
+
+            Test.@testset "order 2 — nested Dual" begin
+                d1 = ForwardDiff.Dual{:Tag1}(3.0, 1.0)
+                d2 = ForwardDiff.Dual{:Tag2}(d1, d1)
+                Test.@test Common.deepvalue(d2) === 3.0
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - real_norm ignores dual parts (ForwardDiff)
+        # ====================================================================
+
+        Test.@testset "real_norm ignores dual parts" begin
+            u_real = [1.0, 2.0, 3.0]
+            u_dual = ForwardDiff.Dual{:T}.(u_real, ones(3))
+
+            # The norm must be identical regardless of dual parts
+            norm_real = Common.real_norm(u_real, 0.0)
+            norm_dual = Common.real_norm(u_dual, 0.0)
+            Test.@test norm_real ≈ norm_dual
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - Grid invariance
+        # ====================================================================
+
+        Test.@testset "grids differ WITHOUT real_norm (baseline)" begin
+            f!(du, u, p, t) = (du .= u)  # ẋ = x
+            u0_real = [1.0]
+
+            # Integration with real numbers
+            prob_real = ODEProblem(f!, u0_real, (0.0, 1.0), nothing)
+            sol_real = SciMLBase.solve(prob_real, Tsit5(); reltol=1e-8, abstol=1e-8, dense=false)
+
+            # Integration with Dual (Jacobian w.r.t. u0) using DiffEqBase.ODE_DEFAULT_NORM
+            function integrate_dual_default(x0)
+                prob = ODEProblem(f!, x0, (0.0, 1.0), nothing)
+                return SciMLBase.solve(prob, Tsit5(); reltol=1e-8, abstol=1e-8, dense=false,
+                    internalnorm=DiffEqBase.ODE_DEFAULT_NORM)
+            end
+            u0_dual = ForwardDiff.Dual{:T}.([1.0], [1.0])
+            sol_dual = integrate_dual_default(u0_dual)
+
+            # The grids MUST be different with DiffEqBase.ODE_DEFAULT_NORM
+            t_real = sol_real.t
+            t_dual = ForwardDiff.value.(sol_dual.t)
+            Test.@test t_real ≠ t_dual
+        end
+
+        Test.@testset "grids identical WITH real_norm (objective)" begin
+            f!(du, u, p, t) = (du .= u)
+            u0_real = [1.0]
+
+            prob_real = ODEProblem(f!, u0_real, (0.0, 1.0), nothing)
+            sol_real = SciMLBase.solve(prob_real, Tsit5();
+                reltol=1e-8, abstol=1e-8, dense=false,
+                internalnorm=Common.real_norm)
+
+            function integrate_dual_with_norm(x0)
+                prob = ODEProblem(f!, x0, (0.0, 1.0), nothing)
+                return SciMLBase.solve(prob, Tsit5();
+                    reltol=1e-8, abstol=1e-8, dense=false,
+                    internalnorm=Common.real_norm)
+            end
+            u0_dual = ForwardDiff.Dual{:T}.([1.0], [1.0])
+            sol_dual = integrate_dual_with_norm(u0_dual)
+
+            t_real = sol_real.t
+            t_dual = ForwardDiff.value.(sol_dual.t)
+            Test.@test t_real == t_dual
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Default option verification
+        # ====================================================================
+
+        Test.@testset "real_norm is default internalnorm" begin
+            integ = Integrators.build_integrator()
+            opts = Strategies.options_dict(integ)
+            Test.@test haskey(opts, :internalnorm)
+            Test.@test opts[:internalnorm] === Common.real_norm
+        end
+    end
+end
+
+end # module
+
+test_forwarddiff_extension() = TestForwardDiffExtension.test_forwarddiff_extension()

--- a/test/suite/extensions/test_forwarddiff_extension.jl
+++ b/test/suite/extensions/test_forwarddiff_extension.jl
@@ -107,13 +107,13 @@ function test_forwarddiff_extension()
 
             # Integration with real numbers
             prob_real = ODEProblem(f!, u0_real, (0.0, 1.0), nothing)
-            sol_real = SciMLBase.solve(prob_real, Tsit5(); reltol=1e-8, abstol=1e-8, dense=false)
+            sol_real = SciMLBase.solve(prob_real, Tsit5(); reltol=1e-8, abstol=1e-8, dense=false, save_everystep=true)
 
             # Integration with Dual (Jacobian w.r.t. u0) using DiffEqBase.ODE_DEFAULT_NORM
             function integrate_dual_default(x0)
                 prob = ODEProblem(f!, x0, (0.0, 1.0), nothing)
                 return SciMLBase.solve(prob, Tsit5(); reltol=1e-8, abstol=1e-8, dense=false,
-                    internalnorm=DiffEqBase.ODE_DEFAULT_NORM)
+                    internalnorm=DiffEqBase.ODE_DEFAULT_NORM, save_everystep=true)
             end
             u0_dual = ForwardDiff.Dual{:T}.([1.0], [1.0])
             sol_dual = integrate_dual_default(u0_dual)
@@ -131,13 +131,13 @@ function test_forwarddiff_extension()
             prob_real = ODEProblem(f!, u0_real, (0.0, 1.0), nothing)
             sol_real = SciMLBase.solve(prob_real, Tsit5();
                 reltol=1e-8, abstol=1e-8, dense=false,
-                internalnorm=Common.real_norm)
+                internalnorm=Common.real_norm, save_everystep=true)
 
             function integrate_dual_with_norm(x0)
                 prob = ODEProblem(f!, x0, (0.0, 1.0), nothing)
                 return SciMLBase.solve(prob, Tsit5();
                     reltol=1e-8, abstol=1e-8, dense=false,
-                    internalnorm=Common.real_norm)
+                    internalnorm=Common.real_norm, save_everystep=true)
             end
             u0_dual = ForwardDiff.Dual{:T}.([1.0], [1.0])
             sol_dual = integrate_dual_with_norm(u0_dual)
@@ -165,7 +165,7 @@ function test_forwarddiff_extension()
         Test.@testset "Flow API grid invariance" begin
             # Simple ODE: ẋ = x
             vf = Data.VectorField(x -> x; is_autonomous=true, is_variable=false)
-            flow = Flows.Flow(vf)
+            flow = Flows.Flow(vf; save_everystep=true)
 
             # Integration with real numbers
             result_real = flow((0.0, 1.0), [1.0])


### PR DESCRIPTION
- Add deepvalue and real_norm fallbacks to Common module
- Create CTFlowsForwardDiffExt extension for ForwardDiff-specific implementations
- Refactor CTFlowsSciMLExt to use Common functions and add internalnorm option
- Update Project.toml to add DiffEqBase to extras and targets
- Add comprehensive tests for new architecture
- Add docstrings for all new functions