### PR TITLE
Add Hamiltonian vector field support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,12 +39,14 @@ Plots = "1"
 RecipesBase = "1"
 Reexport = "1"
 SciMLBase = "3"
+StaticArrays = "1"
 Test = "1"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DiffEqBase", "ForwardDiff", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "Test"]
+test = ["Aqua", "DiffEqBase", "ForwardDiff", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test"]

--- a/ext/CTFlowsPlots.jl
+++ b/ext/CTFlowsPlots.jl
@@ -97,4 +97,95 @@ function Plots.plot!(p::Plots.Plot, sol::Solutions.VectorFieldSolution; kwargs..
     return Plots.plot!(p, ts, states; kwargs...)
 end
 
+# =============================================================================
+# Plots.plot — HamiltonianVectorFieldSolution
+# =============================================================================
+
+"""
+Internal helper to convert a Hamiltonian solution to time, state, and costate arrays.
+
+# Arguments
+- `sol::Solutions.HamiltonianVectorFieldSolution`: The Hamiltonian solution to convert.
+
+# Returns
+- `Tuple{AbstractVector, AbstractMatrix, AbstractMatrix}`: A tuple of (time vector, state matrix, costate matrix).
+
+# Notes
+- Uses `reduce(hcat, ...)'` for robust handling of 1D states.
+- Uses `state(sol)` and `costate(sol)` to explicitly obtain the state and costate functions.
+- Internal function, not part of public API.
+"""
+function _ham_sol_to_arrays(sol::Solutions.HamiltonianVectorFieldSolution)
+    ts = Solutions.times(sol)
+    x = Solutions.state(sol)
+    p = Solutions.costate(sol)
+    states = reduce(hcat, x.(ts))'
+    costates = reduce(hcat, p.(ts))'
+    return ts, states, costates
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Plot a `HamiltonianVectorFieldSolution` by extracting time points, states, and costates.
+
+Uses a `(1, 2)` layout to show state and costate in separate subplots.
+
+# Arguments
+- `sol::Solutions.HamiltonianVectorFieldSolution`: The Hamiltonian solution to plot.
+- `kwargs...`: Additional keyword arguments passed to `Plots.plot`.
+
+# Returns
+- The plot object returned by `Plots.plot`.
+
+See also: [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Solutions.times`](@ref), [`CTFlows.Solutions.state`](@ref), [`CTFlows.Solutions.costate`](@ref).
+"""
+function Plots.plot(sol::Solutions.HamiltonianVectorFieldSolution; kwargs...)
+    ts, states, costates = _ham_sol_to_arrays(sol)
+    return Plots.plot(ts, [states costates]; layout=(1, 2), kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Plot into an existing plot by extracting time points, states, and costates.
+
+Uses a `(1, 2)` layout to show state and costate in separate subplots.
+
+# Arguments
+- `sol::Solutions.HamiltonianVectorFieldSolution`: The Hamiltonian solution to plot.
+- `kwargs...`: Additional keyword arguments passed to `Plots.plot!`.
+
+# Returns
+- The modified plot object returned by `Plots.plot!`.
+
+See also: [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Solutions.times`](@ref), [`CTFlows.Solutions.state`](@ref), [`CTFlows.Solutions.costate`](@ref).
+"""
+function Plots.plot!(sol::Solutions.HamiltonianVectorFieldSolution; kwargs...)
+    ts, states, costates = _ham_sol_to_arrays(sol)
+    return Plots.plot!(ts, [states costates]; layout=(1, 2), kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Plot into an existing plot by extracting time points, states, and costates.
+
+Uses a `(1, 2)` layout to show state and costate in separate subplots.
+
+# Arguments
+- `p::Plots.Plot`: The existing plot to modify.
+- `sol::Solutions.HamiltonianVectorFieldSolution`: The Hamiltonian solution to plot.
+- `kwargs...`: Additional keyword arguments passed to `Plots.plot!`.
+
+# Returns
+- The modified plot object returned by `Plots.plot!`.
+
+See also: [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Solutions.times`](@ref), [`CTFlows.Solutions.state`](@ref), [`CTFlows.Solutions.costate`](@ref).
+"""
+function Plots.plot!(p::Plots.Plot, sol::Solutions.HamiltonianVectorFieldSolution; kwargs...)
+    ts, states, costates = _ham_sol_to_arrays(sol)
+    return Plots.plot!(p, ts, [states costates]; layout=(1, 2), kwargs...)
+end
+
 end # module CTFlowsPlots

--- a/ext/CTFlowsSciML.jl
+++ b/ext/CTFlowsSciML.jl
@@ -543,13 +543,79 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Build solver options for a HamiltonianPointConfig.
+
+Returns the point integration options from the SciML integrator strategy.
+
+# Arguments
+- `integ::SciML`: The SciML integrator strategy.
+- `config::Common.HamiltonianPointConfig`: The Hamiltonian point configuration.
+
+# Returns
+- `Dict{Symbol,Any}`: The resolved solver options for point integration.
+
+See also: [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Common.HamiltonianPointConfig`](@ref).
+"""
+function Integrators.build_options(integ::SciML, config::Common.HamiltonianPointConfig)
+    return integ.options_point
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build solver options for a HamiltonianTrajectoryConfig.
+
+Returns the trajectory integration options from the SciML integrator strategy.
+
+# Arguments
+- `integ::SciML`: The SciML integrator strategy.
+- `config::Common.HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
+
+# Returns
+- `Dict{Symbol,Any}`: The resolved solver options for trajectory integration.
+
+See also: [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref).
+"""
+function Integrators.build_options(integ::SciML, config::Common.HamiltonianTrajectoryConfig)
+    return integ.options_trajectory
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Build an `ODEProblem` from a system and configuration.
+
+Dispatches between in-place and out-of-place RHS based on the mutability of the initial condition:
+- If `ismutable(u0)` is true, uses the in-place `rhs(system)` with signature `(du, u, p, t) -> nothing`.
+- If `ismutable(u0)` is false (e.g., `StaticArrays.SVector`), uses the out-of-place `rhs_oop(system)` with signature `(u, p, t) -> du`.
+
+This allows zero-allocation integration with immutable array types like `StaticArrays.SVector`.
+
+# Arguments
+- `integ::SciML`: The SciML integrator strategy.
+- `system::Systems.AbstractSystem`: The system to build an ODE problem for.
+- `config::Common.AbstractConfig`: The configuration containing initial condition and time span.
+- `variable`: Optional variable parameter for non-fixed systems.
+
+# Returns
+- `SciMLBase.ODEProblem`: The ODE problem ready for integration.
+
+# Notes
+- The variable parameter is wrapped in `Common.ODEParameters` for uniform access.
+- For Hamiltonian systems, the initial condition concatenates `x0` and `p0`.
+
+See also: [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Systems.rhs_oop`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """
 function Integrators.build_problem(integ::SciML, system::Systems.AbstractSystem, config::Common.AbstractConfig; variable)
-    f! = Systems.rhs(system)
     u0 = Common.initial_condition(config)
     p = Common.ODEParameters(variable)
-    prob = ODEProblem(f!, u0, Common.tspan(config), p)
+    if ismutable(u0)
+        f! = Systems.rhs(system)
+        prob = ODEProblem(f!, u0, Common.tspan(config), p)
+    else
+        f = Systems.rhs_oop(system)
+        prob = ODEProblem(f, u0, Common.tspan(config), p)
+    end
     return prob
 end
 

--- a/reports/hamilonian/hamiltonian-vector-field.md
+++ b/reports/hamilonian/hamiltonian-vector-field.md
@@ -1,0 +1,51 @@
+@vector_field.jl#L1-217 Nous avons ici un VectorField. J'aimerais ajouter un HamiltonianVectorField.
+
+Soit Hv, un HamiltonianVectorField. Alors, on a la signature : 
+
+```
+dx, dp = Hv([t ,] x, p[, v])
+```
+
+À partir d'un HamiltonianVectorField, on pourra créer un System :
+
+@abstract_system.jl#L1-239 
+@building.jl#L1-38 
+@vector_field_system.jl#L1-126 
+
+Il faudra sûrement créer un HamiltonianVectorFieldSystem.
+
+A partir d'un HamiltonianVectorFieldSystem, il faudra pouvoir créer un flot hamiltonien, qui en principe existe déjà : 
+
+@abstract_flow.jl#L1-247
+ @flow.jl#L131-134 à comparer avec @flow.jl#L101-104. 
+
+Il faudra aussi pouvoir construire un flot, directement depuis le HamiltonianVectorField, comme on fait de manière analogue @building.jl#L29-34 .
+
+Bien entendu, à partir d'un flot, qu'il soit hamiltonien ou non, on pourra l'appeler : @calling.jl#L1-46. J'espère que c'est suffisamment générique, la fonction call que il n'y aura pas grand chose à changer.
+
+Pour intégrer un flot, nous avons besoin d'un intégrateur : @abstract_integrator.jl#L1-149 @sciml.jl#L1-171. Un intégrateur est une Strategy et doit donc implémenter certaines méthodes en ce sens, ce qu'il fait déjà. Mais c'est donc aussi un intégrateur. Et cela doit être clair, je pense, qu'il y a des fonctions qui peuvent avoir plusieurs méthodes en fonction du fait d'avoir un système hamiltonien ou pas. Cela peut aussi passer par la config, car quand on a un système hamiltonien, on va utiliser une config hamiltonienne @configs.jl#L1-625 . @CTFlowsSciML.jl#L1-592 : je n'ai pas l'impression qu'il y ait de distinction à ce niveau là. @integration_result.jl#L1-93 non plus ici. Peut-être au niveau des solutions, car en effet, une fois intégré le flot, il faut retourner une solution. 
+
+Il faudra gérer la sortie : 
+
+@building.jl#L1-67 
+
+En effet, si on a un flot hamiltonien f, on voudra faire soit
+
+```
+xf, pf = f(t0, x0, p0, tf)
+```
+
+soit 
+
+```
+flow_sol = f((t0, tf), x0, p0)
+```
+
+avec la variable si le flot est variable.
+
+Remarque : on pourra se poser la question de la nécessité d'avoir dans @building.jl#L23-24 @building.jl#L44-45 @building.jl#L64-65 à la fois le système et la config, qui doivent être les deux cohérents, car si on a un système hamiltonien, il faudra une config hamiltonien. Il est à noter que plus tard, nous aurons des flots construits à partir d'un problème de contrôle optimal, le flot hamiltonien et on voudra faire xf, pf = f(t0, x0, p0, tf) mais dans la version f((t0, tf), x0, p0) la solution retournée aura un type particulier : CTModels.Solution. Ce sera en fait une solution d'un problème de contrôle optimal.
+
+Remarque : pour être très cohérent, doit-on appeler les configs PointConfig et TrajectoryConfig : StatePointConfig et StateTrajectoryConfig ?
+
+Pour créer une solution particulière, on aura besoin de créer l'analogue de @vector_field_solution.jl#L1-291 . De manière équivalent, il y aura à gérer l'affichage mais aussi @CTFlowsPlots.jl#L1-101 . On pourra simplement faire un layout (1, 2) pour l'état et le co-état.
+

--- a/src/Data/Data.jl
+++ b/src/Data/Data.jl
@@ -1,10 +1,10 @@
 """
     Data
 
-Data structures for CTFlows including vector fields with traits.
+Data structures for CTFlows including vector fields and Hamiltonian vector fields with traits.
 
-This module defines the `VectorField` type which encapsulates a vector-field
-function together with its time-dependence and variable-dependence traits.
+This module defines the `VectorField` and `HamiltonianVectorField` types which encapsulate
+vector-field functions together with their time-dependence and variable-dependence traits.
 """
 module Data
 
@@ -22,11 +22,13 @@ using ..Common
 # ==============================================================================
 
 include(joinpath(@__DIR__, "vector_field.jl"))
+include(joinpath(@__DIR__, "hamiltonian_vector_field.jl"))
 
 # ==============================================================================
 # Module exports
 # ==============================================================================
 
 export VectorField
+export HamiltonianVectorField
 
 end # module Data

--- a/src/Data/hamiltonian_vector_field.jl
+++ b/src/Data/hamiltonian_vector_field.jl
@@ -1,0 +1,218 @@
+"""
+$(TYPEDEF)
+
+Parametric container for a Hamiltonian vector field function together with its
+time-dependence and variable-dependence traits.
+
+The function returns a tuple `(dx, dp)` representing the derivatives of state `x`
+and costate `p` according to Hamiltonian dynamics.
+
+# Type Parameters
+- `F`: concrete type of the wrapped function.
+- `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
+- `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+
+# Fields
+- `f::F`: the Hamiltonian vector field function.
+
+# Construction
+
+Use the keyword constructor:
+
+```julia
+HamiltonianVectorField(f; autonomous = true, variable = false)        # default: f(x, p)
+HamiltonianVectorField((t, x, p) -> ...; autonomous = false)             # f(t, x, p)
+HamiltonianVectorField((x, p, v) -> ...; variable = true)                # f(x, p, v)
+HamiltonianVectorField((t, x, p, v) -> ...; autonomous = false, variable = true)
+```
+
+# Call Signatures
+
+Every `HamiltonianVectorField` is callable via its **natural** signature (matching the
+traits), and via a **uniform** signature `(t, x, p, v)` that ignores the
+unused arguments.
+
+See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+"""
+struct HamiltonianVectorField{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence}
+    f::F
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Construct a `HamiltonianVectorField` with trait flags.
+
+# Arguments
+- `f::Function`: The Hamiltonian vector field function returning `(dx, dp)`.
+- `is_autonomous::Bool`: If true, system is autonomous (default: `Common.__is_autonomous()`).
+- `is_variable::Bool`: If true, system depends on variable parameters (default: `Common.__is_variable()`).
+
+# Returns
+- `HamiltonianVectorField`: A HamiltonianVectorField with appropriate traits.
+
+# Example
+```julia-repl
+julia> using CTFlows.Systems, CTFlows.Common
+
+julia> hvf = HamiltonianVectorField((x, p) -> (x, -p))  # Uses defaults: is_autonomous=true, is_variable=false
+HamiltonianVectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  function: var"#1"
+
+julia> hvf = HamiltonianVectorField((t, x, p) -> (t .* x, -p); is_autonomous=false)
+HamiltonianVectorField
+  time_dependence: NonAutonomous
+  variable_dependence: Fixed
+  function: var"#2"
+```
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
+"""
+function HamiltonianVectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
+    TD = is_autonomous ? Common.Autonomous : Common.NonAutonomous
+    VD = is_variable ? Common.NonFixed : Common.Fixed
+    return HamiltonianVectorField{typeof(f), TD, VD}(f)
+end
+
+# =============================================================================
+# Natural call signatures - one per trait combination
+# =============================================================================
+
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed})(x, p) = H.f(x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed})(t, x, p) = H.f(t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed})(x, p, v) = H.f(x, p, v)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.NonFixed})(t, x, p, v) = H.f(t, x, p, v)
+
+# =============================================================================
+# Uniform (t, x, p, v) call - used by HamiltonianVectorFieldSystem.rhs
+# Every combination forwards to its natural call, ignoring unused args.
+# (NonAutonomous, NonFixed) is already covered by the natural signature above.
+# =============================================================================
+
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed})(t, x, p, v) = H.f(x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed})(t, x, p, v) = H.f(t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed})(t, x, p, v) = H.f(x, p, v)
+
+# =============================================================================
+# Trait accessors for HamiltonianVectorField
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Indicate that `HamiltonianVectorField` has the time-dependence trait.
+
+This implementation declares that all Hamiltonian vector fields support time-dependence queries.
+Concrete `HamiltonianVectorField` instances have their time dependence encoded in the type parameter `TD`.
+
+See also: [`CTFlows.Common.time_dependence`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref).
+"""
+Common.has_time_dependence_trait(::HamiltonianVectorField) = true
+
+"""
+$(TYPEDSIGNATURES)
+
+Indicate that `HamiltonianVectorField` has the variable-dependence trait.
+
+This implementation declares that all Hamiltonian vector fields support variable-dependence queries.
+Concrete `HamiltonianVectorField` instances have their variable dependence encoded in the type parameter `VD`.
+
+See also: [`CTFlows.Common.variable_dependence`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref).
+"""
+Common.has_variable_dependence_trait(::HamiltonianVectorField) = true
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract the time dependence trait from a HamiltonianVectorField.
+
+# Returns
+- `Type{<:TimeDependence}`: The time dependence trait type (Autonomous or NonAutonomous).
+
+# Example
+```julia
+using CTFlows.Systems
+using CTFlows.Common
+
+hvf_autonomous = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true)
+Common.time_dependence(hvf_autonomous)  # Returns Autonomous
+
+hvf_nonautonomous = HamiltonianVectorField((t, x, p) -> (t .* x, -p); autonomous=false)
+Common.time_dependence(hvf_nonautonomous)  # Returns NonAutonomous
+```
+
+See also: [`CTFlows.Common.has_time_dependence_trait`](@ref), [`CTFlows.Common.is_autonomous`](@ref).
+"""
+function Common.time_dependence(hvf::HamiltonianVectorField{<:Function, TD, <:Common.VariableDependence}) where {TD <: Common.TimeDependence}
+    return TD
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract the variable dependence trait from a HamiltonianVectorField.
+
+# Returns
+- `Type{<:VariableDependence}`: The variable dependence trait type (Fixed or NonFixed).
+
+# Example
+```julia
+using CTFlows.Systems
+using CTFlows.Common
+
+hvf_fixed = HamiltonianVectorField((x, p) -> (x, -p); variable=false)
+Common.variable_dependence(hvf_fixed)  # Returns Fixed
+
+hvf_nonfixed = HamiltonianVectorField((x, p, v) -> (x .* v, -p); variable=true)
+Common.variable_dependence(hvf_nonfixed)  # Returns NonFixed
+```
+
+See also: [`CTFlows.Common.has_variable_dependence_trait`](@ref), [`CTFlows.Common.is_variable`](@ref).
+"""
+function Common.variable_dependence(hvf::HamiltonianVectorField{<:Function, <:Common.TimeDependence, VD}) where {VD <: Common.VariableDependence}
+    return VD
+end
+
+# =============================================================================
+# Base.show
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of a HamiltonianVectorField.
+
+Shows the type name, time dependence, variable dependence, and function type.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `hvf::HamiltonianVectorField`: The HamiltonianVectorField to display.
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref).
+"""
+function Base.show(io::IO, hvf::HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
+    println(io, "HamiltonianVectorField")
+    println(io, "  time_dependence: ", nameof(TD))
+    println(io, "  variable_dependence: ", nameof(VD))
+    print(io, "  function: ", typeof(hvf.f))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a HamiltonianVectorField in the REPL with text/plain MIME type.
+
+Delegates to the compact show method.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `::MIME"text/plain"`: The MIME type for REPL display.
+- `hvf::HamiltonianVectorField`: The HamiltonianVectorField to display.
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref).
+"""
+function Base.show(io::IO, ::MIME"text/plain", hvf::HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
+    show(io, hvf)
+end

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -31,3 +31,69 @@ function Flow(data::Data.VectorField; opts...)
     integrator = Integrators.build_integrator(; opts...)
     return build_flow(system, integrator)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+High-level constructor for `HamiltonianFlow` from Hamiltonian vector field data.
+
+This constructor builds a complete Hamiltonian flow by:
+1. Building a `HamiltonianVectorFieldSystem` from the Hamiltonian vector field data
+2. Building a `SciML` integrator with the given options
+3. Routing options through the integrator's CTSolvers strategy
+4. Combining them into a callable `HamiltonianFlow`
+
+# Arguments
+- `data::CTFlows.Data.HamiltonianVectorField`: The Hamiltonian vector field defining the system dynamics.
+- `opts...`: Keyword options passed to the integrator's strategy.
+
+# Returns
+- `CTFlows.Flows.HamiltonianFlow`: The complete Hamiltonian flow ready for integration.
+
+# Example
+```julia
+using CTFlows.Data, CTFlows.Flows, CTFlows.Common
+
+hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+flow = Flows.Flow(hvf; reltol=1e-8)
+```
+
+See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_system`](@ref), [`CTFlows.Integrators.build_integrator`](@ref).
+"""
+function Flow(data::Data.HamiltonianVectorField; opts...)
+    system = Systems.build_system(data)
+    integrator = Integrators.build_integrator(; opts...)
+    return build_flow(system, integrator)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+High-level constructor for `HamiltonianFlow` from Hamiltonian vector field data with known state dimension.
+
+This constructor builds a complete Hamiltonian flow with a known state dimension for
+type stability and validation. The dimension is stored as a type parameter.
+
+# Arguments
+- `data::CTFlows.Data.HamiltonianVectorField`: The Hamiltonian vector field defining the system dynamics.
+- `n_state::Int`: The state dimension (number of state variables, not including costates).
+- `opts...`: Keyword options passed to the integrator's strategy.
+
+# Returns
+- `CTFlows.Flows.HamiltonianFlow`: The complete Hamiltonian flow ready for integration.
+
+# Example
+```julia
+using CTFlows.Data, CTFlows.Flows, CTFlows.Common
+
+hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+flow = Flows.Flow(hvf, 3; reltol=1e-8)  # with known state dimension
+```
+
+See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_system`](@ref), [`CTFlows.Integrators.build_integrator`](@ref).
+"""
+function Flow(data::Data.HamiltonianVectorField, n_state::Int; opts...)
+    system = Systems.build_system(data, n_state)
+    integrator = Integrators.build_integrator(; opts...)
+    return build_flow(system, integrator)
+end

--- a/src/Solutions/Solutions.jl
+++ b/src/Solutions/Solutions.jl
@@ -36,6 +36,7 @@ using ..Integrators
 # ==============================================================================
 
 include(joinpath(@__DIR__, "vector_field_solution.jl"))
+include(joinpath(@__DIR__, "hamiltonian_vector_field_solution.jl"))
 include(joinpath(@__DIR__, "building.jl"))
 
 # ==============================================================================
@@ -43,7 +44,9 @@ include(joinpath(@__DIR__, "building.jl"))
 # ==============================================================================
 
 export state, time_grid
+export costate
 export VectorFieldSolution
+export HamiltonianVectorFieldSolution
 export build_solution
 export plot
 

--- a/src/Solutions/building.jl
+++ b/src/Solutions/building.jl
@@ -64,3 +64,70 @@ See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Sol
 function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.TrajectoryConfig)
     return VectorFieldSolution(result)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a solution for a scalar HamiltonianPointConfig integration.
+
+Returns the final state and costate as a tuple of scalars `(xf, pf)`, unwrapping the
+length-1 vectors that were introduced by scalar-promotion at ODE problem construction time.
+
+# Arguments
+- `result::Integrators.AbstractIntegrationResult`: The integration result.
+- `sys::Systems.HamiltonianVectorFieldSystem`: The Hamiltonian vector field system.
+- `config::Common.HamiltonianPointConfig{<:Real, <:Number, <:Number, <:Real}`: Scalar Hamiltonian point configuration.
+
+# Returns
+- `Tuple{Number, Number}`: The final state and costate as scalars.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.HamiltonianVectorFieldSystem, config::Common.HamiltonianPointConfig{<:Real, <:Number, <:Number, <:Real})
+    u = Integrators.final_state(result)
+    return (u[1], u[2])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a solution for a vectorial HamiltonianPointConfig integration.
+
+Returns the final state and costate as a tuple of vectors `(xf, pf)`.
+
+# Arguments
+- `result::Integrators.AbstractIntegrationResult`: The integration result.
+- `sys::Systems.HamiltonianVectorFieldSystem`: The Hamiltonian vector field system.
+- `config::Common.HamiltonianPointConfig`: Vectorial Hamiltonian point configuration.
+
+# Returns
+- `Tuple{AbstractVector, AbstractVector}`: The final state and costate vectors.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.HamiltonianVectorFieldSystem, config::Common.HamiltonianPointConfig)
+    u = Integrators.final_state(result)
+    n = length(Common.initial_condition(config))
+    return (u[1:n], u[n+1:2n])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a solution for a HamiltonianTrajectoryConfig integration.
+
+Wraps the integration result in a `HamiltonianVectorFieldSolution` for future extensibility.
+
+# Arguments
+- `result::Integrators.AbstractIntegrationResult`: The integration result.
+- `sys::Systems.HamiltonianVectorFieldSystem`: The Hamiltonian vector field system.
+- `config::Common.HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
+
+# Returns
+- `HamiltonianVectorFieldSolution`: The wrapped integration result.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref).
+"""
+function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.HamiltonianVectorFieldSystem, config::Common.HamiltonianTrajectoryConfig)
+    return HamiltonianVectorFieldSolution(result)
+end

--- a/src/Solutions/hamiltonian_vector_field_solution.jl
+++ b/src/Solutions/hamiltonian_vector_field_solution.jl
@@ -1,0 +1,306 @@
+"""
+$(TYPEDEF)
+
+Abstract supertype for Hamiltonian vector field solution containers.
+
+This type defines the interface for all solution types that wrap ODE integration
+results for Hamiltonian systems.
+
+See also: [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Integrators.AbstractIntegrationResult`](@ref).
+"""
+abstract type AbstractHamiltonianVectorFieldSolution end
+
+"""
+$(TYPEDEF)
+
+Container for the integration result from a HamiltonianTrajectoryConfig integration.
+
+This type wraps the integration result returned by integrators and provides
+semantic accessors for time grids, state functions, and costate functions.
+
+# Fields
+- `result`: The integration result object (subtype of `AbstractIntegrationResult`).
+
+# Accessors
+- `times(sol)`: Get the time grid (alias: `time_grid(sol)`)
+- `state(sol)`: Get the solution as a callable state function `x(t)`
+- `costate(sol)`: Get the solution as a callable costate function `p(t)`
+- `sol(t)`: Evaluate the solution at time `t`, returning tuple `(x(t), p(t))`
+
+# Example
+```julia
+using CTFlows.Solutions
+
+sol = HamiltonianVectorFieldSolution(result)
+ts = times(sol)           # or time_grid(sol)
+x = state(sol)            # callable state function x(t)
+p = costate(sol)          # callable costate function p(t)
+x(0.5), p(0.5)           # evaluate at t = 0.5
+x0, p0 = sol(0.0)        # returns tuple (x(0), p(0))
+```
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.AbstractHamiltonianVectorFieldSolution`](@ref).
+"""
+struct HamiltonianVectorFieldSolution{R<:Integrators.AbstractIntegrationResult} <: AbstractHamiltonianVectorFieldSolution
+    result::R
+end
+
+# =============================================================================
+# Semantic Accessors and Delegation
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the vector of time points from the solution.
+
+Delegates to `Integrators.times(sol.result)`.
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+
+# Returns
+- `AbstractVector`: The vector of time points.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Integrators.evaluate_at`](@ref).
+"""
+function Integrators.times(sol::HamiltonianVectorFieldSolution)
+    return Integrators.times(sol.result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Alias for `times(sol)` — returns the time grid from the solution.
+
+This is an alternative, more explicit name for `times` in numerical contexts
+where "time grid" is the standard terminology.
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+
+# Returns
+- `AbstractVector`: The vector of time points.
+
+See also: [`CTFlows.Solutions.times`](@ref), [`CTFlows.Solutions.state`](@ref).
+"""
+function time_grid(sol::HamiltonianVectorFieldSolution)
+    return times(sol)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate the solution at a given time, returning a tuple `(x(t), p(t))`.
+
+Splits the combined state vector into state and costate halves.
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+- `t::Real`: The time at which to evaluate the solution.
+
+# Returns
+- `Tuple{AbstractVector, AbstractVector}`: The state `x(t)` and costate `p(t)` at time `t`.
+
+See also: [`CTFlows.Solutions.evaluate_at`](@ref), [`CTFlows.Solutions.times`](@ref).
+"""
+function (sol::HamiltonianVectorFieldSolution)(t::Real)
+    u = Integrators.evaluate_at(sol.result, t)
+    n = length(u) ÷ 2
+    return (u[1:n], u[n+1:2n])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the solution as a state function of time `x(t)`.
+
+This is a semantic accessor that returns a function which, when called with a time,
+returns only the state component `x(t)` (not the costate).
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+
+# Returns
+- `Function`: A function `t -> x(t)` that returns the state at time `t`.
+
+# Example
+```julia
+using CTFlows.Solutions
+
+sol = HamiltonianVectorFieldSolution(result)
+x = state(sol)    # x is a function of time
+x(0.0)            # initial state
+x(0.5)            # interpolated state at t = 0.5
+```
+
+See also: [`CTFlows.Solutions.costate`](@ref), [`CTFlows.Solutions.times`](@ref).
+"""
+function state(sol::HamiltonianVectorFieldSolution)
+    return t -> sol(t)[1]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the solution as a costate function of time `p(t)`.
+
+This is a semantic accessor that returns a function which, when called with a time,
+returns only the costate component `p(t)` (not the state).
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+
+# Returns
+- `Function`: A function `t -> p(t)` that returns the costate at time `t`.
+
+# Example
+```julia
+using CTFlows.Solutions
+
+sol = HamiltonianVectorFieldSolution(result)
+p = costate(sol)  # p is a function of time
+p(0.0)            # initial costate
+p(0.5)            # interpolated costate at t = 0.5
+```
+
+See also: [`CTFlows.Solutions.state`](@ref), [`CTFlows.Solutions.times`](@ref).
+"""
+function costate(sol::HamiltonianVectorFieldSolution)
+    return t -> sol(t)[2]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the final state and costate from the solution as a tuple `(xf, pf)`.
+
+Splits the combined state vector into state and costate halves.
+
+# Arguments
+- `sol::HamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+
+# Returns
+- `Tuple{AbstractVector, AbstractVector}`: The final state `xf` and final costate `pf`.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.final_state`](@ref).
+"""
+function Integrators.final_state(sol::HamiltonianVectorFieldSolution)
+    u = Integrators.final_state(sol.result)
+    n = length(u) ÷ 2
+    return (u[1:n], u[n+1:2n])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Merge a sequence of HamiltonianVectorFieldSolution objects into a single HamiltonianVectorFieldSolution.
+
+This extracts the internal integration results, merges them, and wraps the result
+in a new HamiltonianVectorFieldSolution.
+
+# Arguments
+- `segments::AbstractVector{<:HamiltonianVectorFieldSolution}`: Sequence of Hamiltonian vector field solutions to merge.
+
+# Returns
+- `HamiltonianVectorFieldSolution`: A merged Hamiltonian vector field solution containing the merged integration result.
+
+See also: [`CTFlows.Integrators.merge`](@ref), [`CTFlows.Integrators.AbstractIntegrationResult`](@ref).
+"""
+function Integrators.merge(segments::AbstractVector{<:HamiltonianVectorFieldSolution})
+    if isempty(segments)
+        throw(Exceptions.IncorrectArgument(
+            "Cannot merge empty sequence of HamiltonianVectorFieldSolution";
+            got = "0 segments",
+            expected = "at least 1 segment",
+            context = "HamiltonianVectorFieldSolution merge",
+        ))
+    end
+    
+    internal_results = [sol.result for sol in segments]
+    merged_result = Integrators.merge(internal_results)
+    return HamiltonianVectorFieldSolution(merged_result)
+end
+
+# =============================================================================
+# Stub methods — to be extended by CTFlowsPlots
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Plot stub — throws error if Plots extension not loaded.
+
+# Arguments
+- `sol::AbstractHamiltonianVectorFieldSolution`: The Hamiltonian vector field solution.
+- `kwargs...`: Additional plotting keyword arguments (ignored).
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: If Plots extension is not loaded.
+
+See also: [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Solutions.AbstractHamiltonianVectorFieldSolution`](@ref).
+"""
+function RecipesBase.plot(sol::AbstractHamiltonianVectorFieldSolution; kwargs...)
+    throw(
+        Exceptions.ExtensionError(
+            "Plots extension not loaded";
+            suggestion = "Load Plots.jl with: using Plots",
+            context = "RecipesBase.plot - extension availability check",
+        ),
+    )
+end
+
+# =============================================================================
+# Base.show
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the `HamiltonianVectorFieldSolution` in a readable text/plain format.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `::MIME"text/plain"`: The MIME type.
+- `sol::HamiltonianVectorFieldSolution`: The solution to display.
+"""
+function Base.show(io::IO, ::MIME"text/plain", sol::HamiltonianVectorFieldSolution)
+    print(io, "HamiltonianVectorFieldSolution")
+    print(io, "\n  result: ", nameof(typeof(sol.result)))
+    
+    try
+        ts = times(sol)
+        if !isempty(ts)
+            print(io, "\n  time span: (", first(ts), ", ", last(ts), ")")
+            print(io, "\n  time points: ", length(ts))
+        end
+    catch
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the `HamiltonianVectorFieldSolution` in a compact one-line format.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `sol::HamiltonianVectorFieldSolution`: The solution to display.
+"""
+function Base.show(io::IO, sol::HamiltonianVectorFieldSolution)
+    print(io, "HamiltonianVectorFieldSolution(")
+    parts = String[]
+    push!(parts, "result=$(nameof(typeof(sol.result)))")
+    
+    try
+        ts = times(sol)
+        if !isempty(ts)
+            push!(parts, "tspan=($(first(ts)), $(last(ts)))")
+            push!(parts, "n=$(length(ts))")
+        end
+    catch
+    end
+    
+    print(io, join(parts, ", "))
+    print(io, ")")
+end

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -25,7 +25,8 @@ using ..Data
 # ==============================================================================
 
 include(joinpath(@__DIR__, "abstract_system.jl"))
-include(joinpath(@__DIR__, "vector_field_system.jl"))   
+include(joinpath(@__DIR__, "vector_field_system.jl"))
+include(joinpath(@__DIR__, "hamiltonian_vector_field_system.jl"))
 include(joinpath(@__DIR__, "building.jl"))
 
 # ==============================================================================
@@ -34,7 +35,10 @@ include(joinpath(@__DIR__, "building.jl"))
 
 export AbstractSystem, AbstractStateSystem, AbstractHamiltonianSystem
 export rhs
+export rhs_oop
+export state_dimension
 export VectorFieldSystem
+export HamiltonianVectorFieldSystem
 export build_system
 
 end # module Systems

--- a/src/Systems/abstract_system.jl
+++ b/src/Systems/abstract_system.jl
@@ -236,3 +236,56 @@ function rhs(system::AbstractSystem)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return the out-of-place right-hand side function for the system.
+
+The returned function must have the signature `(u, p, t) -> du` and
+return the derivative at state `u`, parameters `p`, and time `t` without modifying `u`.
+
+This is used for immutable array types like `StaticArrays.SVector` where in-place
+operations are not possible.
+
+# Example
+
+```julia
+using CTFlows.Systems
+
+struct MySystem <: Systems.AbstractSystem{Common.Autonomous, Common.Fixed}
+    data::Vector{Float64}
+end
+
+# Implement rhs_oop to return the ODE right-hand side function (out-of-place)
+function Systems.rhs_oop(sys::MySystem)
+    return (u, p, t) -> sys.data .* u
+end
+
+# Usage
+sys = MySystem([1.0, 2.0])
+rhs_oop_func = Systems.rhs_oop(sys)
+u = [3.0, 4.0]
+p = nothing
+t = 0.0
+du = rhs_oop_func(u, p, t)  # du = [3.0, 8.0]
+```
+
+# Throws
+- [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
+
+# Notes
+- This method is called when `ismutable(u0)` returns `false` for the initial condition.
+- For mutable arrays like `Vector`, the in-place `rhs` method is used instead.
+
+See also: [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Systems.AbstractSystem`](@ref).
+"""
+function rhs_oop(system::AbstractSystem)
+    throw(
+        Exceptions.NotImplemented(
+            "AbstractSystem rhs_oop method not implemented";
+            required_method = "rhs_oop(sys::$(typeof(system)))",
+            suggestion = "Implement rhs_oop for your system type to support immutable array initial conditions.",
+            context = "AbstractSystem.rhs_oop - required method implementation",
+        ),
+    )
+end

--- a/src/Systems/building.jl
+++ b/src/Systems/building.jl
@@ -35,3 +35,82 @@ See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Systems.VectorFieldSyste
 function build_system(vf::Data.VectorField)
     return VectorFieldSystem(vf)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `HamiltonianVectorFieldSystem` from a `HamiltonianVectorField` without known state dimension.
+
+Constructs a concrete Hamiltonian system that wraps the Hamiltonian vector field with
+a pre-computed right-hand side function for integration. The state dimension is not
+specified and will be inferred at runtime.
+
+# Arguments
+- `hvf::Data.HamiltonianVectorField`: The Hamiltonian vector field to wrap into a system.
+
+# Returns
+- `HamiltonianVectorFieldSystem`: A concrete Hamiltonian system with unknown dimension.
+
+# Example
+```julia-repl
+julia> using CTFlows.Systems, CTFlows.Common
+
+julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+HamiltonianVectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  function: var"#1"
+
+julia> sys = build_system(hvf)
+HamiltonianVectorFieldSystem
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  n_state: unknown
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+```
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
+function build_system(hvf::Data.HamiltonianVectorField)
+    return HamiltonianVectorFieldSystem(hvf)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `HamiltonianVectorFieldSystem` from a `HamiltonianVectorField` with known state dimension.
+
+Constructs a concrete Hamiltonian system that wraps the Hamiltonian vector field with
+a pre-computed right-hand side function for integration. The state dimension `n_state`
+is stored as a type parameter for compile-time validation and performance.
+
+# Arguments
+- `hvf::Data.HamiltonianVectorField`: The Hamiltonian vector field to wrap into a system.
+- `n_state::Int`: The state dimension (number of state variables, not including costates).
+
+# Returns
+- `HamiltonianVectorFieldSystem`: A concrete Hamiltonian system with known dimension.
+
+# Example
+```julia-repl
+julia> using CTFlows.Systems, CTFlows.Common
+
+julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+HamiltonianVectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  function: var"#1"
+
+julia> sys = build_system(hvf, 3)
+HamiltonianVectorFieldSystem
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  n_state: 3
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+```
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
+function build_system(hvf::Data.HamiltonianVectorField, n_state::Int)
+    return HamiltonianVectorFieldSystem(hvf, n_state)
+end

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -1,0 +1,279 @@
+"""
+$(TYPEDEF)
+
+Concrete `AbstractHamiltonianSystem` wrapping a `HamiltonianVectorField`. The state
+dimension `N` is stored as a type parameter for compile-time validation and
+performance. If `N=nothing`, the dimension is inferred at runtime.
+
+# Type Parameters
+- `N`: State dimension (`Int` if known, `nothing` if unknown).
+- `F`: concrete type of the wrapped HamiltonianVectorField function.
+- `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
+- `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+- `RHS`: type of the pre-computed right-hand side function.
+
+# Fields
+- `hvf::HamiltonianVectorField{F, TD, VD}`: the underlying Hamiltonian vector field.
+- `rhs::RHS`: the pre-computed in-place right-hand side closure with signature `(du, u, p, t) -> nothing`.
+
+# Example
+```julia-repl
+julia> using CTFlows.Systems, CTFlows.Common
+
+julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+HamiltonianVectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  function: var"#1"
+
+julia> sys = HamiltonianVectorFieldSystem(hvf, 3)  # with known dimension
+HamiltonianVectorFieldSystem
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  n_state: 3
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+
+julia> sys = HamiltonianVectorFieldSystem(hvf)  # without dimension
+HamiltonianVectorFieldSystem
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  n_state: unknown
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+```
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.AbstractHamiltonianSystem`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+"""
+struct HamiltonianVectorFieldSystem{N, F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, RHS<:Function} <: AbstractHamiltonianSystem{TD, VD}
+    hvf::Data.HamiltonianVectorField{F, TD, VD}
+    rhs::RHS
+end
+
+# =============================================================================
+# Constructors
+# =============================================================================
+
+# Constructor with known dimension N
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD}, n_state::Int) where {F, TD, VD}
+    rhs = _build_rhs(hvf, Val(n_state))
+    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, typeof(rhs)}(hvf, rhs)
+end
+
+# Constructor without dimension (N=nothing)
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
+    rhs = _build_rhs(hvf, Val(nothing))
+    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, typeof(rhs)}(hvf, rhs)
+end
+
+# =============================================================================
+# Internal helpers for building RHS (in-place)
+# =============================================================================
+
+function _build_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
+    return function (du, u, p, t)
+        x = @view(u[1:N])
+        pk = @view(u[N+1:2N])
+        dx, dp = hvf(t, x, pk, p.variable)
+        du[1:N] .= dx
+        du[N+1:2N] .= dp
+        return nothing
+    end
+end
+
+function _build_rhs(hvf::Data.HamiltonianVectorField, ::Val{nothing})
+    return function (du, u, p, t)
+        n = length(u) ÷ 2
+        x = @view(u[1:n])
+        pk = @view(u[n+1:2n])
+        dx, dp = hvf(t, x, pk, p.variable)
+        du[1:n] .= dx
+        du[n+1:2n] .= dp
+        return nothing
+    end
+end
+
+# =============================================================================
+# Internal helpers for building RHS (out-of-place for SVector)
+# =============================================================================
+
+function _build_oop_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
+    return function (u, p, t)
+        x = u[1:N]
+        pk = u[N+1:2N]
+        dx, dp = hvf(t, x, pk, p.variable)
+        return vcat(dx, dp)
+    end
+end
+
+function _build_oop_rhs(hvf::Data.HamiltonianVectorField, ::Val{nothing})
+    return function (u, p, t)
+        n = length(u) ÷ 2
+        x = u[1:n]
+        pk = u[n+1:2n]
+        dx, dp = hvf(t, x, pk, p.variable)
+        return vcat(dx, dp)
+    end
+end
+
+# =============================================================================
+# rhs accessor (in-place)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place right-hand side for a `HamiltonianVectorFieldSystem`. Returns the pre-computed
+closure stored in the system, which has signature `(du, u, p, t) -> nothing` and
+splits the combined state `u` into `(x, p)` halves, calls the underlying Hamiltonian
+vector field, and concatenates `(dx, dp)` into `du`.
+
+# Arguments
+- `sys::HamiltonianVectorFieldSystem`: The system for which to return the RHS function.
+
+# Returns
+- `Function`: The pre-computed closure with signature `(du, u, p, t) -> nothing`.
+
+# Notes
+- The RHS splits `u` into state `x` and costate `p` halves: `x = u[1:N]`, `p = u[N+1:2N]`.
+- If `N=nothing`, the split uses `n = length(u) ÷ 2` at runtime.
+- The closure is computed once at construction time for performance.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTFlows.Systems.rhs_oop`](@ref).
+"""
+function rhs(sys::HamiltonianVectorFieldSystem)
+    return sys.rhs
+end
+
+# =============================================================================
+# rhs_oop accessor (out-of-place for SVector)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place right-hand side for a `HamiltonianVectorFieldSystem`. Returns a closure
+with signature `(u, p, t) -> du` that splits the combined state `u` into `(x, p)` halves,
+calls the underlying Hamiltonian vector field, and concatenates `(dx, dp)`.
+
+# Arguments
+- `sys::HamiltonianVectorFieldSystem`: The system for which to return the RHS function.
+
+# Returns
+- `Function`: The closure with signature `(u, p, t) -> du`.
+
+# Notes
+- This method is used for immutable array types like `StaticArrays.SVector`.
+- The RHS splits `u` into state `x` and costate `p` halves: `x = u[1:N]`, `p = u[N+1:2N]`.
+- If `N=nothing`, the split uses `n = length(u) ÷ 2` at runtime.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref).
+"""
+function rhs_oop(sys::HamiltonianVectorFieldSystem{N, F, TD, VD, RHS}) where {N, F, TD, VD, RHS}
+    return _build_oop_rhs(sys.hvf, Val(N))
+end
+
+# =============================================================================
+# state_dimension accessor
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the state dimension `N` for a `HamiltonianVectorFieldSystem`.
+
+If the system was constructed with a known dimension, returns `N::Int`.
+If the dimension was not specified at construction time, returns `nothing`.
+
+# Arguments
+- `sys::HamiltonianVectorFieldSystem`: The Hamiltonian system.
+
+# Returns
+- `Union{Int, Nothing}`: The state dimension, or `nothing` if unknown.
+
+# Example
+```julia
+using CTFlows.Systems
+
+hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
+sys_with_n = HamiltonianVectorFieldSystem(hvf, 3)
+state_dimension(sys_with_n)  # Returns 3
+
+sys_without_n = HamiltonianVectorFieldSystem(hvf)
+state_dimension(sys_without_n)  # Returns nothing
+```
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
+function state_dimension(sys::HamiltonianVectorFieldSystem{N}) where N
+    return N
+end
+
+# =============================================================================
+# Validation helper
+# =============================================================================
+
+function _check_state_dimension(sys::HamiltonianVectorFieldSystem{N}, x0) where N
+    if N !== nothing && length(x0) != N
+        throw(
+            Exceptions.IncorrectArgument(
+                "State dimension mismatch";
+                got = "length(x0)=$(length(x0))",
+                expected = "length(x0)=$N",
+                context = "HamiltonianVectorFieldSystem._check_state_dimension",
+            ),
+        )
+    end
+    return true
+end
+
+function _check_state_dimension(sys::HamiltonianVectorFieldSystem{nothing}, x0)
+    # No dimension specified, skip validation
+    return true
+end
+
+# =============================================================================
+# Base.show
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of a HamiltonianVectorFieldSystem.
+
+Shows the type name, time dependence, variable dependence, state dimension, and
+the underlying Hamiltonian vector field type.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `sys::HamiltonianVectorFieldSystem`: The HamiltonianVectorFieldSystem to display.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
+function Base.show(io::IO, sys::HamiltonianVectorFieldSystem{N, F, TD, VD, RHS}) where {N, F, TD, VD, RHS}
+    println(io, "HamiltonianVectorFieldSystem")
+    println(io, "  time_dependence: ", nameof(TD))
+    println(io, "  variable_dependence: ", nameof(VD))
+    if N === nothing
+        println(io, "  n_state: unknown")
+    else
+        println(io, "  n_state: ", N)
+    end
+    print(io, "  hamiltonian_vector_field: ", typeof(sys.hvf))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a HamiltonianVectorFieldSystem in the REPL with text/plain MIME type.
+
+Delegates to the compact show method.
+
+# Arguments
+- `io::IO`: The IO stream to write to.
+- `::MIME"text/plain"`: The MIME type for REPL display.
+- `sys::HamiltonianVectorFieldSystem`: The HamiltonianVectorFieldSystem to display.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
+function Base.show(io::IO, ::MIME"text/plain", sys::HamiltonianVectorFieldSystem{N, F, TD, VD, RHS}) where {N, F, TD, VD, RHS}
+    show(io, sys)
+end

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -83,6 +83,44 @@ function rhs(sys::VectorFieldSystem)
     return sys.rhs
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place right-hand side for a `VectorFieldSystem`. Returns a closure
+with signature `(u, p, t) -> du` that uses the uniform `(t, x, v)` call on the
+underlying `VectorField`, where `p` is a `Common.ODEParameters` wrapper
+containing the variable (or `nothing` for `Fixed` systems).
+
+# Arguments
+- `sys::VectorFieldSystem`: The system for which to return the RHS function.
+
+# Returns
+- `Function`: The closure with signature `(u, p, t) -> du`.
+
+# Example
+```julia
+using CTFlows.Systems, CTFlows.Common
+
+vf = VectorField(x -> -x; autonomous=true, variable=false)
+sys = VectorFieldSystem(vf)
+rhs_oop = Systems.rhs_oop(sys)
+
+u = [1.0, 2.0]
+p = Common.ODEParameters(nothing)
+du = rhs_oop(u, p, 0.0)
+# du is [-1.0, -2.0]
+```
+
+# Notes
+- This method is used for immutable array types like `StaticArrays.SVector`.
+- The closure uses the uniform `(t, x, v)` signature to work with all trait combinations.
+
+See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
+"""
+function rhs_oop(sys::VectorFieldSystem)
+    return (u, p, t) -> sys.vf(t, u, p.variable)
+end
+
 # =============================================================================
 # Base.show
 # =============================================================================

--- a/test/suite/data/test_hamiltonian_vector_field.jl
+++ b/test/suite/data/test_hamiltonian_vector_field.jl
@@ -1,0 +1,122 @@
+module TestHamiltonianVectorField
+
+import Test
+import CTFlows.Data: Data
+import CTFlows.Common: Common
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+function test_hamiltonian_vector_field()
+    Test.@testset "Hamiltonian Vector Field Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+        
+        # ====================================================================
+        # UNIT TESTS - Construction
+        # ====================================================================
+        
+        Test.@testset "Construction" begin
+            # Autonomous, Fixed
+            hvf_autonomous_fixed = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            Test.@test hvf_autonomous_fixed isa Data.HamiltonianVectorField
+            Test.@test Common.time_dependence(hvf_autonomous_fixed) == Common.Autonomous
+            Test.@test Common.variable_dependence(hvf_autonomous_fixed) == Common.Fixed
+            
+            # NonAutonomous, Fixed
+            hvf_nonautonomous_fixed = Data.HamiltonianVectorField((t, x, p) -> (x, -p); is_autonomous=false, is_variable=false)
+            Test.@test hvf_nonautonomous_fixed isa Data.HamiltonianVectorField
+            Test.@test Common.time_dependence(hvf_nonautonomous_fixed) == Common.NonAutonomous
+            Test.@test Common.variable_dependence(hvf_nonautonomous_fixed) == Common.Fixed
+            
+            # Autonomous, NonFixed
+            hvf_autonomous_nonfixed = Data.HamiltonianVectorField((x, p, v) -> (x .* v, -p); is_autonomous=true, is_variable=true)
+            Test.@test hvf_autonomous_nonfixed isa Data.HamiltonianVectorField
+            Test.@test Common.time_dependence(hvf_autonomous_nonfixed) == Common.Autonomous
+            Test.@test Common.variable_dependence(hvf_autonomous_nonfixed) == Common.NonFixed
+            
+            # NonAutonomous, NonFixed
+            hvf_nonautonomous_nonfixed = Data.HamiltonianVectorField((t, x, p, v) -> (x .* v, -p); is_autonomous=false, is_variable=true)
+            Test.@test hvf_nonautonomous_nonfixed isa Data.HamiltonianVectorField
+            Test.@test Common.time_dependence(hvf_nonautonomous_nonfixed) == Common.NonAutonomous
+            Test.@test Common.variable_dependence(hvf_nonautonomous_nonfixed) == Common.NonFixed
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Natural signatures
+        # ====================================================================
+        
+        Test.@testset "Natural Signatures" begin
+            # (x, p) for Autonomous, Fixed
+            hvf1 = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            dx, dp = hvf1([1.0, 2.0], [3.0, 4.0])
+            Test.@test dx == [1.0, 2.0]
+            Test.@test dp == [-3.0, -4.0]
+            
+            # (t, x, p) for NonAutonomous, Fixed
+            hvf2 = Data.HamiltonianVectorField((t, x, p) -> (t .* x, -p); is_autonomous=false, is_variable=false)
+            dx, dp = hvf2(2.0, [1.0, 2.0], [3.0, 4.0])
+            Test.@test dx == [2.0, 4.0]
+            Test.@test dp == [-3.0, -4.0]
+            
+            # (x, p, v) for Autonomous, NonFixed
+            hvf3 = Data.HamiltonianVectorField((x, p, v) -> (x .* v, -p); is_autonomous=true, is_variable=true)
+            dx, dp = hvf3([1.0, 2.0], [3.0, 4.0], 2.0)
+            Test.@test dx == [2.0, 4.0]
+            Test.@test dp == [-3.0, -4.0]
+            
+            # (t, x, p, v) for NonAutonomous, NonFixed
+            hvf4 = Data.HamiltonianVectorField((t, x, p, v) -> (t .* x .* v, -p); is_autonomous=false, is_variable=true)
+            dx, dp = hvf4(2.0, [1.0, 2.0], [3.0, 4.0], 2.0)
+            Test.@test dx == [4.0, 8.0]
+            Test.@test dp == [-3.0, -4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Uniform signature
+        # ====================================================================
+        
+        Test.@testset "Uniform Signature" begin
+            # All combinations should work with (t, x, p, v)
+            hvf_autonomous_fixed = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            dx, dp = hvf_autonomous_fixed(0.0, [1.0, 2.0], [3.0, 4.0], nothing)
+            Test.@test dx == [1.0, 2.0]
+            Test.@test dp == [-3.0, -4.0]
+            
+            hvf_nonautonomous_fixed = Data.HamiltonianVectorField((t, x, p) -> (t .* x, -p); is_autonomous=false, is_variable=false)
+            dx, dp = hvf_nonautonomous_fixed(2.0, [1.0, 2.0], [3.0, 4.0], nothing)
+            Test.@test dx == [2.0, 4.0]
+            Test.@test dp == [-3.0, -4.0]
+            
+            hvf_autonomous_nonfixed = Data.HamiltonianVectorField((x, p, v) -> (x .* v, -p); is_autonomous=true, is_variable=true)
+            dx, dp = hvf_autonomous_nonfixed(0.0, [1.0, 2.0], [3.0, 4.0], 2.0)
+            Test.@test dx == [2.0, 4.0]
+            Test.@test dp == [-3.0, -4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Trait accessors
+        # ====================================================================
+        
+        Test.@testset "Trait Accessors" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            Test.@test Common.has_time_dependence_trait(hvf) == true
+            Test.@test Common.has_variable_dependence_trait(hvf) == true
+            Test.@test Common.time_dependence(hvf) == Common.Autonomous
+            Test.@test Common.variable_dependence(hvf) == Common.Fixed
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Base.show
+        # ====================================================================
+        
+        Test.@testset "Base.show" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            # Just check that show doesn't throw
+            Test.@test_nowarn sprint(show, hvf)
+        end
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_hamiltonian_vector_field() = TestHamiltonianVectorField.test_hamiltonian_vector_field()

--- a/test/suite/solutions/test_hamiltonian_vector_field_solution.jl
+++ b/test/suite/solutions/test_hamiltonian_vector_field_solution.jl
@@ -1,0 +1,112 @@
+module TestHamiltonianVectorFieldSolution
+
+import Test
+import CTFlows.Integrators: Integrators
+import CTFlows.Solutions: Solutions
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# =============================================================================
+# Fake integration result for testing
+# =============================================================================
+
+struct FakeHamiltonianResult <: Integrators.AbstractIntegrationResult
+    final_u::Vector{Float64}
+    ts::Vector{Float64}
+    us::Vector{Vector{Float64}}
+end
+
+Integrators.final_state(r::FakeHamiltonianResult) = r.final_u
+Integrators.times(r::FakeHamiltonianResult) = r.ts
+function Integrators.evaluate_at(r::FakeHamiltonianResult, t::Real)
+    idx = findfirst(≥(t), r.ts)
+    if isnothing(idx)
+        idx = length(r.ts)
+    end
+    return r.us[idx]
+end
+
+function test_hamiltonian_vector_field_solution()
+    Test.@testset "Hamiltonian Vector Field Solution Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+        
+        # ====================================================================
+        # UNIT TESTS - Construction
+        # ====================================================================
+        
+        Test.@testset "Construction" begin
+            result = FakeHamiltonianResult([1.0, 2.0, 3.0, 4.0], [0.0, 0.5, 1.0], [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]])
+            sol = Solutions.HamiltonianVectorFieldSolution(result)
+            Test.@test sol isa Solutions.HamiltonianVectorFieldSolution
+            Test.@test sol isa Solutions.AbstractHamiltonianVectorFieldSolution
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - sol(t) returns tuple
+        # ====================================================================
+        
+        Test.@testset "sol(t) returns tuple" begin
+            result = FakeHamiltonianResult([1.0, 2.0, 3.0, 4.0], [0.0, 0.5, 1.0], [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]])
+            sol = Solutions.HamiltonianVectorFieldSolution(result)
+            
+            x, p = sol(0.0)
+            Test.@test x == [1.0, 2.0]
+            Test.@test p == [3.0, 4.0]
+            
+            x, p = sol(0.5)
+            Test.@test x == [1.5, 2.5]
+            Test.@test p == [3.5, 4.5]
+            
+            x, p = sol(1.0)
+            Test.@test x == [2.0, 3.0]
+            Test.@test p == [4.0, 5.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - state and costate accessors
+        # ====================================================================
+        
+        Test.@testset "state and costate accessors" begin
+            result = FakeHamiltonianResult([1.0, 2.0, 3.0, 4.0], [0.0, 0.5, 1.0], [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]])
+            sol = Solutions.HamiltonianVectorFieldSolution(result)
+            
+            x_func = Solutions.state(sol)
+            Test.@test x_func isa Function
+            Test.@test x_func(0.0) == [1.0, 2.0]
+            
+            p_func = Solutions.costate(sol)
+            Test.@test p_func isa Function
+            Test.@test p_func(0.0) == [3.0, 4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - final_state
+        # ====================================================================
+        
+        Test.@testset "final_state" begin
+            result = FakeHamiltonianResult([1.0, 2.0, 3.0, 4.0], [0.0, 0.5, 1.0], [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]])
+            sol = Solutions.HamiltonianVectorFieldSolution(result)
+            
+            x, p = Integrators.final_state(sol)
+            Test.@test x == [1.0, 2.0]
+            Test.@test p == [3.0, 4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - time_grid
+        # ====================================================================
+        
+        Test.@testset "time_grid" begin
+            result = FakeHamiltonianResult([1.0, 2.0, 3.0, 4.0], [0.0, 0.5, 1.0], [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]])
+            sol = Solutions.HamiltonianVectorFieldSolution(result)
+            
+            tg = Solutions.time_grid(sol)
+            Test.@test tg == [0.0, 0.5, 1.0]
+        end
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_hamiltonian_vector_field_solution() = TestHamiltonianVectorFieldSolution.test_hamiltonian_vector_field_solution()

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -1,0 +1,196 @@
+module TestHamiltonianVectorFieldSystem
+
+import Test
+import CTBase.Exceptions
+import CTFlows.Data: Data
+import CTFlows.Common: Common
+import CTFlows.Systems: Systems
+import CTFlows.Solutions: Solutions
+import StaticArrays: SA
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+function test_hamiltonian_vector_field_system()
+    Test.@testset "Hamiltonian Vector Field System Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+        
+        # ====================================================================
+        # UNIT TESTS - Construction
+        # ====================================================================
+        
+        Test.@testset "Construction" begin
+            # From HamiltonianVectorField without dimension
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            sys1 = Systems.HamiltonianVectorFieldSystem(hvf)
+            Test.@test sys1 isa Systems.HamiltonianVectorFieldSystem
+            Test.@test sys1 isa Systems.AbstractHamiltonianSystem
+            Test.@test Systems.state_dimension(sys1) === nothing
+            
+            # From HamiltonianVectorField with dimension
+            sys2 = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            Test.@test sys2 isa Systems.HamiltonianVectorFieldSystem
+            Test.@test Systems.state_dimension(sys2) == 3
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - build_system
+        # ====================================================================
+        
+        Test.@testset "build_system" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            # Without dimension
+            sys1 = Systems.build_system(hvf)
+            Test.@test sys1 isa Systems.HamiltonianVectorFieldSystem
+            Test.@test Systems.state_dimension(sys1) === nothing
+            
+            # With dimension
+            sys2 = Systems.build_system(hvf, 3)
+            Test.@test sys2 isa Systems.HamiltonianVectorFieldSystem
+            Test.@test Systems.state_dimension(sys2) == 3
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - rhs (in-place)
+        # ====================================================================
+        
+        Test.@testset "rhs" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            sys = Systems.HamiltonianVectorFieldSystem(hvf)
+            
+            rhs = Systems.rhs(sys)
+            Test.@test rhs isa Function
+            
+            # Test RHS call
+            u = [1.0, 2.0, 3.0, 4.0]  # x = [1, 2], p = [3, 4]
+            du = zeros(4)
+            p = Common.ODEParameters(nothing)
+            rhs(du, u, p, 0.0)
+            
+            # dx = x = [1, 2], dp = -p = [-3, -4]
+            Test.@test du[1:2] == [1.0, 2.0]
+            Test.@test du[3:4] == [-3.0, -4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - rhs_oop (out-of-place)
+        # ====================================================================
+        
+        Test.@testset "rhs_oop" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            sys = Systems.HamiltonianVectorFieldSystem(hvf)
+            
+            rhs_oop = Systems.rhs_oop(sys)
+            Test.@test rhs_oop isa Function
+            
+            # Test RHS OOP call
+            u = [1.0, 2.0, 3.0, 4.0]  # x = [1, 2], p = [3, 4]
+            p = Common.ODEParameters(nothing)
+            du = rhs_oop(u, p, 0.0)
+            
+            # dx = x = [1, 2], dp = -p = [-3, -4]
+            Test.@test du[1:2] == [1.0, 2.0]
+            Test.@test du[3:4] == [-3.0, -4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - SVector unit
+        # ====================================================================
+        
+        Test.@testset "SVector unit" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            # Call hvf with SVector
+            x = SA[1.0, 2.0]
+            p = SA[3.0, 4.0]
+            dx, dp = hvf(x, p)
+            Test.@test dx == SA[1.0, 2.0]
+            Test.@test dp == SA[-3.0, -4.0]
+            
+            # Call rhs_oop with SVector
+            sys = Systems.HamiltonianVectorFieldSystem(hvf)
+            rhs_oop = Systems.rhs_oop(sys)
+            u = SA[1.0, 2.0, 3.0, 4.0]
+            p_param = Common.ODEParameters(nothing)
+            du = rhs_oop(u, p_param, 0.0)
+            Test.@test du == SA[1.0, 2.0, -3.0, -4.0]
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Validation
+        # ====================================================================
+        
+        Test.@testset "Validation" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            # System with known dimension
+            sys = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            
+            # Correct dimension
+            Test.@test Systems._check_state_dimension(sys, [1.0, 2.0, 3.0]) == true
+            
+            # Wrong dimension
+            Test.@test_throws Exceptions.IncorrectArgument Systems._check_state_dimension(sys, [1.0, 2.0])
+            
+            # System without known dimension - should skip validation
+            sys_no_dim = Systems.HamiltonianVectorFieldSystem(hvf)
+            Test.@test Systems._check_state_dimension(sys_no_dim, [1.0, 2.0, 3.0]) == true
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Base.show
+        # ====================================================================
+        
+        Test.@testset "Base.show" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            # Without dimension
+            sys1 = Systems.HamiltonianVectorFieldSystem(hvf)
+            Test.@test_nowarn sprint(show, sys1)
+            
+            # With dimension
+            sys2 = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            Test.@test_nowarn sprint(show, sys2)
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Type parameter N
+        # ====================================================================
+        
+        Test.@testset "Type parameter N" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            sys_with_n = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            Test.@test Systems.state_dimension(sys_with_n) == 3
+            
+            sys_without_n = Systems.HamiltonianVectorFieldSystem(hvf)
+            Test.@test Systems.state_dimension(sys_without_n) === nothing
+        end
+        
+        # ====================================================================
+        # UNIT TESTS - Validation
+        # ====================================================================
+        
+        Test.@testset "Validation" begin
+            hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+            
+            # System with known dimension
+            sys = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            
+            # Correct dimension
+            Test.@test Systems._check_state_dimension(sys, [1.0, 2.0, 3.0]) == true
+            
+            # Wrong dimension
+            Test.@test_throws Exceptions.IncorrectArgument Systems._check_state_dimension(sys, [1.0, 2.0])
+            
+            # System without known dimension - should skip validation
+            sys_no_dim = Systems.HamiltonianVectorFieldSystem(hvf)
+            Test.@test Systems._check_state_dimension(sys_no_dim, [1.0, 2.0, 3.0]) == true
+        end
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_hamiltonian_vector_field_system() = TestHamiltonianVectorFieldSystem.test_hamiltonian_vector_field_system()

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -3,6 +3,7 @@ module TestVectorFieldSystem
 import Test
 import CTFlows.Systems
 import CTFlows.Common
+import StaticArrays: SA
 
 const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
@@ -115,6 +116,40 @@ function test_vector_field_system()
                 rhs2(du2, [1.0, 1.0], p, 0.0)
                 Test.@test du1 ≈ [2.0, 2.0] atol=1e-10
                 Test.@test du2 ≈ [3.0, 3.0] atol=1e-10
+            end
+
+            Test.@testset "rhs_oop returns callable" begin
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                rhs_oop = Systems.rhs_oop(sys)
+                Test.@test rhs_oop isa Function
+            end
+
+            Test.@testset "rhs_oop function has correct signature (u, p, t)" begin
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                rhs_oop = Systems.rhs_oop(sys)
+                u = [1.0, 2.0]
+                p = Common.ODEParameters(nothing)
+                t = 0.0
+                du = rhs_oop(u, p, t)
+                Test.@test du ≈ [-1.0, -2.0] atol=1e-10
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - SVector unit
+        # ====================================================================
+
+        Test.@testset "SVector unit" begin
+            Test.@testset "rhs_oop with SVector" begin
+                vf = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                rhs_oop = Systems.rhs_oop(sys)
+                u = SA[1.0, 2.0]
+                p = Common.ODEParameters(nothing)
+                du = rhs_oop(u, p, 0.0)
+                Test.@test du == SA[-1.0, -2.0]
             end
         end
 


### PR DESCRIPTION
- Add HamiltonianVectorField with time/variable dependence traits
- Add HamiltonianVectorFieldSystem{N} with type parameter for state dimension
- Add rhs_oop to AbstractSystem and VectorFieldSystem for immutable array support
- Add HamiltonianVectorFieldSolution with state and costate accessors
- Add build_system, build_solution, and Flow constructors for Hamiltonian types
- Update CTFlowsSciML extension: build_options for Hamiltonian configs, ismutable dispatch in build_problem
- Update CTFlowsPlots extension: plot methods for HamiltonianVectorFieldSolution
- Add StaticArrays dependency to Project.toml
- Add comprehensive unit tests for all new types
- Add docstrings for all new public symbols