### PR TITLE
Refactor config hierarchy with trait-based dispatch

### DIFF
--- a/ext/CTFlowsSciML.jl
+++ b/ext/CTFlowsSciML.jl
@@ -379,42 +379,44 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return pre-computed solver options for StatePointConfig.
+Return pre-computed solver options for point integration configs.
 
-For a StatePointConfig, options like `dense`, `save_everystep`, and `save_start`
-are set to `false` to minimize memory since only the final state is needed.
+For point configs (e.g., StatePointConfig, HamiltonianPointConfig), options like
+`dense`, `save_everystep`, and `save_start` are set to `false` to minimize memory
+since only the final state is needed.
 
 # Arguments
 - `integ::SciML`: The SciML integrator with pre-computed option caches.
-- `config::Common.StatePointConfig`: The point configuration.
+- `config::Common.AbstractPointConfig`: The point configuration.
 
 # Returns
-- `Dict{Symbol,Any}`: Pre-computed options optimized for StatePointConfig.
+- `Dict{Symbol,Any}`: Pre-computed options optimized for point integration.
 
-See also: [`Integrators.build_options`](@ref), [`Integrators.SciML`](@ref).
+See also: [`Integrators.build_options`](@ref), [`Integrators.SciML`](@ref), [`CTFlows.Common.AbstractPointConfig`](@ref).
 """
-function Integrators.build_options(integ::SciML, config::Common.StatePointConfig)
+function Integrators.build_options(integ::SciML, config::Common.AbstractPointConfig)
     return integ.options_point
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Return pre-computed solver options for StateTrajectoryConfig.
+Return pre-computed solver options for trajectory integration configs.
 
-For a StateTrajectoryConfig, options like `dense`, `save_everystep`, and `save_start`
-are set to `true` to enable full trajectory storage and interpolation.
+For trajectory configs (e.g., StateTrajectoryConfig, HamiltonianTrajectoryConfig),
+options like `dense`, `save_everystep`, and `save_start` are set to `true` to enable
+full trajectory storage and interpolation.
 
 # Arguments
 - `integ::SciML`: The SciML integrator with pre-computed option caches.
-- `config::Common.StateTrajectoryConfig`: The trajectory configuration.
+- `config::Common.AbstractTrajectoryConfig`: The trajectory configuration.
 
 # Returns
-- `Dict{Symbol,Any}`: Pre-computed options optimized for StateTrajectoryConfig.
+- `Dict{Symbol,Any}`: Pre-computed options optimized for trajectory integration.
 
-See also: [`Integrators.build_options`](@ref), [`Integrators.SciML`](@ref).
+See also: [`Integrators.build_options`](@ref), [`Integrators.SciML`](@ref), [`CTFlows.Common.AbstractTrajectoryConfig`](@ref).
 """
-function Integrators.build_options(integ::SciML, config::Common.StateTrajectoryConfig)
+function Integrators.build_options(integ::SciML, config::Common.AbstractTrajectoryConfig)
     return integ.options_trajectory
 end
 
@@ -423,14 +425,14 @@ $(TYPEDSIGNATURES)
 
 Return pre-computed solver options for fallback case (Nothing).
 
-Defaults to StateTrajectoryConfig options when no configuration is provided.
+Defaults to trajectory options when no configuration is provided.
 
 # Arguments
 - `integ::SciML`: The SciML integrator with pre-computed option caches.
 - `config::Nothing`: No configuration provided (fallback).
 
 # Returns
-- `Dict{Symbol,Any}`: Pre-computed options for StateTrajectoryConfig (fallback).
+- `Dict{Symbol,Any}`: Pre-computed options for trajectory integration (fallback).
 
 See also: [`Integrators.build_options`](@ref), [`Integrators.SciML`](@ref).
 """
@@ -543,46 +545,6 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build solver options for a HamiltonianPointConfig.
-
-Returns the point integration options from the SciML integrator strategy.
-
-# Arguments
-- `integ::SciML`: The SciML integrator strategy.
-- `config::Common.HamiltonianPointConfig`: The Hamiltonian point configuration.
-
-# Returns
-- `Dict{Symbol,Any}`: The resolved solver options for point integration.
-
-See also: [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Common.HamiltonianPointConfig`](@ref).
-"""
-function Integrators.build_options(integ::SciML, config::Common.HamiltonianPointConfig)
-    return integ.options_point
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Build solver options for a HamiltonianTrajectoryConfig.
-
-Returns the trajectory integration options from the SciML integrator strategy.
-
-# Arguments
-- `integ::SciML`: The SciML integrator strategy.
-- `config::Common.HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
-
-# Returns
-- `Dict{Symbol,Any}`: The resolved solver options for trajectory integration.
-
-See also: [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref).
-"""
-function Integrators.build_options(integ::SciML, config::Common.HamiltonianTrajectoryConfig)
-    return integ.options_trajectory
-end
-
-"""
-$(TYPEDSIGNATURES)
-
 Build an `ODEProblem` from a system and configuration.
 
 Dispatches between in-place and out-of-place RHS based on the mutability of the initial condition:
@@ -606,7 +568,12 @@ This allows zero-allocation integration with immutable array types like `StaticA
 
 See also: [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Systems.rhs_oop`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """
-function Integrators.build_problem(integ::SciML, system::Systems.AbstractSystem, config::Common.AbstractConfig; variable)
+function Integrators.build_problem(
+    integ::SciML, 
+    system::Systems.AbstractSystem, 
+    config::Common.AbstractConfig; 
+    variable,
+    )
     u0 = Common.initial_condition(config)
     p = Common.ODEParameters(variable)
     if ismutable(u0)

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -37,7 +37,7 @@ include(joinpath(@__DIR__, "internal_norm.jl"))
 @reexport import CTModels.OCP: Autonomous, NonAutonomous, TimeDependence
 @reexport import CTModels.OCP: is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable
 
-export AbstractTag, AbstractConfig, AbstractPointConfig, AbstractTrajectoryConfig, StatePointConfig, StateTrajectoryConfig, HamiltonianPointConfig, HamiltonianTrajectoryConfig, tspan, initial_condition, initial_state, initial_costate
+export AbstractTag, AbstractModeTag, AbstractContentTag, PointTag, TrajectoryTag, StateTag, HamiltonianTag, AbstractConfig, AbstractPointConfig, AbstractTrajectoryConfig, AbstractStateConfig, AbstractHamiltonianConfig, StatePointConfig, StateTrajectoryConfig, HamiltonianPointConfig, HamiltonianTrajectoryConfig, tspan, initial_condition, initial_state, initial_costate
 export VariableDependence, Fixed, NonFixed
 export ODEParameters
 export has_time_dependence_trait, has_variable_dependence_trait

--- a/src/Common/abstract_tag.jl
+++ b/src/Common/abstract_tag.jl
@@ -34,3 +34,69 @@ julia> # CTFlowsSciML implementation when the extension is loaded
 - The pattern avoids hard dependencies on optional packages
 """
 abstract type AbstractTag end
+
+# =============================================================================
+# Intermediate abstract tags for configuration traits
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Abstract base type for mode tags (Point vs Trajectory).
+
+Mode tags encode the integration mode in configuration types.
+"""
+abstract type AbstractModeTag <: AbstractTag end
+
+"""
+$(TYPEDEF)
+
+Abstract base type for content tags (State vs Hamiltonian).
+
+Content tags encode the content type in configuration types.
+"""
+abstract type AbstractContentTag <: AbstractTag end
+
+# =============================================================================
+# Concrete mode tags
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Tag for point integration mode (single endpoint evaluation).
+
+Used as a type parameter in `AbstractConfig` to indicate point integration.
+"""
+struct PointTag <: AbstractModeTag end
+
+"""
+$(TYPEDEF)
+
+Tag for trajectory integration mode (full time evolution).
+
+Used as a type parameter in `AbstractConfig` to indicate trajectory integration.
+"""
+struct TrajectoryTag <: AbstractModeTag end
+
+# =============================================================================
+# Concrete content tags
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Tag for state content (no costate).
+
+Used as a type parameter in `AbstractConfig` to indicate state-only configurations.
+"""
+struct StateTag <: AbstractContentTag end
+
+"""
+$(TYPEDEF)
+
+Tag for Hamiltonian content (state + costate).
+
+Used as a type parameter in `AbstractConfig` to indicate Hamiltonian configurations.
+"""
+struct HamiltonianTag <: AbstractContentTag end

--- a/src/Common/configs.jl
+++ b/src/Common/configs.jl
@@ -10,11 +10,12 @@ Abstract configuration type for integration problems.
 Marker type for dispatch on configuration objects. Concrete subtypes define
 specific integration scenarios (e.g., point-to-point, trajectory, costate).
 
-The type parameter `X0` encodes the type of the initial condition:
-- `X0 <: Number` for scalar initial conditions
-- `X0 <: AbstractVector` for vector initial conditions
+The type parameters encode:
+- `X0`: Type of the initial condition (scalar `Number` or vector `AbstractVector`)
+- `Mode`: Integration mode (`PointTag` or `TrajectoryTag`)
+- `Content`: Content type (`StateTag` or `HamiltonianTag`)
 
-This enables compile-time dispatch on scalar vs vector cases without runtime type tests.
+This enables compile-time dispatch on mode and content without runtime type tests.
 
 # Interface Requirements
 
@@ -28,61 +29,37 @@ julia> using CTFlows.Common
 julia> StatePointConfig <: Common.AbstractConfig
 true
 
-julia> StateTrajectoryConfig <: Common.AbstractConfig
+julia> StatePointConfig <: Common.AbstractPointConfig
+true
+
+julia> StatePointConfig <: Common.AbstractStateConfig
 true
 \`\`\`
 
-See also: [`CTFlows.Common.AbstractPointConfig`](@ref), [`CTFlows.Common.AbstractTrajectoryConfig`](@ref).
+See also: [`CTFlows.Common.AbstractPointConfig`](@ref), [`CTFlows.Common.AbstractTrajectoryConfig`](@ref), [`CTFlows.Common.AbstractStateConfig`](@ref), [`CTFlows.Common.AbstractHamiltonianConfig`](@ref).
 """
 abstract type AbstractConfig{X0} end
 
-"""
-$(TYPEDEF)
-
-Abstract configuration for point-to-point integration problems.
-
-Concrete subtypes define integration from a single initial condition to a specific
-final time, without storing the full trajectory.
-
-# Interface Requirements
-
-All subtypes must implement:
-- `tspan(config)`: Return the time span as a tuple `(t0, tf)`.
-
-See also: [`CTFlows.Common.StatePointConfig`](@ref), [`CTFlows.Common.HamiltonianPointConfig`](@ref).
-"""
-abstract type AbstractPointConfig{X0} <: AbstractConfig{X0} end
-
-"""
-$(TYPEDEF)
-
-Abstract configuration for trajectory integration problems.
-
-Concrete subtypes define integration over a continuous time interval, useful for
-generating full trajectories.
-
-# Interface Requirements
-
-All subtypes must implement:
-- `tspan(config)`: Return the time span as a tuple `(t0, tf)`.
-
-See also: [`CTFlows.Common.StateTrajectoryConfig`](@ref), [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref).
-"""
-abstract type AbstractTrajectoryConfig{X0} <: AbstractConfig{X0} end
-
 # =============================================================================
-# Interface: tspan
+# Interface: stubs
 # =============================================================================
 
 """
 $(TYPEDSIGNATURES)
 
-Extract the time span from an `AbstractConfig`.
+Return the time span for a configuration (stub method).
+
+This is a stub method on the base `AbstractConfig` type that throws
+`NotImplemented`. Concrete subtypes should implement this method to return
+their specific time span format.
+
+# Arguments
+- `c::AbstractConfig`: The configuration.
 
 # Throws
-- `CTBase.Exceptions.NotImplemented`: If not implemented by the concrete type.
+- `Exceptions.NotImplemented`: Always thrown for the base abstract type.
 
-See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.StatePointConfig`](@ref), [`CTFlows.Common.StateTrajectoryConfig`](@ref).
+See also: [`CTFlows.Common.AbstractConfig`](@ref).
 """
 function tspan(c::AbstractConfig)
     throw(Exceptions.NotImplemented(
@@ -93,8 +70,294 @@ function tspan(c::AbstractConfig)
     ))
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial condition for a configuration (stub method).
+
+This is a stub method on the base `AbstractConfig` type that throws
+`NotImplemented`. Concrete subtypes should implement this method to return
+their specific initial condition format.
+
+# Arguments
+- `c::AbstractConfig`: The configuration.
+
+# Throws
+- `Exceptions.NotImplemented`: Always thrown for the base abstract type.
+
+See also: [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function initial_condition(c::AbstractConfig)
+    throw(Exceptions.NotImplemented(
+        "AbstractConfig initial_condition method not implemented";
+        required_method = "initial_condition(c::$(typeof(c)))",
+        suggestion = "Return the initial condition for this configuration.",
+        context = "AbstractConfig.initial_condition - required method implementation",
+    ))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial state for a configuration (stub method).
+
+This is a stub method on the base `AbstractConfig` type that throws
+`NotImplemented`. Concrete subtypes should implement this method to return
+their specific initial state.
+
+# Arguments
+- `c::AbstractConfig`: The configuration.
+
+# Throws
+- `Exceptions.NotImplemented`: Always thrown for the base abstract type.
+
+See also: [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function initial_state(c::AbstractConfig)
+    throw(Exceptions.NotImplemented(
+        "AbstractConfig initial_state method not implemented";
+        required_method = "initial_state(c::$(typeof(c)))",
+        suggestion = "Return the initial state for this configuration.",
+        context = "AbstractConfig.initial_state - required method implementation",
+    ))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial costate for a configuration (stub method).
+
+This is a stub method on the base `AbstractConfig` type that throws
+`NotImplemented`. Concrete subtypes should implement this method to return
+their specific initial costate (if applicable).
+
+# Arguments
+- `c::AbstractConfig`: The configuration.
+
+# Throws
+- `Exceptions.NotImplemented`: Always thrown for the base abstract type.
+
+See also: [`CTFlows.Common.AbstractConfig`](@ref).
+"""
+function initial_costate(c::AbstractConfig)
+    throw(Exceptions.NotImplemented(
+        "AbstractConfig initial_costate method not implemented";
+        required_method = "initial_costate(c::$(typeof(c)))",
+        suggestion = "Return the initial costate for this configuration.",
+        context = "AbstractConfig.initial_costate - required method implementation",
+    ))
+end
+
 # =============================================================================
-# StatePointConfig
+# Type Aliases for Convenient Dispatch
+# =============================================================================
+
+abstract type AbstractConfigWithMaC{X0, Mode<:AbstractModeTag, Content<:AbstractContentTag} <: AbstractConfig{X0} end
+
+"""
+$(TYPEDEF)
+
+Alias for point integration mode configurations.
+
+Matches any `AbstractConfig` with `PointTag` as the mode parameter.
+"""
+const AbstractPointConfig{X0, C} = AbstractConfigWithMaC{X0, PointTag, C}
+
+"""
+$(TYPEDEF)
+
+Alias for trajectory integration mode configurations.
+
+Matches any `AbstractConfig` with `TrajectoryTag` as the mode parameter.
+"""
+const AbstractTrajectoryConfig{X0, C} = AbstractConfigWithMaC{X0, TrajectoryTag, C}
+
+"""
+$(TYPEDEF)
+
+Alias for state content configurations.
+
+Matches any `AbstractConfig` with `StateTag` as the content parameter.
+"""
+const AbstractStateConfig{X0, M} = AbstractConfigWithMaC{X0, M, StateTag}
+
+"""
+$(TYPEDEF)
+
+Alias for Hamiltonian content configurations.
+
+Matches any `AbstractConfig` with `HamiltonianTag` as the content parameter.
+"""
+const AbstractHamiltonianConfig{X0, M} = AbstractConfigWithMaC{X0, M, HamiltonianTag}
+
+# =============================================================================
+# Interface implementations on abstract config types
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the time span as a tuple for point configurations.
+
+For point configurations, extracts the initial and final times from the
+`t0` and `tf` fields.
+
+# Arguments
+- `c::AbstractPointConfig`: The point configuration.
+
+# Returns
+- `Tuple{Real, Real}`: Time span as (t0, tf).
+
+See also: [`CTFlows.Common.AbstractPointConfig`](@ref), [`CTFlows.Common.tspan`](@ref).
+"""
+function tspan(c::AbstractPointConfig)::Tuple{Real, Real}
+    return (c.t0, c.tf)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the time span for trajectory configurations.
+
+For trajectory configurations, returns the stored `tspan` field directly.
+
+# Arguments
+- `c::AbstractTrajectoryConfig`: The trajectory configuration.
+
+# Returns
+- `Tuple{Real, Real}`: Time span as (t0, tf).
+
+See also: [`CTFlows.Common.AbstractTrajectoryConfig`](@ref), [`CTFlows.Common.tspan`](@ref).
+"""
+function tspan(c::AbstractTrajectoryConfig)::Tuple{Real, Real}
+    return c.tspan
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial condition as a vector for scalar state configurations.
+
+For scalar initial conditions, wraps the scalar in a length-1 vector to
+maintain consistent vector-based ODE problem construction.
+
+# Arguments
+- `c::AbstractStateConfig{<:Number, M}`: The state configuration with scalar initial state.
+
+# Returns
+- `Vector{<:Number}`: Length-1 vector containing the scalar initial state.
+
+See also: [`CTFlows.Common.AbstractStateConfig`](@ref), [`CTFlows.Common.initial_condition`](@ref).
+"""
+function initial_condition(c::AbstractStateConfig{<:Number, M}) where {M}
+    return [c.x0]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial condition for state configurations.
+
+For vector initial conditions, returns the state vector directly.
+
+# Arguments
+- `c::AbstractStateConfig`: The state configuration.
+
+# Returns
+- The initial state vector.
+
+See also: [`CTFlows.Common.AbstractStateConfig`](@ref).
+"""
+function initial_condition(c::AbstractStateConfig)
+    return c.x0
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial condition for Hamiltonian configurations.
+
+For Hamiltonian systems, the initial condition is the concatenation of the
+initial state and initial costate: `vcat(x0, p0)`.
+
+# Arguments
+- `c::AbstractHamiltonianConfig`: The Hamiltonian configuration.
+
+# Returns
+- Concatenated vector `[x0; p0]`.
+
+See also: [`CTFlows.Common.AbstractHamiltonianConfig`](@ref), [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_costate`](@ref).
+"""
+function initial_condition(c::AbstractHamiltonianConfig)
+    return vcat(c.x0, c.p0)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial state from a configuration.
+
+Extracts the initial state field from the configuration.
+
+# Arguments
+- `c::AbstractConfigWithMaC`: The configuration with mode and content traits.
+
+# Returns
+- The initial state vector.
+
+See also: [`CTFlows.Common.AbstractConfigWithMaC`](@ref).
+"""
+function initial_state(c::AbstractConfigWithMaC)
+    return c.x0
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial costate for state configurations (error stub).
+
+State configurations do not have a costate field. This method throws a
+`PreconditionError` to enforce the contract that `initial_costate` is only
+defined for Hamiltonian configurations.
+
+# Arguments
+- `c::AbstractStateConfig`: The state configuration.
+
+# Throws
+- `Exceptions.PreconditionError`: Always thrown for state configurations.
+
+See also: [`CTFlows.Common.AbstractStateConfig`](@ref), [`CTFlows.Common.AbstractHamiltonianConfig`](@ref), [`CTFlows.Common.initial_costate`](@ref).
+"""
+function initial_costate(c::AbstractStateConfig)
+    throw(Exceptions.PreconditionError(
+        "initial_costate is only defined for Hamiltonian configs";
+        context = "initial_costate - requires Hamiltonian config",
+        reason = "config type $(typeof(c)) does not have a costate field",
+        suggestion = "use HamiltonianPointConfig or HamiltonianTrajectoryConfig instead",
+    ))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the initial costate for Hamiltonian configurations.
+
+Extracts the initial costate field from the Hamiltonian configuration.
+
+# Arguments
+- `c::AbstractHamiltonianConfig`: The Hamiltonian configuration.
+
+# Returns
+- The initial costate vector.
+
+See also: [`CTFlows.Common.AbstractHamiltonianConfig`](@ref).
+"""
+function initial_costate(c::AbstractHamiltonianConfig)
+    return c.p0
+end
+
+# =============================================================================
+# Concrete configurations
 # =============================================================================
 
 """
@@ -123,44 +386,11 @@ StatePointConfig
 
 See also: [`CTFlows.Common.StateTrajectoryConfig`](@ref)
 """
-struct StatePointConfig{T0<:Real, X0, TF<:Real} <: AbstractPointConfig{X0}
+struct StatePointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfigWithMaC{X0, PointTag, StateTag}
     t0::T0
     x0::X0
     tf::TF
 end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the time span from a `StatePointConfig`.
-
-Returns a tuple `(t0, tf)` for consistency with `StateTrajectoryConfig`.
-
-# Arguments
-- `c::StatePointConfig`: The point configuration.
-
-# Returns
-- `Tuple{Real, Real}`: Time span as `(t0, tf)`.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = StatePointConfig(0.0, [1.0, 0.0], 1.0)
-
-julia> tspan(config)
-(0.0, 1.0)
-\`\`\`
-
-See also: [`CTFlows.Common.StatePointConfig`](@ref), [`CTFlows.Common.StateTrajectoryConfig`](@ref)
-"""
-function tspan(c::StatePointConfig)::Tuple{Real, Real}
-    return (c.t0, c.tf)
-end
-
-# =============================================================================
-# StateTrajectoryConfig
-# =============================================================================
 
 """
 $(TYPEDEF)
@@ -186,43 +416,11 @@ StateTrajectoryConfig
 
 See also: [`CTFlows.Common.StatePointConfig`](@ref)
 """
-struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractTrajectoryConfig{X0}
+struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfigWithMaC{X0, TrajectoryTag, StateTag}
     tspan::TS
     x0::X0
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Extract the time span from a `StateTrajectoryConfig`.
-
-Returns the stored time span tuple.
-
-# Arguments
-- `c::StateTrajectoryConfig`: The trajectory configuration.
-
-# Returns
-- `Tuple{Real, Real}`: Time span as `(t0, tf)`.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
-
-julia> tspan(config)
-(0.0, 1.0)
-\`\`\`
-
-See also: [`CTFlows.Common.StateTrajectoryConfig`](@ref), [`CTFlows.Common.StatePointConfig`](@ref)
-"""
-function tspan(c::StateTrajectoryConfig)::Tuple{Real, Real}
-    return c.tspan
-end
-
-# =============================================================================
-# HamiltonianPointConfig
-# =============================================================================
 
 """
 $(TYPEDEF)
@@ -253,46 +451,12 @@ HamiltonianPointConfig
 
 See also: [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref), [`CTFlows.Common.StatePointConfig`](@ref).
 """
-struct HamiltonianPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractPointConfig{X0}
+struct HamiltonianPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfigWithMaC{X0, PointTag, HamiltonianTag}
     t0::T0
     x0::X0
     p0::P0
     tf::TF
 end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the time span from a `HamiltonianPointConfig`.
-
-Returns a tuple `(t0, tf)` for consistency with other config types.
-
-# Arguments
-- `c::HamiltonianPointConfig`: The Hamiltonian point configuration.
-
-# Returns
-- `Tuple{Real, Real}`: Time span as `(t0, tf)`.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
-
-julia> tspan(config)
-(0.0, 1.0)
-\`\`\`
-
-See also: [`CTFlows.Common.HamiltonianPointConfig`](@ref).
-"""
-function tspan(c::HamiltonianPointConfig)::Tuple{Real, Real}
-    return (c.t0, c.tf)
-end
-
-
-# =============================================================================
-# HamiltonianTrajectoryConfig
-# =============================================================================
 
 """
 $(TYPEDEF)
@@ -321,216 +485,10 @@ HamiltonianTrajectoryConfig
 
 See also: [`CTFlows.Common.HamiltonianPointConfig`](@ref), [`CTFlows.Common.StateTrajectoryConfig`](@ref).
 """
-struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractTrajectoryConfig{X0}
+struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfigWithMaC{X0, TrajectoryTag, HamiltonianTag}
     tspan::TS
     x0::X0
     p0::P0
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the time span from a `HamiltonianTrajectoryConfig`.
-
-Returns the stored time span tuple.
-
-# Arguments
-- `c::HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
-
-# Returns
-- `Tuple{Real, Real}`: Time span as `(t0, tf)`.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
-
-julia> tspan(config)
-(0.0, 1.0)
-\`\`\`
-
-See also: [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref).
-"""
-function tspan(c::HamiltonianTrajectoryConfig)::Tuple{Real, Real}
-    return c.tspan
-end
-
-
-# =============================================================================
-# Generic Accessor Functions
-# =============================================================================
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial state from an `AbstractConfig`.
-
-Returns the initial state. For scalar configurations (`X0 <: Number`),
-wraps in a vector for consistency with ODE solver expectations. For vector
-configurations, returns the vector unchanged.
-
-This uses compile-time dispatch on the type parameter `X0` to avoid runtime
-type tests.
-
-# Arguments
-- `c::AbstractConfig{<:Number}`: Scalar configuration.
-
-# Returns
-- `AbstractVector`: The initial condition wrapped in a vector.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = StatePointConfig(0.0, 1.0, 1.0)  # scalar x0
-
-julia> initial_condition(config)
-[1.0]
-\`\`\`
-
-See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.StatePointConfig`](@ref).
-"""
-function initial_condition(c::AbstractConfig{<:Number})
-    return [c.x0]
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial condition from an `AbstractConfig`.
-
-Returns the initial condition as a vector for vector configurations.
-
-This uses compile-time dispatch on the type parameter `X0` to avoid runtime
-type tests.
-
-# Arguments
-- `c::AbstractConfig`: Vector configuration.
-
-# Returns
-- `AbstractVector`: The initial condition vector.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = StatePointConfig(0.0, [1.0, 0.0], 1.0)  # vector x0
-
-julia> initial_condition(config)
-[1.0, 0.0]
-\`\`\`
-
-See also: [`CTFlows.Common.AbstractConfig`](@ref), [`CTFlows.Common.StatePointConfig`](@ref).
-"""
-function initial_condition(c::AbstractConfig)
-    return c.x0
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial condition from a Hamiltonian config.
-
-Returns the concatenated state and costate as a single vector, which is the
-expected format for ODE solvers in the Hamiltonian framework.
-
-# Arguments
-- `c::Union{HamiltonianPointConfig, HamiltonianTrajectoryConfig}`: The Hamiltonian configuration.
-
-# Returns
-- `AbstractVector`: Concatenated state and costate vector.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
-
-julia> initial_condition(config)
-4-element Vector{Float64}:
- 1.0
- 0.0
- 0.5
- 0.3
-\`\`\`
-
-See also: [`CTFlows.Common.HamiltonianPointConfig`](@ref), [`CTFlows.Common.HamiltonianTrajectoryConfig`](@ref), [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_costate`](@ref).
-"""
-function initial_condition(c::Union{HamiltonianPointConfig, HamiltonianTrajectoryConfig})
-    return vcat(c.x0, c.p0)
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial state from an `AbstractConfig`.
-
-For point and trajectory configs, returns the state `x0`. For Hamiltonian
-configs, returns the state `x0` (separate from costate).
-
-# Arguments
-- `c::AbstractConfig`: The configuration.
-
-# Returns
-- The initial state (scalar, vector, or tuple for Hamiltonian configs).
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = StatePointConfig(0.0, [1.0, 0.0], 1.0)
-
-julia> initial_state(config)
-[1.0, 0.0]
-\`\`\`
-
-See also: [`CTFlows.Common.initial_costate`](@ref), [`CTFlows.Common.initial_condition`](@ref).
-"""
-function initial_state(c::Common.AbstractConfig)
-    return c.x0
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial costate from a Hamiltonian config.
-
-For Hamiltonian configs, returns the costate `p0`. For non-Hamiltonian configs,
-throws `NotImplemented` since costate is not defined.
-
-# Arguments
-- `c::AbstractConfig`: The configuration.
-
-# Returns
-- The initial costate (vector).
-
-# Throws
-- `CTBase.Exceptions.NotImplemented`: If config is not a Hamiltonian config.
-
-# Example
-\`\`\`julia-repl
-julia> using CTFlows.Common
-
-julia> config = HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
-
-julia> initial_costate(config)
-[0.5, 0.3]
-\`\`\`
-
-See also: [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_condition`](@ref).
-"""
-function initial_costate(c::Union{Common.HamiltonianPointConfig, Common.HamiltonianTrajectoryConfig})
-    return c.p0
-end
-
-function initial_costate(c::Common.AbstractConfig)
-    throw(Exceptions.PreconditionError(
-        "initial_costate is only defined for Hamiltonian configs";
-        context = "initial_costate - requires Hamiltonian config",
-        reason = "config type $(typeof(c)) does not have a costate field",
-        suggestion = "use HamiltonianPointConfig or HamiltonianTrajectoryConfig instead",
-    ))
 end
 
 # =============================================================================

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -5,62 +5,36 @@
 """
 $(TYPEDSIGNATURES)
 
-Extract the initial state from a point configuration.
+Extract the initial state from a state configuration.
 
 # Arguments
-- `config::Common.StatePointConfig`: The point configuration.
+- `config::Common.AbstractStateConfig`: The state configuration (StatePointConfig or StateTrajectoryConfig).
 
 # Returns
 - Initial state vector.
 
-See also: [`CTFlows.Common.initial_state`](@ref).
+See also: [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.AbstractStateConfig`](@ref).
 """
-_extract_initial_state(config::Common.StatePointConfig) = Common.initial_state(config)
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial state from a trajectory configuration.
-
-# Arguments
-- `config::Common.StateTrajectoryConfig`: The trajectory configuration.
-
-# Returns
-- Initial state vector.
-
-See also: [`CTFlows.Common.initial_state`](@ref).
-"""
-_extract_initial_state(config::Common.StateTrajectoryConfig) = Common.initial_state(config)
+function _extract_initial_state(config::Common.AbstractStateConfig)
+    return Common.initial_state(config)
+end
 
 """
 $(TYPEDSIGNATURES)
 
-Extract the initial state and costate from a Hamiltonian point configuration.
+Extract the initial state and costate from a Hamiltonian configuration.
 
 # Arguments
-- `config::Common.HamiltonianPointConfig`: The Hamiltonian point configuration.
+- `config::Common.AbstractHamiltonianConfig`: The Hamiltonian configuration (HamiltonianPointConfig or HamiltonianTrajectoryConfig).
 
 # Returns
 - Tuple of (initial_state, initial_costate).
 
-See also: [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_costate`](@ref).
+See also: [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_costate`](@ref), [`CTFlows.Common.AbstractHamiltonianConfig`](@ref).
 """
-_extract_initial_state(config::Common.HamiltonianPointConfig) = (Common.initial_state(config), Common.initial_costate(config))
-
-"""
-$(TYPEDSIGNATURES)
-
-Extract the initial state and costate from a Hamiltonian trajectory configuration.
-
-# Arguments
-- `config::Common.HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
-
-# Returns
-- Tuple of (initial_state, initial_costate).
-
-See also: [`CTFlows.Common.initial_state`](@ref), [`CTFlows.Common.initial_costate`](@ref).
-"""
-_extract_initial_state(config::Common.HamiltonianTrajectoryConfig) = (Common.initial_state(config), Common.initial_costate(config))
+function _extract_initial_state(config::Common.AbstractHamiltonianConfig)
+    return (Common.initial_state(config), Common.initial_costate(config))
+end
 
 """
 $(TYPEDSIGNATURES)
@@ -221,9 +195,7 @@ See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
 function _evaluate_phase(flow::Flows.HamiltonianFlow, t0, tf, state_tuple, ::Common.AbstractPointConfig; variable, unsafe)
     x, p = state_tuple
-    xfpf = flow(t0, x, p, tf; variable=variable, unsafe=unsafe)
-    nx = length(x)
-    return (xfpf[1:nx], xfpf[nx+1:end])
+    return flow(t0, x, p, tf; variable=variable, unsafe=unsafe)
 end
 
 """

--- a/src/Solutions/building.jl
+++ b/src/Solutions/building.jl
@@ -1,27 +1,83 @@
+# =============================================================================
+# Solution from VectorFieldSystem
+# =============================================================================
+
 """
 $(TYPEDSIGNATURES)
 
-Default implementation for `StatePointConfig` — return the final state.
+Default implementation for scalar point configs — return the final state.
 
 For scalar configurations (`X0 <: Number`), unwraps the length-1 vector that was
-introduced by scalar-promotion at ODE problem construction time. For vector
-configurations, returns the state vector unchanged.
+introduced by scalar-promotion at ODE problem construction time.
 
-This uses compile-time dispatch on the configuration's type parameter `X0`
-to avoid runtime type tests.
+This uses compile-time dispatch on the configuration's type parameter to avoid
+runtime type tests.
 
 # Arguments
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
 - `sys::Systems.VectorFieldSystem`: The vector field system.
-- `config::Common.StatePointConfig{<:Real, <:Number, <:Real}`: Scalar point configuration.
+- `config::Common.AbstractPointConfig{<:Number, Common.StateTag}`: Scalar point configuration.
 
 # Returns
 - `Number`: The unwrapped scalar final state.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractPointConfig`](@ref).
 """
-function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.StatePointConfig{<:Real, <:Number, <:Real})
+function build_solution(
+    result::Integrators.AbstractIntegrationResult, 
+    sys::Systems.AbstractStateSystem, 
+    config::Common.AbstractPointConfig{<:Number, Common.StateTag}
+    )
     return final_state(result)[1]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Default implementation for point configs — return the final state.
+
+For vector configurations, returns the state vector unchanged.
+
+# Arguments
+- `result::Integrators.AbstractIntegrationResult`: The integration result.
+- `sys::Systems.VectorFieldSystem`: The vector field system.
+- `config::Common.AbstractPointConfig`: Point configuration.
+
+# Returns
+- `AbstractVector`: The final state vector.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractPointConfig`](@ref).
+"""
+function build_solution(
+    result::Integrators.AbstractIntegrationResult, 
+    sys::Systems.AbstractStateSystem, 
+    config::Common.AbstractPointConfig{X0, Common.StateTag}
+    ) where {X0}
+    return final_state(result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Default implementation for trajectory configs — wrap the integration result
+in a `VectorFieldSolution` for future extensibility.
+
+# Arguments
+- `result::Integrators.AbstractIntegrationResult`: The integration result.
+- `sys::Systems.VectorFieldSystem`: The vector field system.
+- `config::Common.AbstractTrajectoryConfig`: The trajectory configuration.
+
+# Returns
+- `VectorFieldSolution`: The wrapped integration result.
+
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.VectorFieldSolution`](@ref), [`CTFlows.Common.AbstractTrajectoryConfig`](@ref).
+"""
+function build_solution(
+    result::Integrators.AbstractIntegrationResult, 
+    sys::Systems.AbstractStateSystem, 
+    config::Common.AbstractTrajectoryConfig{X0, Common.StateTag}
+    ) where {X0}
+    return VectorFieldSolution(result)
 end
 
 # =============================================================================
@@ -55,51 +111,14 @@ _ham_split_solution(u, x0::Number) = (u[1], u[2])
 _ham_split_solution(u, x0::AbstractVector) = (u[1:length(x0)], u[length(x0)+1:end])
 _ham_split_solution(u, x0::AbstractMatrix) = (u[1:size(x0, 1), :], u[size(x0, 1)+1:end, :])
 
-"""
-$(TYPEDSIGNATURES)
-
-Default implementation for `StatePointConfig` — return the final state.
-
-For vector configurations, returns the state vector unchanged.
-
-# Arguments
-- `result::Integrators.AbstractIntegrationResult`: The integration result.
-- `sys::Systems.VectorFieldSystem`: The vector field system.
-- `config::Common.StatePointConfig`: Vector point configuration.
-
-# Returns
-- `AbstractVector`: The final state vector.
-
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
-"""
-function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.StatePointConfig)
-    return final_state(result)
-end
+# =============================================================================
+# Solution from HamiltonianVectorFieldSystem
+# =============================================================================
 
 """
 $(TYPEDSIGNATURES)
 
-Default implementation for `StateTrajectoryConfig` — wrap the integration result
-in a `VectorFieldSolution` for future extensibility.
-
-# Arguments
-- `result::Integrators.AbstractIntegrationResult`: The integration result.
-- `sys::Systems.VectorFieldSystem`: The vector field system.
-- `config::Common.StateTrajectoryConfig`: The trajectory configuration.
-
-# Returns
-- `VectorFieldSolution`: The wrapped integration result.
-
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.VectorFieldSolution`](@ref).
-"""
-function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.VectorFieldSystem, config::Common.StateTrajectoryConfig)
-    return VectorFieldSolution(result)
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Build a solution for a HamiltonianPointConfig integration.
+Build a solution for Hamiltonian point configs.
 
 Returns the final state and costate as a tuple `(xf, pf)`, dispatching on the
 type of the initial condition to handle scalar, vector, and matrix cases.
@@ -107,7 +126,7 @@ type of the initial condition to handle scalar, vector, and matrix cases.
 # Arguments
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
 - `sys::Systems.HamiltonianVectorFieldSystem`: The Hamiltonian vector field system.
-- `config::Common.HamiltonianPointConfig`: The Hamiltonian point configuration.
+- `config::Common.AbstractPointConfig{<:Any, Common.HamiltonianTag}`: The Hamiltonian point configuration.
 
 # Returns
 - `Tuple`: The final state and costate. Type depends on `x0`/`p0`:
@@ -115,29 +134,37 @@ type of the initial condition to handle scalar, vector, and matrix cases.
   - `Tuple{AbstractVector, AbstractVector}` for vector inputs
   - `Tuple{AbstractMatrix, AbstractMatrix}` for matrix inputs
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Common.AbstractPointConfig`](@ref), [`CTFlows.Common.AbstractHamiltonianConfig`](@ref).
 """
-function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.HamiltonianVectorFieldSystem, config::Common.HamiltonianPointConfig)
+function build_solution(
+    result::Integrators.AbstractIntegrationResult, 
+    sys::Systems.AbstractHamiltonianSystem, 
+    config::Common.AbstractPointConfig{X0, Common.HamiltonianTag}
+    ) where {X0}
     return _ham_split_solution(Integrators.final_state(result), Common.initial_state(config))
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Build a solution for a HamiltonianTrajectoryConfig integration.
+Build a solution for Hamiltonian trajectory configs.
 
 Wraps the integration result in a `HamiltonianVectorFieldSolution` for future extensibility.
 
 # Arguments
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
 - `sys::Systems.HamiltonianVectorFieldSystem`: The Hamiltonian vector field system.
-- `config::Common.HamiltonianTrajectoryConfig`: The Hamiltonian trajectory configuration.
+- `config::Common.AbstractTrajectoryConfig{<:Any, Common.HamiltonianTag}`: The Hamiltonian trajectory configuration.
 
 # Returns
 - `HamiltonianVectorFieldSolution`: The wrapped integration result.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref).
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Common.AbstractTrajectoryConfig`](@ref), [`CTFlows.Common.AbstractHamiltonianConfig`](@ref).
 """
-function build_solution(result::Integrators.AbstractIntegrationResult, sys::Systems.HamiltonianVectorFieldSystem, config::Common.HamiltonianTrajectoryConfig)
+function build_solution(
+    result::Integrators.AbstractIntegrationResult, 
+    sys::Systems.AbstractHamiltonianSystem, 
+    config::Common.AbstractTrajectoryConfig{X0, Common.HamiltonianTag}
+    ) where {X0}
     return HamiltonianVectorFieldSolution(result)
 end

--- a/test/suite/common/test_configs.jl
+++ b/test/suite/common/test_configs.jl
@@ -13,9 +13,8 @@ const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING :
 
 """
 Fake config type for testing the AbstractConfig contract.
-Does not implement tspan to trigger NotImplemented error.
 """
-struct FakeConfig{X0} <: Common.AbstractConfig{X0}
+struct FakeConfig{X0} <: Common.AbstractConfigWithMaC{X0, Common.PointTag, Common.StateTag}
     x0::X0
 end
 
@@ -23,7 +22,7 @@ end
 Fake config type that implements the tspan contract.
 Used to test contract implementation without relying on concrete types.
 """
-struct FakeConfigWithTspan{X0} <: Common.AbstractConfig{X0}
+struct FakeConfigWithTspan{X0} <: Common.AbstractConfigWithMaC{X0, Common.PointTag, Common.StateTag}
     t0::Float64
     tf::Float64
     x0::X0
@@ -45,6 +44,25 @@ function test_configs()
         # ====================================================================
 
         Test.@testset "Abstract Type" begin
+            Test.@testset "Trait Aliases" begin
+                # Mode aliases
+                Test.@test Common.StatePointConfig <: Common.AbstractPointConfig
+                Test.@test Common.HamiltonianPointConfig <: Common.AbstractPointConfig
+                Test.@test Common.StateTrajectoryConfig <: Common.AbstractTrajectoryConfig
+                Test.@test Common.HamiltonianTrajectoryConfig <: Common.AbstractTrajectoryConfig
+
+                # Content aliases
+                Test.@test Common.StatePointConfig <: Common.AbstractStateConfig
+                Test.@test Common.StateTrajectoryConfig <: Common.AbstractStateConfig
+                Test.@test Common.HamiltonianPointConfig <: Common.AbstractHamiltonianConfig
+                Test.@test Common.HamiltonianTrajectoryConfig <: Common.AbstractHamiltonianConfig
+
+                # Negative checks
+                Test.@test !(Common.StatePointConfig <: Common.AbstractHamiltonianConfig)
+                Test.@test !(Common.HamiltonianPointConfig <: Common.AbstractStateConfig)
+                Test.@test !(Common.StatePointConfig <: Common.AbstractTrajectoryConfig)
+            end
+
             Test.@testset "initial_condition is exported" begin
                 Test.@test isdefined(Common, :initial_condition)
             end
@@ -101,6 +119,18 @@ function test_configs()
             Test.@testset "initial_costate for HamiltonianTrajectoryConfig" begin
                 config = Common.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
                 Test.@test Common.initial_costate(config) == [0.5, 0.3]
+            end
+
+            Test.@testset "tspan unified dispatch" begin
+                sp = Common.StatePointConfig(0.0, [1.0], 1.0)
+                st = Common.StateTrajectoryConfig((0.0, 1.0), [1.0])
+                hp = Common.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+                ht = Common.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0], [0.5])
+
+                Test.@test Common.tspan(sp) == (0.0, 1.0)
+                Test.@test Common.tspan(st) == (0.0, 1.0)
+                Test.@test Common.tspan(hp) == (0.0, 1.0)
+                Test.@test Common.tspan(ht) == (0.0, 1.0)
             end
 
             Test.@testset "initial_costate throws PreconditionError for non-Hamiltonian configs" begin
@@ -226,11 +256,6 @@ function test_configs()
         # ====================================================================
 
         Test.@testset "tspan Contract" begin
-            Test.@testset "AbstractConfig tspan throws NotImplemented" begin
-                config = FakeConfig(1.0)
-                Test.@test_throws Exceptions.NotImplemented Common.tspan(config)
-            end
-
             Test.@testset "StatePointConfig tspan returns tuple" begin
                 config = Common.StatePointConfig(0.0, [1.0, 0.0], 1.0)
                 ts = Common.tspan(config)

--- a/test/suite/multiphase/test_calling_multiphase.jl
+++ b/test/suite/multiphase/test_calling_multiphase.jl
@@ -146,20 +146,27 @@ function Solutions.evaluate_at(result::MockIntegrationResult, t::Real)
     end
 end
 
-function Solutions.build_solution(result::MockIntegrationResult, sys, config)
+function Solutions.build_solution(result::MockIntegrationResult, sys::Systems.AbstractStateSystem, config::Common.AbstractPointConfig{<:Any, Common.StateTag})
     # For StatePointConfig, return the final state directly (as expected by _evaluate_phase)
-    if config isa Common.StatePointConfig
-        return result.u
-    elseif config isa Common.HamiltonianPointConfig
-        # For HamiltonianFlow, return the concatenated state (will be split by _evaluate_phase)
-        return result.u
-    elseif config isa Common.StateTrajectoryConfig
-        # For StateTrajectoryConfig with StateFlow, return the full result
-        return result
-    elseif config isa Common.HamiltonianTrajectoryConfig
-        # For StateTrajectoryConfig with HamiltonianFlow, return the full result
-        return result
-    end
+    return result.u
+end
+
+function Solutions.build_solution(result::MockIntegrationResult, sys::Systems.AbstractStateSystem, config::Common.AbstractTrajectoryConfig{<:Any, Common.StateTag})
+    # For StateTrajectoryConfig with StateFlow, return the full result
+    return result
+end
+
+function Solutions.build_solution(result::MockIntegrationResult, sys::Systems.AbstractHamiltonianSystem, config::Common.AbstractPointConfig{<:Any, Common.HamiltonianTag})
+    # For HamiltonianFlow, return a tuple (x, p) matching _ham_split_solution behavior
+    x_len = length(result.u) ÷ 2
+    x_part = result.u[1:x_len]
+    p_part = result.u[x_len+1:end]
+    return (x_part, p_part)
+end
+
+function Solutions.build_solution(result::MockIntegrationResult, sys::Systems.AbstractHamiltonianSystem, config::Common.AbstractTrajectoryConfig{<:Any, Common.HamiltonianTag})
+    # For HamiltonianTrajectoryConfig, return the full result
+    return result
 end
 
 # ==============================================================================


### PR DESCRIPTION
- Add AbstractModeTag and AbstractContentTag intermediate tags
- Add concrete tags: PointTag, TrajectoryTag, StateTag, HamiltonianTag
- Unify AbstractConfig with mode and content trait parameters
- Create trait aliases: AbstractPointConfig, AbstractTrajectoryConfig, AbstractStateConfig, AbstractHamiltonianConfig
- Update concrete configs to subtype from AbstractConfig with appropriate tags
- Unify methods (tspan, initial_condition, initial_state, initial_costate) on trait aliases
- Update CTFlowsSciML build_options to dispatch on trait aliases
- Update Solutions.build_solution signatures to use trait aliases
- Update MultiPhase._evaluate_phase for HamiltonianFlow point config
- Add docstrings for all new and modified methods
- Fix test mocks and expectations for trait-based dispatch

All 1272 tests passing.