### PR TITLE
Add switching times verification in flow concatenation

### DIFF
--- a/src/MultiPhase/concatenation.jl
+++ b/src/MultiPhase/concatenation.jl
@@ -1,3 +1,38 @@
+# =============================================================================
+# Private helper: switching times validation
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Validate that switching times are strictly increasing.
+
+Throws a [`PreconditionError`](@extref) if the switching times are not in strictly
+increasing order (i.e., if any `switches[i] >= switches[i+1]`).
+
+# Arguments
+- `switches::Vector{<:Real}`: Vector of switching times to validate.
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): If switching times are not strictly increasing.
+
+# Notes
+- This is a private helper function used internally by concatenation operators.
+- Strictly increasing means each time must be greater than the previous one.
+"""
+function _check_switching_times_order(switches::Vector{<:Real})
+    for i in 1:(length(switches) - 1)
+        if switches[i] >= switches[i + 1]
+            throw(Exceptions.PreconditionError(
+                "Switching times must be strictly increasing";
+                context = "flow concatenation",
+                reason = "found non-increasing sequence: $switches",
+                suggestion = "ensure all switching times are in strictly increasing order",
+            ))
+        end
+    end
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -24,6 +59,7 @@ See also: [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref), [`CTFlows.MultiPhase
 function Base.:*(f1::Flows.AbstractStateFlow, (t_switch, f2)::Tuple{Real, Flows.AbstractStateFlow})
     flows = vcat(get_flows(f1), get_flows(f2))
     switches = vcat(get_switching_times(f1), [t_switch], get_switching_times(f2))
+    _check_switching_times_order(switches)
     jumps = vcat(get_jumps(f1), [nothing], get_jumps(f2))
     return MultiPhaseStateFlow(flows, switches, jumps)
 end
@@ -55,6 +91,7 @@ See also: [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref), [`CTFlows.MultiPhase
 function Base.:*(f1::Flows.AbstractStateFlow, (t_switch, jump, f2)::Tuple{Real, Any, Flows.AbstractStateFlow})
     flows = vcat(get_flows(f1), get_flows(f2))
     switches = vcat(get_switching_times(f1), [t_switch], get_switching_times(f2))
+    _check_switching_times_order(switches)
     jumps = vcat(get_jumps(f1), [jump], get_jumps(f2))
     return MultiPhaseStateFlow(flows, switches, jumps)
 end
@@ -85,6 +122,7 @@ See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.Mult
 function Base.:*(f1::Flows.AbstractHamiltonianFlow, (t_switch, f2)::Tuple{Real, Flows.AbstractHamiltonianFlow})
     flows = vcat(get_flows(f1), get_flows(f2))
     switches = vcat(get_switching_times(f1), [t_switch], get_switching_times(f2))
+    _check_switching_times_order(switches)
     jumps = vcat(get_jumps(f1), [nothing], get_jumps(f2))
     return MultiPhaseHamiltonianFlow(flows, switches, jumps)
 end
@@ -116,6 +154,7 @@ See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.Mult
 function Base.:*(f1::Flows.AbstractHamiltonianFlow, (t_switch, jump, f2)::Tuple{Real, Any, Flows.AbstractHamiltonianFlow})
     flows = vcat(get_flows(f1), get_flows(f2))
     switches = vcat(get_switching_times(f1), [t_switch], get_switching_times(f2))
+    _check_switching_times_order(switches)
     jumps = vcat(get_jumps(f1), [jump], get_jumps(f2))
     return MultiPhaseHamiltonianFlow(flows, switches, jumps)
 end
@@ -148,6 +187,7 @@ See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.Mult
 function Base.:*(f1::Flows.AbstractHamiltonianFlow, (t_switch, jump_x, jump_p, f2)::Tuple{Real, Any, Any, Flows.AbstractHamiltonianFlow})
     flows = vcat(get_flows(f1), get_flows(f2))
     switches = vcat(get_switching_times(f1), [t_switch], get_switching_times(f2))
+    _check_switching_times_order(switches)
     jumps = vcat(get_jumps(f1), [(jump_x, jump_p)], get_jumps(f2))
     return MultiPhaseHamiltonianFlow(flows, switches, jumps)
 end

--- a/test/suite/multiphase/test_concatenation.jl
+++ b/test/suite/multiphase/test_concatenation.jl
@@ -1,6 +1,7 @@
 module TestConcatenation
 
 import Test
+import CTBase.Exceptions
 import CTFlows.MultiPhase
 import CTFlows.Systems
 import CTFlows.Integrators
@@ -208,26 +209,36 @@ function test_concatenation()
             # 3d. n × m  (new case)
             # ------------------------------------------------------------------
             Test.@testset "n × m — no jump" begin
-                mpf1 = _mpstate(2)   # switches: [1.0], jumps: [nothing]
-                mpf2 = _mpstate(3)   # switches: [1.0, 2.0], jumps: [nothing, nothing]
-                mpf  = mpf1 * (5.0, mpf2)
+                f1 = _state_flow(:s1)
+                f2 = _state_flow(:s2)
+                f3 = _state_flow(:s3)
+                f4 = _state_flow(:s4)
+                f5 = _state_flow(:s5)
+                mpf1 = f1 * (1.0, f2) * (2.0, f3)  # switches: [1.0, 2.0]
+                mpf2 = f4 * (5.0, f5)  # switches: [5.0]
+                mpf  = mpf1 * (3.0, mpf2)  # switches: [1.0, 2.0, 3.0, 5.0]
                 Test.@test mpf isa MultiPhase.MultiPhaseStateFlow
                 Test.@test length(mpf.flows)          == 5
-                Test.@test mpf.switching_times        == [1.0, 5.0, 1.0, 2.0]
+                Test.@test mpf.switching_times        == [1.0, 2.0, 3.0, 5.0]
                 Test.@test all(==(nothing), mpf.jumps)
                 Test.@test length(mpf.jumps)          == 4
             end
 
             Test.@testset "n × m — with jump" begin
-                mpf1 = _mpstate(2)
-                mpf2 = _mpstate(3)
-                mpf  = mpf1 * (5.0, jump, mpf2)
+                f1 = _state_flow(:s1)
+                f2 = _state_flow(:s2)
+                f3 = _state_flow(:s3)
+                f4 = _state_flow(:s4)
+                f5 = _state_flow(:s5)
+                mpf1 = f1 * (1.0, f2) * (2.0, f3)  # switches: [1.0, 2.0], jumps: [nothing, nothing]
+                mpf2 = f4 * (5.0, f5)  # switches: [5.0], jumps: [nothing]
+                mpf  = mpf1 * (3.0, jump, mpf2)  # switches: [1.0, 2.0, 3.0, 5.0], jumps: [nothing, nothing, jump, nothing]
                 Test.@test length(mpf.flows)          == 5
-                Test.@test mpf.switching_times        == [1.0, 5.0, 1.0, 2.0]
-                Test.@test mpf.jumps[1]               == nothing   # from mpf1
-                Test.@test mpf.jumps[2]               === jump     # new junction
-                Test.@test mpf.jumps[3]               == nothing   # from mpf2
-                Test.@test mpf.jumps[4]               == nothing   # from mpf2
+                Test.@test mpf.switching_times        == [1.0, 2.0, 3.0, 5.0]
+                Test.@test mpf.jumps[1]               === nothing   # from mpf1
+                Test.@test mpf.jumps[2]               === nothing   # from mpf1
+                Test.@test mpf.jumps[3]               === jump     # new junction
+                Test.@test mpf.jumps[4]               === nothing   # from mpf2
             end
 
             # ------------------------------------------------------------------
@@ -348,31 +359,46 @@ function test_concatenation()
             # 4d. n × m
             # ------------------------------------------------------------------
             Test.@testset "n × m — no jump" begin
-                mpf1 = _mpham(2)
-                mpf2 = _mpham(3)
-                mpf  = mpf1 * (5.0, mpf2)
+                f1 = _ham_flow(:h1)
+                f2 = _ham_flow(:h2)
+                f3 = _ham_flow(:h3)
+                f4 = _ham_flow(:h4)
+                f5 = _ham_flow(:h5)
+                mpf1 = f1 * (1.0, f2) * (2.0, f3)  # switches: [1.0, 2.0]
+                mpf2 = f4 * (5.0, f5)  # switches: [5.0]
+                mpf  = mpf1 * (3.0, mpf2)  # switches: [1.0, 2.0, 3.0, 5.0]
                 Test.@test mpf isa MultiPhase.MultiPhaseHamiltonianFlow
                 Test.@test length(mpf.flows)          == 5
-                Test.@test mpf.switching_times        == [1.0, 5.0, 1.0, 2.0]
+                Test.@test mpf.switching_times        == [1.0, 2.0, 3.0, 5.0]
                 Test.@test all(==(nothing), mpf.jumps)
             end
 
             Test.@testset "n × m — with jump" begin
-                mpf1 = _mpham(2)
-                mpf2 = _mpham(3)
-                mpf  = mpf1 * (5.0, jump, mpf2)
+                f1 = _ham_flow(:h1)
+                f2 = _ham_flow(:h2)
+                f3 = _ham_flow(:h3)
+                f4 = _ham_flow(:h4)
+                f5 = _ham_flow(:h5)
+                mpf1 = f1 * (1.0, f2) * (2.0, f3)  # switches: [1.0, 2.0], jumps: [nothing, nothing]
+                mpf2 = f4 * (5.0, f5)  # switches: [5.0], jumps: [nothing]
+                mpf  = mpf1 * (3.0, jump, mpf2)  # switches: [1.0, 2.0, 3.0, 5.0], jumps: [nothing, nothing, jump, nothing]
                 Test.@test length(mpf.flows)          == 5
-                Test.@test mpf.jumps[1]               == nothing
-                Test.@test mpf.jumps[2]               === jump
-                Test.@test mpf.jumps[3]               == nothing
-                Test.@test mpf.jumps[4]               == nothing
+                Test.@test mpf.jumps[1]               === nothing
+                Test.@test mpf.jumps[2]               === nothing
+                Test.@test mpf.jumps[3]               === jump
+                Test.@test mpf.jumps[4]               === nothing
             end
 
             Test.@testset "n × m — with (jump_x, jump_p)" begin
-                mpf1 = _mpham(2)
-                mpf2 = _mpham(3)
-                mpf  = mpf1 * (5.0, jump_x, jump_p, mpf2)
-                Test.@test mpf.jumps[2]               == (jump_x, jump_p)
+                f1 = _ham_flow(:h1)
+                f2 = _ham_flow(:h2)
+                f3 = _ham_flow(:h3)
+                f4 = _ham_flow(:h4)
+                f5 = _ham_flow(:h5)
+                mpf1 = f1 * (1.0, f2) * (2.0, f3)  # switches: [1.0, 2.0], jumps: [nothing, nothing]
+                mpf2 = f4 * (5.0, f5)  # switches: [5.0], jumps: [nothing]
+                mpf  = mpf1 * (3.0, jump_x, jump_p, mpf2)  # switches: [1.0, 2.0, 3.0, 5.0], jumps: [nothing, nothing, (jump_x, jump_p), nothing]
+                Test.@test mpf.jumps[3]               == (jump_x, jump_p)
             end
 
             # ------------------------------------------------------------------
@@ -417,20 +443,63 @@ function test_concatenation()
 
             Test.@testset "Mixed single/multi — 5 phases" begin
                 f1   = _state_flow(:s1)
-                mpf2 = _mpstate(2)   # [s1, s2], switches [1.0]
-                mpf3 = _mpstate(2)   # [s1, s2], switches [1.0]
-                # f1 * (0.5, mpf2) * (3.0, mpf3)
-                # = (3-phase, switches [0.5, 1.0]) * (3.0, 2-phase, switches [1.0])
-                # → 5 phases, switches [0.5, 1.0, 3.0, 1.0]
-                mpf = f1 * (0.5, mpf2) * (3.0, mpf3)
+                f2   = _state_flow(:s2)
+                f3   = _state_flow(:s3)
+                f4   = _state_flow(:s4)
+                f5   = _state_flow(:s5)
+                mpf2 = f2 * (2.0, f3)  # switches: [2.0]
+                mpf3 = f4 * (5.0, f5)  # switches: [5.0]
+                mpf = f1 * (1.0, mpf2) * (3.0, mpf3)  # switches: [1.0, 2.0, 3.0, 5.0]
                 Test.@test length(mpf.flows)     == 5
-                Test.@test mpf.switching_times   == [0.5, 1.0, 3.0, 1.0]
+                Test.@test mpf.switching_times   == [1.0, 2.0, 3.0, 5.0]
                 Test.@test length(mpf.jumps)     == 4
             end
         end
 
         # ======================================================================
-        # 6. Exports
+        # 6. Switching times validation
+        # ======================================================================
+        Test.@testset "Switching times validation" begin
+            Test.@testset "Valid switching times — no error" begin
+                f1, f2 = _state_flow(:a), _state_flow(:b)
+                mpf = f1 * (1.0, f2)
+                Test.@test mpf isa MultiPhase.MultiPhaseStateFlow
+            end
+
+            Test.@testset "Invalid switching times — t_switch not greater than f1 times" begin
+                mpf1 = _mpstate(2)   # switches: [1.0]
+                f3   = _state_flow(:s3)
+                Test.@test_throws Exceptions.PreconditionError mpf1 * (0.5, f3)  # 0.5 < 1.0
+            end
+
+            Test.@testset "Invalid switching times — t_switch not less than f2 times" begin
+                f1   = _state_flow(:s0)
+                mpf2 = _mpstate(2)   # switches: [1.0]
+                Test.@test_throws Exceptions.PreconditionError f1 * (2.0, mpf2)  # 2.0 > 1.0
+            end
+
+            Test.@testset "Invalid switching times — HamiltonianFlow" begin
+                mpf1 = _mpham(2)   # switches: [1.0]
+                f3   = _ham_flow(:h3)
+                Test.@test_throws Exceptions.PreconditionError mpf1 * (0.5, f3)
+            end
+
+            Test.@testset "PreconditionError message quality" begin
+                mpf1 = _mpstate(2)   # switches: [1.0]
+                f3   = _state_flow(:s3)
+                try
+                    mpf1 * (0.5, f3)
+                    Test.@test false  # Should have thrown
+                catch e
+                    Test.@test e isa Exceptions.PreconditionError
+                    Test.@test occursin("strictly increasing", e.msg)
+                    Test.@test occursin("flow concatenation", e.context)
+                end
+            end
+        end
+
+        # ======================================================================
+        # 7. Exports
         # ======================================================================
         Test.@testset "Exports" begin
             for sym in (:MultiPhaseStateFlow, :MultiPhaseHamiltonianFlow,


### PR DESCRIPTION
- Add private helper _check_switching_times_order to validate that switching times are strictly increasing
- Call validation in all 5 concatenation functions
- Update existing tests to use strictly increasing switching times
- Add new testset for switching times validation
- Throw PreconditionError with descriptive message when validation fails