### PR TITLE
feat: InPlace vector field support via AbstractMutabilityTrait

### DIFF
--- a/ext/CTFlowsSciML.jl
+++ b/ext/CTFlowsSciML.jl
@@ -580,7 +580,7 @@ function Integrators.build_problem(
         f! = Systems.rhs(system)
         prob = ODEProblem(f!, u0, Common.tspan(config), p)
     else
-        f = Systems.rhs_oop(system)
+        f = Systems.rhs_oop(system, false)  # false = is_u0_mutable
         prob = ODEProblem(f, u0, Common.tspan(config), p)
     end
     return prob

--- a/reports/CTFlows/data.md
+++ b/reports/CTFlows/data.md
@@ -1,0 +1,63 @@
+# Data
+
+## Overview
+
+The Data module provides data structures for vector fields and Hamiltonian vector fields with trait-based encoding of properties. These structures encapsulate vector-field functions together with their time-dependence and variable-dependence traits, enabling compile-time dispatch throughout the CTFlows stack.
+
+## Key Types
+
+### Abstract Types
+
+- `AbstractVectorField{TD, VD}` - Abstract base type for all vector fields with type parameters for time dependence (TD) and variable dependence (VD)
+
+### Concrete Types
+
+- `VectorField{F, TD, VD}` - Standard vector field wrapping a function `f(u, p, t)` or `f(u, p)` depending on time dependence
+- `HamiltonianVectorField{F, TD, VD}` - Hamiltonian vector field wrapping a function that returns state and costate derivatives
+
+## Traits
+
+Vector fields use two trait type parameters:
+
+- **Time Dependence (TD)**: `Autonomous` or `NonAutonomous`
+  - Encodes whether the vector field depends explicitly on time
+  - Affects function signature (time parameter presence)
+
+- **Variable Dependence (VD)**: `Fixed` or `NonFixed`
+  - Encodes whether parameters are fixed or variable
+  - Used for optimization and sensitivity analysis contexts
+
+Trait accessors are implemented at the abstract level:
+- `time_dependence(vf::AbstractVectorField)` - Returns the time dependence trait type
+- `variable_dependence(vf::AbstractVectorField)` - Returns the variable dependence trait type
+- `has_time_dependence_trait(vf::AbstractVectorField)` - Always returns true
+- `has_variable_dependence_trait(vf::AbstractVectorField)` - Always returns true
+
+## Usage Pattern
+
+The typical usage pattern for data structures:
+
+1. Define a vector field function with appropriate signature
+2. Create a `VectorField` or `HamiltonianVectorField` wrapping the function
+3. Specify time and variable dependence via keyword arguments or constructor parameters
+4. The traits are encoded in the type parameters for compile-time dispatch
+5. Vector fields are then used to build systems (see [systems.md](systems.md))
+
+Vector fields serve as the foundational data layer - they encode the dynamics with trait information that propagates through systems, flows, and solutions.
+
+## Source Files
+
+- `src/Data/abstract_vector_field.jl` - Abstract type definition and trait accessors
+- `src/Data/vector_field.jl` - Concrete VectorField implementation
+- `src/Data/hamiltonian_vector_field.jl` - Concrete HamiltonianVectorField implementation
+
+## Test Files
+
+- `test/suite/data/test_abstract_vector_field.jl` - Abstract vector field tests
+- `test/suite/data/test_vector_field.jl` - VectorField tests
+- `test/suite/data/test_hamiltonian_vector_field.jl` - HamiltonianVectorField tests
+
+## See Also
+
+- [traits.md](traits.md) - Trait system overview
+- [systems.md](systems.md) - How vector fields are used to build systems

--- a/reports/CTFlows/flows.md
+++ b/reports/CTFlows/flows.md
@@ -1,0 +1,83 @@
+# Flows
+
+## Overview
+
+The Flows module provides flow types that combine systems with integrators. A flow is a callable object that exposes the integration protocol - it carries no business logic of its own, but serves as the interface for performing ODE integration. Flows inherit traits from their systems, enabling compile-time dispatch throughout the integration process.
+
+## Key Types
+
+### Abstract Types
+
+- `AbstractFlow{TD, VD}` - Abstract base type for all flows with time dependence (TD) and variable dependence (VD) traits
+- `AbstractStateFlow{TD, VD, S}` - Abstract type for state flows (non-Hamiltonian), parameterized by system type S
+- `AbstractHamiltonianFlow{TD, VD, S}` - Abstract type for Hamiltonian flows (state + costate), parameterized by system type S
+
+### Concrete Types
+
+- `Flow{S, I}` - Concrete flow combining a system S with an integrator I
+- `StateFlow{S, I}` - Concrete state flow (alias for Flow with state system)
+- `HamiltonianFlow{S, I}` - Concrete Hamiltonian flow (alias for Flow with Hamiltonian system)
+
+## Traits
+
+Flows inherit their traits from the underlying system:
+
+- **Time Dependence (TD)**: `Autonomous` or `NonAutonomous` - inherited from system
+- **Variable Dependence (VD)**: `Fixed` or `NonFixed` - inherited from system
+
+Trait accessors are implemented at the abstract level:
+- `time_dependence(flow::AbstractFlow)` - Returns the time dependence trait type
+- `variable_dependence(flow::AbstractFlow)` - Returns the variable dependence trait type
+- `has_time_dependence_trait(flow::AbstractFlow)` - Always returns true
+- `has_variable_dependence_trait(flow::AbstractFlow)` - Always returns true
+
+## Usage Pattern
+
+The typical usage pattern for flows:
+
+1. Create a system (see [systems.md](systems.md))
+2. Create an integrator (see [integrators.md](integrators.md))
+3. Build a flow from the system and integrator using `build_flow`
+4. Call the flow to perform integration: `flow(t0, x0, tf)` for state or `flow(t0, x0, p0, tf)` for Hamiltonian
+5. The flow returns a solution (see [solutions.md](solutions.md))
+
+### Contract Methods
+
+All concrete flows must implement:
+
+- `system(flow::AbstractFlow)` - Returns the associated AbstractSystem
+- `integrator(flow::AbstractFlow)` - Returns the associated AbstractIntegrator
+
+### Callable Interface
+
+Flows are callable objects with the following signatures:
+
+- For state flows: `(flow)(t0, x0, tf)` - Integrates from initial state x0 at time t0 to final time tf
+- For Hamiltonian flows: `(flow)(t0, x0, p0, tf)` - Integrates from initial state x0 and costate p0 at time t0 to final time tf
+
+### Building Functions
+
+- `build_flow(system, integrator)` - Constructs a flow from a system and integrator
+
+Flows serve as the integration interface layer - they combine the dynamics (system) with the numerical method (integrator) to provide a callable integration operation.
+
+## Source Files
+
+- `src/Flows/abstract_flow.jl` - Abstract type definitions and contract methods
+- `src/Flows/flow.jl` - Concrete Flow implementation
+- `src/Flows/building.jl` - Flow building functions
+- `src/Flows/calling.jl` - Flow callable interface implementation
+
+## Test Files
+
+- `test/suite/flows/test_abstract_flow.jl` - Abstract flow tests
+- `test/suite/flows/test_flow.jl` - Flow tests
+- `test/suite/flows/test_building.jl` - Flow building tests
+- `test/suite/flows/test_calling.jl` - Flow callable interface tests
+
+## See Also
+
+- [systems.md](systems.md) - System types used in flows
+- [integrators.md](integrators.md) - Integrator types used in flows
+- [solutions.md](solutions.md) - Solution types returned by flows
+- [multiphase.md](multiphase.md) - Multi-phase flow concatenation

--- a/reports/CTFlows/index.md
+++ b/reports/CTFlows/index.md
@@ -1,0 +1,102 @@
+# CTFlows Internal Documentation
+
+This directory contains internal documentation notes for CTFlows, providing a conceptual overview of the package's capabilities. These notes serve as a foundation for future official documentation.
+
+## What is CTFlows?
+
+CTFlows is a Julia package for flow-based integration and optimal control. It provides a modular architecture for building and integrating dynamical systems using flow-based approaches. The package is organized into specialized submodules, with all public symbols accessed via qualified paths (e.g., `CTFlows.Systems.AbstractSystem`).
+
+## Module Architecture
+
+CTFlows is organized into the following submodules (in dependency order):
+
+```
+Common
+  ├── Data
+  ├── Systems
+  ├── Integrators
+  ├── Solutions
+  ├── Flows
+  └── MultiPhase
+```
+
+### Common
+Shared utilities and types, including the trait system (mode traits, content traits, time dependence, variable dependence) and configuration types.
+
+### Data
+Data structures for vector fields and Hamiltonian vector fields with trait-based encoding of properties.
+
+### Systems
+System types and contracts for dynamical systems, including state systems and Hamiltonian systems.
+
+### Integrators
+ODE integrator strategies, integrating with the CTSolvers strategy pattern and SciML ecosystem.
+
+### Solutions
+Solution types and solution building functions for integration results.
+
+### Flows
+Flow types that combine systems with integrators, providing callable interfaces for integration.
+
+### MultiPhase
+Multi-phase flow concatenation and sequential integration with switching times and jumps.
+
+## Concept Documentation
+
+The following documents provide detailed conceptual overviews of each major theme:
+
+- [traits.md](traits.md) - Trait system for compile-time dispatch
+- [data.md](data.md) - Vector field data structures
+- [systems.md](systems.md) - System types and contracts
+- [flows.md](flows.md) - Flow types (system + integrator)
+- [integrators.md](integrators.md) - ODE integrator strategies
+- [solutions.md](solutions.md) - Solution types and accessors
+- [multiphase.md](multiphase.md) - Multi-phase concatenation
+
+## Key Concepts
+
+### Traits
+CTFlows uses a trait system for compile-time dispatch. Traits are empty marker types used as type parameters to encode configuration properties:
+- **Mode traits**: PointTrait (point-to-point integration) vs TrajectoryTrait (full trajectory)
+- **Content traits**: StateTrait (state only) vs HamiltonianTrait (state + costate)
+- **Time dependence**: Autonomous vs NonAutonomous
+- **Variable dependence**: Fixed vs NonFixed
+
+### Data Flow
+The typical workflow in CTFlows follows this pattern:
+
+1. Define a vector field (Data module) with appropriate traits
+2. Build a system from the vector field (Systems module)
+3. Create an integrator (Integrators module)
+4. Build a flow combining system and integrator (Flows module)
+5. Call the flow to integrate and obtain a solution (Solutions module)
+6. Optionally concatenate multiple flows for multi-phase problems (MultiPhase module)
+
+### Trait Inheritance
+Traits propagate through the type hierarchy:
+- Vector fields have time and variable dependence traits
+- Systems inherit traits from their underlying vector fields
+- Flows inherit traits from their systems
+- This enables compile-time dispatch throughout the stack
+
+## Source Files
+
+- Main module: `src/CTFlows.jl`
+- Common: `src/Common/`
+- Data: `src/Data/`
+- Systems: `src/Systems/`
+- Integrators: `src/Integrators/`
+- Solutions: `src/Solutions/`
+- Flows: `src/Flows/`
+- MultiPhase: `src/MultiPhase/`
+
+## Test Files
+
+Test examples demonstrating usage can be found in:
+- `test/suite/common/`
+- `test/suite/data/`
+- `test/suite/systems/`
+- `test/suite/integrators/`
+- `test/suite/solutions/`
+- `test/suite/flows/`
+- `test/suite/multiphase/`

--- a/reports/CTFlows/integrators.md
+++ b/reports/CTFlows/integrators.md
@@ -1,0 +1,73 @@
+# Integrators
+
+## Overview
+
+The Integrators module provides ODE integrator strategies for CTFlows. Integrators are responsible for the numerical solution of ODE systems, wrapping external ODE solver libraries (primarily the SciML ecosystem) and providing a strategy pattern interface consistent with the CTSolvers framework.
+
+## Key Types
+
+### Abstract Types
+
+- `AbstractIntegrator` - Abstract base type for all integrators, inherits from CTSolvers.Strategies.AbstractStrategy
+- `AbstractIntegrationResult` - Abstract type for raw ODE integration results
+
+### Concrete Types
+
+- `SciML{Tag}` - Integrator using SciML ecosystem solvers, parameterized by tag type
+- `SciMLTag` - Tag marking SciML-based integrator implementations
+- `Tsit5Tag` - Tag for Tsit5 (Tsitouras 5) SciML solver
+
+### Result Types
+
+- `SciMLIntegrationResult{S}` - Wrapper for SciML ODE solution objects
+
+## Traits
+
+Integrators do not have trait type parameters like data, systems, or flows. Instead, they are strategy objects that can be configured via their tag types and options. The trait information (time dependence, variable dependence) is carried by the systems and flows that use the integrators.
+
+## Usage Pattern
+
+The typical usage pattern for integrators:
+
+1. Create an integrator using `build_sciml_integrator` or `build_integrator`
+2. The integrator is configured with a tag (e.g., Tsit5Tag) and options
+3. The integrator is combined with a system to create a flow (see [flows.md](flows.md))
+4. When the flow is called, the integrator performs the numerical integration
+5. The integrator returns an integration result that is wrapped in a solution type
+
+### Building Functions
+
+- `build_sciml_integrator(tag; options...)` - Builds a SciML integrator with specified tag and options
+- `build_integrator(tag; options...)` - Generic integrator builder (dispatches based on tag)
+
+### Integration Functions
+
+- `build_problem(system, config)` - Builds an ODE problem from a system and configuration
+- `solve_problem(problem, integrator)` - Solves an ODE problem with an integrator
+- `merge(result1, result2)` - Merges integration results (used in multi-phase contexts)
+
+### Result Accessors
+
+- `final_state(result)` - Extracts the final state from an integration result
+- `times(result)` - Extracts the time points from an integration result
+- `evaluate_at(result, t)` - Evaluates the solution at a specific time
+
+Integrators serve as the numerical method layer - they provide the actual ODE solving capability that is called by flows.
+
+## Source Files
+
+- `src/Integrators/abstract_integrator.jl` - Abstract integrator type definition
+- `src/Integrators/integration_result.jl` - Integration result types and accessors
+- `src/Integrators/sciml.jl` - SciML integrator implementation
+- `src/Integrators/building.jl` - Integrator and problem building functions
+
+## Test Files
+
+- `test/suite/integrators/test_abstract_integrator.jl` - Abstract integrator tests
+- `test/suite/integrators/test_sciml.jl` - SciML integrator tests
+- `test/suite/integrators/test_building.jl` - Integrator building tests
+
+## See Also
+
+- [flows.md](flows.md) - How integrators are combined with systems to create flows
+- [solutions.md](solutions.md) - Solution types that wrap integration results

--- a/reports/CTFlows/multiphase.md
+++ b/reports/CTFlows/multiphase.md
@@ -1,0 +1,120 @@
+# MultiPhase
+
+## Overview
+
+The MultiPhase module provides multi-phase flow concatenation and sequential integration. It enables combining multiple flows with switching times and optional jumps to solve problems where the dynamics change at discrete time points (e.g., control switches, phase transitions). The module implements exact sequential integration, ensuring continuity or specified jumps at phase boundaries.
+
+## Key Types
+
+### Concrete Types
+
+- `MultiPhaseStateFlow{TD, VD, N}` - Multi-phase flow for state systems, parameterized by time dependence (TD), variable dependence (VD), and number of phases (N)
+- `MultiPhaseHamiltonianFlow{TD, VD, N}` - Multi-phase flow for Hamiltonian systems (state + costate), parameterized by time dependence (TD), variable dependence (VD), and number of phases (N)
+
+## Traits
+
+Multi-phase flows inherit traits from their constituent flows:
+
+- **Time Dependence (TD)**: `Autonomous` or `NonAutonomous` - inherited from the flows
+- **Variable Dependence (VD)**: `Fixed` or `NonFixed` - inherited from the flows
+
+All flows in a multi-phase sequence must have compatible traits (same time and variable dependence).
+
+## Usage Pattern
+
+The typical usage pattern for multi-phase flows:
+
+1. Create individual flows for each phase (see [flows.md](flows.md))
+2. Specify switching times between phases
+3. Optionally specify jump functions at phase boundaries
+4. Concatenate flows using the `*` operator
+5. Call the multi-phase flow to perform sequential integration
+6. Access individual phases, switching times, and jumps using accessor functions
+
+### Concatenation Operators
+
+- `flow1 * flow2` - Concatenates two flows (infix operator)
+
+Note: only the `*` operator is implemented for concatenation in CTFlows. The `∘` operator is not defined.
+
+### Accessors
+
+- `n_phases(multi_flow)` - Returns the number of phases
+- `get_flow(multi_flow, i)` - Returns the i-th flow in the sequence
+- `get_switching_time(multi_flow, i)` - Returns the switching time before phase i
+- `get_jump(multi_flow, i)` - Returns the jump function at phase boundary i (if any)
+- `get_flows(multi_flow)` - Returns all flows as a tuple
+- `get_switching_times(multi_flow)` - Returns all switching times as a tuple
+- `get_jumps(multi_flow)` - Returns all jump functions as a tuple
+
+## Algebraic Structure and Associativity
+
+### Left Action (partial) of Phase Insertions on Flows
+
+Let F be the set of flows (including already concatenated multi-phase flows). Let E be the set of phase insertions of the form e = (t, g), (t, j, g) for state flows, or (t, jx, jp, g) for Hamiltonian flows, where t ∈ ℝ is a switching time, g is a flow, and j, jx, jp are jump functions.
+
+Define a partial left action
+
+- f ⋆ e := f * e, with domain restricted by strictly increasing switching times.
+
+If f already contains switching times (t₁ < ⋯ < t_k), then f ⋆ (t, …) is defined only when t > t_k. This is enforced in code by `_check_switching_times_order`; violations raise a `PreconditionError`.
+
+Under this precondition, successive insertions are associative on the left: for e₁ = (t₁, g) and e₂ = (t₂, h) with t₁ < t₂ and both defined for f,
+
+- (f ⋆ e₁) ⋆ e₂ = f ⋆ e₁ ⋆ e₂,
+
+and both sides yield the same multi-phase flow with phases of f, then g at t₁, then h at t₂. Internally, concatenation constructs new flows by concatenating (vcat) the lists of flows, switching-times, and jumps; this operation is associative.
+
+Note that an expression like f ⋆ (e₁ ⋆ e₂) is not meaningful here: E elements are not flows, and there is no binary operation defined on E in this design. Composition is achieved by repeated application of the left action.
+
+### Not a Group Action
+
+This structure is not a group action: E has no inverses and the action is partial due to the time-order precondition. One can view CTFlows as implementing a partial left action of the free monoid of well-formed insertion sequences (monotone times) on flows.
+
+### Why not a Right Action or Non-Associative Variant?
+
+One could imagine a right action semantics where adding (t₂, h) after F = f * (t₁, g) would allow t₂ < t₁ and defer routing to evaluation time (e.g., running f up to t₂, then h, etc.). CTFlows deliberately does not implement this:
+
+- Strictly increasing switching times establish a canonical, evaluation-independent partition of the time axis.
+- This simplifies evaluation/merging and error handling, and avoids time-query–dependent routing.
+- The left-insertion operation remains associative under the monotonicity precondition.
+
+Hence, in CTFlows it is valid to build G = (f * (t₁, g)) * (t₂, h) only when t₂ > t₁. Allowing t₂ < t₁ would require different semantics (non-associative right action or time-dependent dispatch) that CTFlows rejects by design.
+
+### Calling Interface
+
+Multi-phase flows are callable with the same signatures as single-phase flows:
+
+- For state flows: `(multi_flow)(t0, x0, tf)` - Sequentially integrates through all phases
+- For Hamiltonian flows: `(multi_flow)(t0, x0, p0, tf)` - Sequentially integrates through all phases
+
+### Sequential Integration
+
+When a multi-phase flow is called:
+
+1. Integration starts at t0 with initial condition
+2. Each phase is integrated up to its switching time
+3. At each switching time, the jump function (if provided) is applied to the state
+4. The result becomes the initial condition for the next phase
+5. Process continues until final time tf
+6. Results from all phases are merged into a single solution
+
+Multi-phase flows serve as the composition layer - they enable complex multi-stage problems to be expressed as sequences of simpler flows with exact handling of phase transitions.
+
+## Source Files
+
+- `src/MultiPhase/multiphase_flow.jl` - Multi-phase flow type definitions
+- `src/MultiPhase/concatenation.jl` - Concatenation operators and building functions
+- `src/MultiPhase/calling.jl` - Multi-phase flow callable interface
+
+## Test Files
+
+- `test/suite/multiphase/test_multiphase_flow.jl` - Multi-phase flow tests
+- `test/suite/multiphase/test_concatenation.jl` - Concatenation tests
+- `test/suite/multiphase/test_calling.jl` - Multi-phase calling tests
+
+## See Also
+
+- [flows.md](flows.md) - Single-phase flow types
+- [systems.md](systems.md) - System types used in flows
+- [solutions.md](solutions.md) - Solution types returned by multi-phase flows

--- a/reports/CTFlows/solutions.md
+++ b/reports/CTFlows/solutions.md
@@ -1,0 +1,72 @@
+# Solutions
+
+## Overview
+
+The Solutions module provides solution types and solution building functions for CTFlows. Solutions wrap raw ODE integration results and provide semantic accessors for state, costate, and time data. They also support plotting functionality through the RecipesBase interface.
+
+## Key Types
+
+### Abstract Types
+
+- `AbstractIntegrationResult` - Abstract type for raw ODE integration results (defined in Integrators module)
+
+### Concrete Types
+
+- `VectorFieldSolution{R, C}` - Solution type for state-only systems, wrapping an integration result R with configuration C
+- `HamiltonianVectorFieldSolution{R, C}` - Solution type for Hamiltonian systems (state + costate), wrapping an integration result R with configuration C
+
+## Traits
+
+Solution types inherit their trait information from the configuration parameter C. The configuration encodes mode (PointTrait vs TrajectoryTrait) and content (StateTrait vs HamiltonianTrait) traits, which determine what data is stored and how it can be accessed.
+
+## Usage Pattern
+
+The typical usage pattern for solutions:
+
+1. A flow is called to perform integration (see [flows.md](flows.md))
+2. The flow returns an integration result (from the Integrators module)
+3. The integration result is wrapped in a solution type using `build_solution`
+4. Solution accessors provide semantic access to the data:
+   - `state(solution)` - Returns the state trajectory or final state
+   - `costate(solution)` - Returns the costate trajectory or final costate (Hamiltonian only)
+   - `time_grid(solution)` - Returns the time points
+5. Solutions can be plotted using the `plot` function (RecipesBase integration)
+
+### Building Functions
+
+- `build_solution(result, config)` - Constructs a solution from an integration result and configuration
+
+### Accessors
+
+For VectorFieldSolution (state-only):
+- `state(solution)` - Returns state data (trajectory or point depending on mode)
+- `time_grid(solution)` - Returns time grid
+
+For HamiltonianVectorFieldSolution (state + costate):
+- `state(solution)` - Returns state data
+- `costate(solution)` - Returns costate data
+- `time_grid(solution)` - Returns time grid
+
+### Plotting
+
+- `plot(solution)` - Plots the solution using RecipesBase, with automatic handling of state vs Hamiltonian and point vs trajectory modes
+
+Solutions serve as the result layer - they wrap raw integration results in a type-safe, semantically meaningful interface that aligns with the configuration used for integration.
+
+## Source Files
+
+- `src/Solutions/vector_field_solution.jl` - VectorFieldSolution implementation
+- `src/Solutions/hamiltonian_vector_field_solution.jl` - HamiltonianVectorFieldSolution implementation
+- `src/Solutions/building.jl` - Solution building functions
+
+## Test Files
+
+- `test/suite/solutions/test_vector_field_solution.jl` - VectorFieldSolution tests
+- `test/suite/solutions/test_hamiltonian_vector_field_solution.jl` - HamiltonianVectorFieldSolution tests
+- `test/suite/solutions/test_building.jl` - Solution building tests
+
+## See Also
+
+- [flows.md](flows.md) - How flows return integration results
+- [integrators.md](integrators.md) - Integration result types
+- [traits.md](traits.md) - Configuration traits that determine solution structure

--- a/reports/CTFlows/systems.md
+++ b/reports/CTFlows/systems.md
@@ -1,0 +1,74 @@
+# Systems
+
+## Overview
+
+The Systems module provides system types and contracts for dynamical systems in CTFlows. Systems represent fully assembled objects that can be integrated, embedding their own right-hand side (rhs) functions, dimensional metadata, and solution-building logic. Systems inherit traits from their underlying data structures (vector fields), enabling compile-time dispatch throughout the integration stack.
+
+## Key Types
+
+### Abstract Types
+
+- `AbstractSystem{TD, VD}` - Abstract base type for all systems with time dependence (TD) and variable dependence (VD) traits
+- `AbstractStateSystem{TD, VD}` - Abstract type for state systems (non-Hamiltonian)
+- `AbstractHamiltonianSystem{TD, VD}` - Abstract type for Hamiltonian systems (state + costate)
+
+### Concrete Types
+
+- `VectorFieldSystem{VF, TD, VD}` - Concrete system wrapping a VectorField
+- `HamiltonianVectorFieldSystem{VF, TD, VD}` - Concrete system wrapping a HamiltonianVectorField
+
+## Traits
+
+Systems inherit their traits from the underlying vector field data structures:
+
+- **Time Dependence (TD)**: `Autonomous` or `NonAutonomous` - inherited from vector field
+- **Variable Dependence (VD)**: `Fixed` or `NonFixed` - inherited from vector field
+
+Trait accessors are implemented at the abstract level:
+- `time_dependence(sys::AbstractSystem)` - Returns the time dependence trait type
+- `variable_dependence(sys::AbstractSystem)` - Returns the variable dependence trait type
+- `has_time_dependence_trait(sys::AbstractSystem)` - Always returns true
+- `has_variable_dependence_trait(sys::AbstractSystem)` - Always returns true
+
+## Usage Pattern
+
+The typical usage pattern for systems:
+
+1. Create a vector field (see [data.md](data.md))
+2. Build a system from the vector field using `build_system`
+3. The system inherits traits from the vector field
+4. The system provides an `rhs` function for ODE integration
+5. Systems are then combined with integrators to create flows (see [flows.md](flows.md))
+
+### Contract Methods
+
+All concrete systems must implement:
+
+- `rhs(system::AbstractSystem)` - Returns a function `(du, u, p, t) -> nothing` that fills `du` in place with the derivative
+- `rhs_oop(system::AbstractSystem)` - Returns a function `(u, p, t) -> du` for out-of-place operations (used with immutable arrays like StaticArrays)
+
+### Building Functions
+
+- `build_system(vector_field)` - Constructs a system from a vector field, automatically handling trait inheritance
+
+Systems serve as the integration-ready layer - they encapsulate the dynamics in a form suitable for ODE solvers.
+
+## Source Files
+
+- `src/Systems/abstract_system.jl` - Abstract type definitions and contract methods
+- `src/Systems/vector_field_system.jl` - VectorFieldSystem implementation
+- `src/Systems/hamiltonian_vector_field_system.jl` - HamiltonianVectorFieldSystem implementation
+- `src/Systems/building.jl` - System building functions
+
+## Test Files
+
+- `test/suite/systems/test_abstract_system.jl` - Abstract system tests
+- `test/suite/systems/test_vector_field_system.jl` - VectorFieldSystem tests
+- `test/suite/systems/test_hamiltonian_vector_field_system.jl` - HamiltonianVectorFieldSystem tests
+- `test/suite/systems/test_building.jl` - System building tests
+
+## See Also
+
+- [data.md](data.md) - Vector field data structures used to build systems
+- [flows.md](flows.md) - How systems are combined with integrators to create flows
+- [traits.md](traits.md) - Trait system overview

--- a/reports/CTFlows/traits.md
+++ b/reports/CTFlows/traits.md
@@ -1,0 +1,84 @@
+# Traits
+
+## Overview
+
+CTFlows uses a trait system for compile-time dispatch. Traits are empty marker types used as type parameters to encode configuration properties at compile time. Unlike tags (which mark extension implementations), traits encode semantic properties of the configuration itself. All concrete trait types are empty structs with no fields, making them zero-cost at runtime.
+
+The trait pattern enables static dispatch on configuration properties without runtime type checks, providing type stability and performance benefits.
+
+## Key Types
+
+### Abstract Trait Hierarchy
+
+- `AbstractTrait` - Base type for all trait markers
+- `AbstractModeTrait` - Base for mode traits (Point vs Trajectory)
+- `AbstractContentTrait` - Base for content traits (State vs Hamiltonian)
+
+### Mode Traits
+
+- `PointTrait` - Point integration mode (single endpoint evaluation)
+- `TrajectoryTrait` - Trajectory integration mode (full time evolution)
+
+### Content Traits
+
+- `StateTrait` - State content (no costate)
+- `HamiltonianTrait` - Hamiltonian content (state + costate)
+
+### Time Dependence (from CTModels.OCP)
+
+- `Autonomous` - Time-independent dynamics
+- `NonAutonomous` - Time-dependent dynamics
+
+### Variable Dependence (from CTModels.OCP)
+
+- `Fixed` - Fixed parameters (non-variable)
+- `NonFixed` - Variable parameters
+
+### Configuration Types
+
+- `AbstractConfig` - Base configuration type
+- `AbstractPointConfig` - Point-mode configuration base
+- `AbstractTrajectoryConfig` - Trajectory-mode configuration base
+- `StatePointConfig` - State-only point configuration
+- `StateTrajectoryConfig` - State-only trajectory configuration
+- `HamiltonianPointConfig` - Hamiltonian point configuration
+- `HamiltonianTrajectoryConfig` - Hamiltonian trajectory configuration
+
+## Traits
+
+Traits are used as type parameters in abstract configuration types:
+
+- Mode traits (second type parameter): distinguish integration modes
+- Content traits (third type parameter): distinguish content types
+- Time dependence (in data/systems/flows): encode autonomous vs non-autonomous
+- Variable dependence (in data/systems/flows): encode fixed vs non-fixed
+
+## Usage Pattern
+
+Traits are used throughout CTFlows to enable compile-time dispatch:
+
+1. Configuration types use mode and content traits as type parameters to determine storage layout and behavior
+2. Data types (vector fields) use time and variable dependence traits to encode dynamics properties
+3. System types inherit traits from their underlying data structures
+4. Flow types inherit traits from their systems
+5. Trait accessors (e.g., `time_dependence`, `variable_dependence`) extract trait values from types
+
+This enables the compiler to generate specialized code for each trait combination without runtime checks.
+
+## Source Files
+
+- `src/Common/abstract_trait.jl` - Abstract trait definitions and concrete trait types
+- `src/Common/configs.jl` - Configuration type definitions
+- `src/Common/traits.jl` - Trait-related utilities
+
+## Test Files
+
+- `test/suite/common/test_abstract_trait.jl` - Trait type tests
+- `test/suite/common/test_configs.jl` - Configuration type tests
+- `test/suite/common/test_traits.jl` - Trait accessor tests
+
+## See Also
+
+- [data.md](data.md) - How traits are used in vector field data structures
+- [systems.md](systems.md) - How traits propagate to system types
+- [flows.md](flows.md) - How traits propagate to flow types

--- a/reports/inplace.md
+++ b/reports/inplace.md
@@ -1,0 +1,494 @@
+on va ajouter la possibilité de fournir une fonction in-place dans @vector_field.jl#L35-38 @hamiltonian_vector_field.jl#L37-40 .
+
+Il faudra ajouter un trait InPlaceTrait vs OutOfPlaceTrait sous types de @abstract_trait.jl#L51-52. Le trait doit apparaitre je pense dans @abstract_vector_field.jl#L36-37. On pourrait même d'abord créer un sous-types pour cette nouvelle notion de trait : AbstractFunctionPlaceTrait <: AbstractTrait, puis InPlaceTrait <: AbstractFunctionPlaceTrait, etc.
+
+Attention, le nom AbstractFunctionPlaceTrait est moche, il faut trouver autre chose.
+
+A la construction, on peut ajouter un kwarg : inplace = Common.__is_inplace() avec le défaut à false. Ou on peut détecter automatiquement, puisque l'on a dans @vector_field.jl#L71-72 @hamiltonian_vector_field.jl#L73-74 les deux autres traits : autonome et variable. A partir de ces deux traits, on sait quelle doit être la signature de la fonction passée en argument, cf. les signatures naturelles : @hamiltonian_vector_field.jl#L83-87 @vector_field.jl#L81-85. Du coup, on peut faire comme dans SciML et déduire de la signature si la fonction est in-place ou out-of-place.
+
+Ensuite, une fois que l'on a ces nouveaux champs de vecteurs. Il faudra construire des systèmes. @abstract_system.jl#L34-35 : un système n'a pas le trait inplace vs outofplace. 
+
+Remarque : on pourrait faire une vraie notion de trait comme @traits.jl#L1-395 et avoir une fonction has_function_place_trait comme @traits.jl#L87-88 qui renvoie une erreur par défaut, puis pour un VectorField et un HamiltonianVectorField, on crée la fonction qui renvoie true, puis il faut créer des fonctions pour récupérer le trait comme @traits.jl#L113-114 et enfin il faut faire des fonctions sur les types qui ont le trait qui sont générique comme @traits.jl#L201-202 : on aurait is_inplace, is_outofplace (à voir pour les noms).
+
+Revenons aux systèmes. Que le champs de vecteurs soit inplace ou non, il faudra toujours construire un rhs et un rhs_oop@vector_field_system.jl#L33-47 @hamiltonian_vector_field_system.jl#L58-71. C'est juste la construction qui est différente.
+
+Si on a f! inplace et que l'on veut construire rhs_oop, il faut utiliser cet exemple @convert.jl#L35-48 concernant le similar.
+
+De plus, dans certains cas, on aura un u0 @CTFlowsSciML.jl#L571-588 qui ne sera pas mutable, donc quand on va faire @convert.jl#L40-41 , par exemple on va passer d'un SVector à un MVector. Dans ce cas, il faut revenir sur un SVector pour que tout fonctionne : @convert.jl#L43-44 avec @convert.jl#L33-34 . Pour ne pas faire if !ismutable(x) à chaque appel du rhs, on peut faire une version de rhs_oop classique mais on va remplacer le getter @hamiltonian_vector_field_system.jl#L232-235 @vector_field_system.jl#L126-129 en lui ajoutant un argument, is_u0_mutable, et nous on renvoie toujours rhs_oop classique sauf si le système est inplace et que le u0 est non mutable, dans ce cas là, on peut construire de manière lazy le rhs_oop_finalize qui fait en plus @convert.jl#L43-44 à la fin. Pour les deux systèmes bien sûr. Après lazy ou pas, à voir, mais ce n'est pas le cas favorable, car si c'est non mutable, il vaut mieux fournir un système out of place. On pourrait d'ailleurs ajouter un warning. 
+
+Grâce à tout ça, on aura la possiblilité de faire de l'inplace que ce soit avec du mutable ou non, et donc dans les tests, on pourra ajouter des appels de flots (pour les tests d'intégration) sur vecteur, matrice, complexe, StaticArrays, static matrices, etc. Pour les scalaires, ça ne devrait pas marcher mais c'est pas grave car ça n'a pas de sens de donner un f! implace si on fait du scalaire.
+
+Je pense qu'il n'y a pas à toucher au reste du code pour que ça marche.
+
+Fais un plan très détaillé en suivant @plan.md .
+
+---
+
+# In-Place Vector Field Support
+
+Ajouter le support des fonctions in-place (`f!`) dans `VectorField` et `HamiltonianVectorField` via un nouveau trait `AbstractMutabilityTrait` (`InPlace` / `OutOfPlace`), avec détection automatique depuis l'arité de la fonction, puis propager le changement jusqu'aux systèmes et à l'extension SciML.
+
+---
+
+## Ce qui change et pourquoi
+
+**Ajouté :**
+- `AbstractMutabilityTrait <: AbstractTrait`, `InPlace`, `OutOfPlace` dans `Common`
+- Trait accessors `has_mutability_trait`, `mutability_trait`, `is_inplace`, `is_outofplace`
+- Troisième paramètre de type `MD <: AbstractMutabilityTrait` dans `AbstractVectorField`, `VectorField`, `HamiltonianVectorField`
+- Signatures naturelles et uniformes **in-place** pour les deux types de champs de vecteurs
+- Champ `rhs_oop_finalize` dans `VectorFieldSystem` et `HamiltonianVectorFieldSystem`
+- Signature `rhs_oop(sys, is_u0_mutable::Bool = true)`
+
+**Modifié :**
+- Constructeurs `VectorField`/`HamiltonianVectorField` : auto-détection du trait via `first(methods(f)).nargs - 1`
+- Constructeurs des systèmes : deux branches de construction selon `InPlace` ou `OutOfPlace`
+- `CTFlowsSciML.build_problem` : passe `rhs_oop(system, false)` quand `u0` est non-mutable
+
+**Invariant :**
+- `AbstractSystem` ne porte pas le trait mutabilité (le système expose toujours `rhs` + `rhs_oop`)
+- Toutes les APIs existantes restent compatibles (kwarg `is_u0_mutable` default = `true`)
+
+---
+
+## Signatures in-place de référence
+
+### VectorField (`f!` avec dx en premier, arity = oop_arity + 1)
+
+| TD / VD | OOP (existant) | InPlace (nouveau) | Uniforme IP |
+|---|---|---|---|
+| Aut, Fixed | `f(x)` | `f!(dx, x)` | `f!(dx, t, x, v)` |
+| NonAut, Fixed | `f(t, x)` | `f!(dx, t, x)` | `f!(dx, t, x, v)` |
+| Aut, NonFixed | `f(x, v)` | `f!(dx, x, v)` | `f!(dx, t, x, v)` |
+| NonAut, NonFixed | `f(t, x, v)` | `f!(dx, t, x, v)` | (identique au naturel) |
+
+### HamiltonianVectorField (`f!` avec (dx, dp) séparés, arity = oop_arity + 2)
+
+| TD / VD | OOP (existant) | InPlace (nouveau) | Uniforme IP |
+|---|---|---|---|
+| Aut, Fixed | `f(x, p)` | `f!(dx, dp, x, p)` | `f!(dx, dp, t, x, p, v)` |
+| NonAut, Fixed | `f(t, x, p)` | `f!(dx, dp, t, x, p)` | `f!(dx, dp, t, x, p, v)` |
+| Aut, NonFixed | `f(x, p, v)` | `f!(dx, dp, x, p, v)` | `f!(dx, dp, t, x, p, v)` |
+| NonAut, NonFixed | `f(t, x, p, v)` | `f!(dx, dp, t, x, p, v)` | (identique au naturel) |
+
+---
+
+## Graphe de dépendances
+
+```
+Common  (AbstractMutabilityTrait, InPlace, OutOfPlace)
+  └── Data  (AbstractVectorField{TD,VD,MD}, VectorField{F,TD,VD,MD}, HamiltonianVectorField{F,TD,VD,MD})
+        └── Systems  (VectorFieldSystem + rhs_oop_finalize, HamiltonianVectorFieldSystem)
+              └── ext/CTFlowsSciML  (build_problem: rhs_oop(system, false))
+```
+
+---
+
+## Step 0 — Branche
+
+```bash
+git checkout develop && git pull
+git checkout -b feat/inplace-vector-field
+```
+
+---
+
+## Phase 1 — Common : nouveau trait
+
+### Step 1 — `src/Common/abstract_trait.jl` (modifié)
+
+> 🏗️ Follow `modules.md` — ajouter après `AbstractContentTrait`, avant les structs concrètes de config
+> 📋 Follow `architecture.md` — SRP : la seule responsabilité est la déclaration de l'abstraction
+
+- Ajouter `abstract type AbstractMutabilityTrait <: AbstractTrait end`
+- Ajouter `struct InPlace <: AbstractMutabilityTrait end`
+- Ajouter `struct OutOfPlace <: AbstractMutabilityTrait end`
+- Mettre à jour le docstring de `AbstractTrait` pour mentionner `AbstractMutabilityTrait`
+
+> ⛔ Pas de docstrings complets — `# TODO: docstring` uniquement sur les nouvelles déclarations.
+
+---
+
+### Step 2 — `src/Common/traits.jl` (modifié)
+
+> 🏗️ Follow `modules.md` — même style que `VariableDependence` / `Fixed` / `NonFixed`
+> ⚠️ Follow `exceptions.md` — fallbacks → `IncorrectArgument` / `NotImplemented`
+
+- Mettre à jour `_caller_function_name` : ajouter `"has_mutability_trait"` dans la liste des noms à ignorer (comme `has_time_dependence_trait` et `has_variable_dependence_trait`)
+- Ajouter `has_mutability_trait(obj::Any)` → `Exceptions.IncorrectArgument` (fallback, même patron que `has_time_dependence_trait`)
+- Ajouter `mutability_trait(obj::Any)` → `Exceptions.NotImplemented` (fallback)
+- Ajouter `is_inplace(obj::Any)` : appelle `has_mutability_trait(obj)`, puis `mutability_trait(obj) === InPlace`
+- Ajouter `is_outofplace(obj::Any)` : appelle `has_mutability_trait(obj)`, puis `mutability_trait(obj) === OutOfPlace`
+- Ajouter `is_inplace(::Type{InPlace}) = true`, `is_inplace(::Type{OutOfPlace}) = false`
+- Ajouter `is_outofplace(::Type{InPlace}) = false`, `is_outofplace(::Type{OutOfPlace}) = true`
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 3 — `src/Common/Common.jl` (modifié)
+
+> 🏗️ Follow `modules.md` — exports en fin de manifest, dans la section `export`
+
+- Exporter `AbstractMutabilityTrait`, `InPlace`, `OutOfPlace`
+- Exporter `has_mutability_trait`, `mutability_trait`
+- Exporter `is_inplace`, `is_outofplace`
+
+---
+
+### Step 4 — Test Checkpoint : Common mutability trait
+
+> 🧪 Follow `testing-creation.md` — structs fakes au top-level, séparation unit/contract/error
+> ▶️ Follow `testing-execution.md`
+
+Modifier `test/suite/common/test_traits.jl` :
+
+- Au top-level : `struct FakeInPlace end`, `struct FakeOutOfPlace end`, `struct FakeNoMutability end`
+- Implémenter `Common.has_mutability_trait(::FakeInPlace) = true`, `Common.mutability_trait(::FakeInPlace) = Common.InPlace` (et idem pour `FakeOutOfPlace`)
+- `@testset "Mutability Trait"` :
+  - `InPlace <: Common.AbstractMutabilityTrait` → true
+  - `OutOfPlace <: Common.AbstractMutabilityTrait` → true
+  - `Common.is_inplace(FakeInPlace())` → true
+  - `Common.is_outofplace(FakeInPlace())` → false
+  - `Common.is_inplace(FakeOutOfPlace())` → false
+  - `Common.is_inplace(FakeNoMutability())` → throws `IncorrectArgument`
+  - `Common.mutability_trait(FakeNoMutability())` → throws `NotImplemented`
+
+Modifier `test/suite/common/test_abstract_trait.jl` :
+- Vérifier `AbstractMutabilityTrait <: Common.AbstractTrait`
+- Vérifier `InPlace <: Common.AbstractMutabilityTrait`
+- Vérifier `OutOfPlace <: Common.AbstractMutabilityTrait`
+
+```bash
+julia --project -e 'using Pkg; Pkg.test("CTFlows"; test_args=["suite/common/test_traits"])' \
+  2>&1 | tee /tmp/ctflows_trait.log
+grep -E "Error|Fail|Test Summary" /tmp/ctflows_trait.log
+```
+
+---
+
+## Phase 2 — Data : nouveau paramètre de type MD
+
+### Step 5 — `src/Data/abstract_vector_field.jl` (modifié)
+
+> 📋 Follow `architecture.md` — OCP : extension sans modification du patron de dispatch existant
+> 🏗️ Follow `modules.md` — utiliser `Common.AbstractMutabilityTrait` qualifié
+
+- Changer `AbstractVectorField{TD<:Common.TimeDependence, VD<:Common.VariableDependence}` en `AbstractVectorField{TD<:Common.TimeDependence, VD<:Common.VariableDependence, MD<:Common.AbstractMutabilityTrait}`
+- Ajouter `Common.has_mutability_trait(::AbstractVectorField) = true`
+- Ajouter `function Common.mutability_trait(vf::AbstractVectorField{<:Common.TimeDependence, <:Common.VariableDependence, MD}) where {MD} = MD`
+- Mettre à jour les extracteurs existants `time_dependence`/`variable_dependence` (signature inchangée, juste le param MD ajouté comme wildcard)
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 6 — `src/Data/vector_field.jl` (modifié)
+
+> 📋 Follow `architecture.md` — OCP : nouvelles méthodes par dispatch, pas de if/elseif sur le type
+> 🏗️ Follow `modules.md` — imports qualifiés ; `Autonomous`, `NonAutonomous`, `Fixed`, `NonFixed` déjà en scope via `using ..Common`
+
+- Changer `VectorField{F<:Function, TD<:TimeDependence, VD<:VariableDependence}` en `VectorField{F<:Function, TD<:TimeDependence, VD<:VariableDependence, MD<:Common.AbstractMutabilityTrait}`
+- Ajouter les fonctions internes `_oop_arity_vf(::Type{Autonomous}, ::Type{Fixed}) = 1` etc. (4 méthodes)
+- Ajouter `_detect_mutability_vf(f::Function, TD, VD)` : lit `first(methods(f)).nargs - 1`, compare à `oop_arity` et `oop_arity + 1`, lève `Exceptions.IncorrectArgument` si ambigu
+- Mettre à jour le constructeur `VectorField(f; is_autonomous, is_variable)` : appelle `_detect_mutability_vf(f, TD, VD)` pour déterminer `MD`
+- Ajouter les signatures naturelles **in-place** (`(dx, x)`, `(dx, t, x)`, `(dx, x, v)`, `(dx, t, x, v)`) sur `VectorField{<:Function, TD, VD, InPlace}`
+- Ajouter le call **uniforme in-place** `(dx, t, x, v)` pour les 3 combinaisons non-triviales de `InPlace`
+- Mettre à jour `Base.show` pour afficher `MD` (ex : `mutability: InPlace`)
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 7 — `src/Data/hamiltonian_vector_field.jl` (modifié)
+
+> Même patrons que Step 6, avec les spécificités HVF
+
+- Changer `HamiltonianVectorField{F, TD, VD}` en `HamiltonianVectorField{F, TD, VD, MD<:Common.AbstractMutabilityTrait}`
+- Ajouter `_oop_arity_hvf(TD, VD)` (4 méthodes : oop_arity = 2, 3, 3, 4)
+- Ajouter `_detect_mutability_hvf(f, TD, VD)` : compare à `oop_arity` (OOP) et `oop_arity + 2` (InPlace)
+- Mettre à jour le constructeur `HamiltonianVectorField(f; is_autonomous, is_variable)`
+- Ajouter les signatures naturelles in-place : `(dx, dp, x, p)`, `(dx, dp, t, x, p)`, `(dx, dp, x, p, v)`, `(dx, dp, t, x, p, v)`
+- Ajouter le call uniforme in-place `(dx, dp, t, x, p, v)` pour les 3 combinaisons non-triviales
+- Mettre à jour `Base.show` pour afficher `MD`
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 8 — Test Checkpoint : Data module
+
+> 🧪 Follow `testing-creation.md` — structs fakes au top-level, isolation
+
+Modifier `test/suite/data/test_vector_field.jl` :
+- `@testset "InPlace VectorField"` :
+  - Construire `VectorField((dx, x) -> (dx .= -x; nothing))` → `is_inplace(vf) == true`, `Common.mutability_trait(vf) === InPlace`
+  - Construire `VectorField(x -> -x)` → `is_outofplace(vf) == true`
+  - Tester le call naturel : `vf(dx, x)` remplit `dx` in-place
+  - Tester le call uniforme : `vf(dx, 0.0, x, nothing)` remplit `dx`
+  - Tester l'erreur sur arité incorrecte : `VectorField((a, b, c) -> nothing)` → `IncorrectArgument`
+  - Tester pour les 4 combinaisons (TD, VD)
+
+Modifier `test/suite/data/test_hamiltonian_vector_field.jl` :
+- `@testset "InPlace HamiltonianVectorField"` :
+  - `HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p; nothing))` → `is_inplace(hvf) == true`
+  - Call naturel et uniforme
+  - Arité incorrecte → `IncorrectArgument`
+  - 4 combinaisons (TD, VD)
+
+Modifier `test/suite/data/test_abstract_vector_field.jl` :
+- `Common.has_mutability_trait(vf)` → true pour `VectorField` et `HamiltonianVectorField`
+- `Common.mutability_trait(vf)` retourne le bon type
+
+```bash
+julia --project -e 'using Pkg; Pkg.test("CTFlows"; test_args=["suite/data"])' \
+  2>&1 | tee /tmp/ctflows_data.log
+grep -E "Error|Fail|Test Summary" /tmp/ctflows_data.log
+```
+
+---
+
+## Phase 3 — Systems : rhs_oop_finalize
+
+### Step 9 — `src/Systems/vector_field_system.jl` (modifié)
+
+> 📋 Follow `architecture.md` — OCP : dispatch sur `MD` (OutOfPlace/InPlace), pas de if dans le constructeur
+> 🏗️ Follow `modules.md` — `Common.InPlace`, `Common.OutOfPlace` qualifiés
+
+**Design `rhs_oop_finalize` :**
+
+- `rhs_oop_finalize::FINRHS` où **`FINRHS = Nothing` pour OOP VF** (finalize n'a pas de sens), et **`FINRHS = <closure>` pour InPlace VF** (construit eagerly)
+- La dispatch sur `MD` rend l'accessor `rhs_oop` type-stable sans `isnothing` au runtime
+
+**Struct :**
+
+```julia
+struct VectorFieldSystem{F, TD, VD, MD, RHS, OOPROHS, FINRHS} <: AbstractStateSystem{TD, VD}
+    vf::Data.VectorField{F, TD, VD, MD}
+    rhs::RHS
+    rhs_oop::OOPROHS          # correct pour u0 mutable (InPlace) ou tout u0 (OOP)
+    rhs_oop_finalize::FINRHS  # nothing (OOP) ou closure avec typeof(u)(dx) (InPlace)
+end
+```
+
+**Helpers internes :**
+- `_build_ip_rhs_vf(vf)` → `(du, u, λ, t) -> (vf(du, t, u, λ.variable); nothing)` (uniform IP call)
+- `_build_oop_rhs_vf_ip(vf)` → `(u, λ, t) -> (dx = similar(u); vf(dx, t, u, λ.variable); dx)` (retourne dx, correct pour mutable)
+- `_build_finalize_rhs_vf_ip(vf)` → `(u, λ, t) -> (dx = similar(u); vf(dx, t, u, λ.variable); typeof(u)(dx))` (correct pour immutable)
+
+**Deux constructeurs dispatching sur `MD` :**
+- `VectorFieldSystem(vf::Data.VectorField{F, TD, VD, Common.OutOfPlace})` : `rhs` inchangé (OOP call), `rhs_oop` = OOP call, `rhs_oop_finalize = nothing`
+- `VectorFieldSystem(vf::Data.VectorField{F, TD, VD, Common.InPlace})` : `rhs` via `_build_ip_rhs_vf`, `rhs_oop` via `_build_oop_rhs_vf_ip`, `rhs_oop_finalize` via `_build_finalize_rhs_vf_ip`
+
+**Deux méthodes `rhs_oop` dispatching sur `MD` (type-stable) :**
+
+```julia
+# OOP VF : FINRHS = Nothing — rhs_oop est toujours correct, ignorer is_u0_mutable
+function rhs_oop(sys::VectorFieldSystem{F,TD,VD,Common.OutOfPlace,RHS,OOPROHS,Nothing},
+                 ::Bool = true) where {F,TD,VD,RHS,OOPROHS}
+    return sys.rhs_oop
+end
+
+# InPlace VF : retourner finalize + warning si u0 immutable
+function rhs_oop(sys::VectorFieldSystem{F,TD,VD,Common.InPlace,RHS,OOPROHS,FINRHS},
+                 is_u0_mutable::Bool = true) where {F,TD,VD,RHS,OOPROHS,FINRHS}
+    is_u0_mutable && return sys.rhs_oop
+    @warn "InPlace VectorField with immutable u0 (e.g. SVector): consider using an out-of-place function for better performance." maxlog=1
+    return sys.rhs_oop_finalize
+end
+```
+
+- Mettre à jour `Base.show` pour afficher `MD` (mutability)
+- Mettre à jour `src/Systems/abstract_system.jl` : changer la signature du fallback `rhs_oop(sys::AbstractSystem)` en `rhs_oop(sys::AbstractSystem, ::Bool = true)` pour cohérence avec la nouvelle API
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 10 — `src/Systems/hamiltonian_vector_field_system.jl` (modifié)
+
+> Même design que Step 9 : `FINRHS = Nothing` pour OOP HVF, closure eagerly built pour InPlace HVF
+
+**Helpers InPlace HVF :**
+- `_build_rhs_hvf_ip(hvf, ::Val{N})` — splite `u` **et** `du` via `_ham_split`, passe les views à `hvf!(dx_view, dp_view, t, x, p, v)` :
+  ```julia
+  (du, u, λ, t) -> begin
+      x, p   = _ham_split(u,  N)
+      dx, dp = _ham_split(du, N)           # views mutables dans du
+      hvf(dx, dp, t, x, p, λ.variable)    # uniform IP call, remplit dx et dp
+      return nothing
+  end
+  ```
+- `_build_oop_rhs_hvf_ip(hvf, ::Val{N})` — alloue dx/dp séparément, vcat final :
+  ```julia
+  (u, λ, t) -> begin
+      x, p       = _ham_split(u, N)
+      dx, dp     = similar(x), similar(p)
+      hvf(dx, dp, t, x, p, λ.variable)
+      return vcat(dx, dp)
+  end
+  ```
+- `_build_finalize_rhs_hvf_ip(hvf, ::Val{N})` — idem + `typeof(u)` conversion :
+  ```julia
+  (u, λ, t) -> begin
+      x, p       = _ham_split(u, N)
+      dx, dp     = similar(x), similar(p)
+      hvf(dx, dp, t, x, p, λ.variable)
+      return typeof(u)(vcat(dx, dp))
+  end
+  ```
+
+**Deux constructeurs** pour chaque dimension (`n_state::Int` et `nothing`), dispatching sur `OutOfPlace`/`InPlace`.
+
+**Deux méthodes `rhs_oop`** avec la même logique que Step 9 (dispatch sur `Common.OutOfPlace`/`Common.InPlace`, warning dans la branche InPlace + `is_u0_mutable=false`).
+
+Mise à jour de `Base.show`.
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 11 — Test Checkpoint : Systems module
+
+> 🧪 Follow `testing-creation.md`
+
+Modifier `test/suite/systems/test_vector_field_system.jl` :
+- `@testset "InPlace VectorFieldSystem"` :
+  - Construire `VectorFieldSystem(VectorField((dx, x) -> (dx .= -x; nothing)))` → sans erreur
+  - `rhs` fonctionne : `rhs!(du, u, p, t)` remplit correctement `du`
+  - `rhs_oop(sys)` fonctionne : retourne une valeur pour u mutable
+  - `rhs_oop(sys, true)` (mutable) retourne `Vector`
+  - `rhs_oop(sys, false)` (immutable) : appeler sur un `SVector` → retourne un `SVector`
+  - 4 combinaisons (TD, VD)
+
+Modifier `test/suite/systems/test_hamiltonian_vector_field_system.jl` :
+- Analogues pour `HamiltonianVectorFieldSystem` avec InPlace HVF
+- Tester `_ham_split` sur `du` pour les views mutables
+- Tester `rhs_oop(sys, false)` avec un `SVector` combiné
+
+```bash
+julia --project -e 'using Pkg; Pkg.test("CTFlows"; test_args=["suite/systems"])' \
+  2>&1 | tee /tmp/ctflows_systems.log
+grep -E "Error|Fail|Test Summary" /tmp/ctflows_systems.log
+```
+
+---
+
+## Phase 4 — Extension SciML
+
+### Step 12 — `ext/CTFlowsSciML.jl` (modifié)
+
+> 🏗️ Follow `modules.md` — appel qualifié `Systems.rhs_oop`
+
+Dans `Integrators.build_problem`, branche `!ismutable(u0)` :
+- Remplacer `f = Systems.rhs_oop(system)` par `f = Systems.rhs_oop(system, false)`
+
+Cela suffit : pour OOP VF, `rhs_oop(system, false)` retourne `rhs_oop` (identique à l'ancien comportement). Pour InPlace VF + u0 immutable, retourne `rhs_oop_finalize` + émet le `@warn` (côté système, Step 9).
+
+> ⛔ Pas de docstrings complets.
+
+---
+
+### Step 13 — Test Checkpoint : Extension SciML
+
+> 🧪 Follow `testing-creation.md`
+
+Modifier `test/suite/extensions/test_sciml_extension.jl` ou `test_flow_callables_sciml.jl` :
+- `@testset "InPlace VF — SciML integration"` :
+  - Intégration avec `VectorField((dx, x) -> dx .= -x)` (mutable `Vector{Float64}`) → même résultat que OOP
+  - Intégration avec `VectorField((dx, x) -> dx .= -x)` + `u0 = @SVector [1.0, 2.0]` → résultat `SVector` correct
+  - Analogues pour `HamiltonianVectorFieldSystem` avec InPlace HVF
+- Vérifier la présence du warning `@test_logs (:warn, r"InPlace")` pour le cas SVector + InPlace
+
+```bash
+julia --project -e 'using Pkg; Pkg.test("CTFlows"; test_args=["suite/extensions/test_sciml_extension"])' \
+  2>&1 | tee /tmp/ctflows_sciml.log
+grep -E "Error|Fail|Test Summary" /tmp/ctflows_sciml.log
+```
+
+---
+
+## Step 14 — Docstrings (tous les fichiers modifiés)
+
+> 📚 Follow `docstrings.md` — `$(TYPEDEF)` / `$(TYPEDSIGNATURES)`, sections `# Arguments`, `# Returns`, `# Throws`, `# Example`, cross-refs `[@ref]`
+
+Écrire ou mettre à jour les docstrings pour chaque symbole nouveau ou modifié.
+
+### Localisation du design SciML (mutable/immutable u0)
+
+La documentation du pattern `rhs` / `rhs_oop` / `rhs_oop_finalize` est répartie ainsi :
+
+**`src/Systems/abstract_system.jl` — `AbstractSystem` (docstring du type)** : endroit central pour expliquer le contrat global :
+- Pourquoi deux accesseurs coexistent : `rhs` pour u0 mutable (SciML in-place), `rhs_oop` pour u0 immutable (SciML OOP)
+- Le pattern général : SciML choisit le callable selon `ismutable(u0)`
+- La distinction InPlace/OutOfPlace VF et son impact sur `rhs_oop_finalize`
+
+**`rhs_oop(sys, is_u0_mutable)` (méthodes concrètes sur `VectorFieldSystem` et `HamiltonianVectorFieldSystem`)** : docstring détaillée sur :
+- Signification du paramètre `is_u0_mutable` (`true` = u0 mutable, `false` = u0 immutable)
+- Comportement selon le trait : OOP VF ignore le paramètre ; InPlace VF retourne `rhs_oop_finalize` + warning si `false`
+- Note de performance : InPlace VF + SVector est non-optimal, recommander OOP VF
+- Cross-ref vers `rhs` et `AbstractSystem`
+
+**`rhs(sys)` (méthodes concrètes)** : note brève — *"Returns the in-place callable for use with mutable initial conditions in SciML. For immutable u0 (e.g. SVector), use `rhs_oop`."*
+
+### Liste complète des symboles à documenter
+
+- `src/Common/abstract_trait.jl` — `AbstractMutabilityTrait`, `InPlace`, `OutOfPlace`
+- `src/Common/traits.jl` — `has_mutability_trait`, `mutability_trait`, `is_inplace`, `is_outofplace` (toutes les surcharges)
+- `src/Data/abstract_vector_field.jl` — `AbstractVectorField` (nouveau param), `has_mutability_trait`, `mutability_trait`
+- `src/Data/vector_field.jl` — `VectorField` (nouveau param, nouvelles calls), constructeur, `_detect_mutability_vf`, calls IP, `Base.show`
+- `src/Data/hamiltonian_vector_field.jl` — analogues
+- `src/Systems/abstract_system.jl` — `AbstractSystem` : design global `rhs`/`rhs_oop`, pattern SciML mutable/immutable, InPlace/OOP VF
+- `src/Systems/vector_field_system.jl` — `VectorFieldSystem` (nouveau champ), `rhs` (note SciML), `rhs_oop` (paramètre + finalize + warning), helpers internes
+- `src/Systems/hamiltonian_vector_field_system.jl` — analogues
+- `ext/CTFlowsSciML.jl` — `build_problem` (comportement étendu)
+
+---
+
+## Step 15 — Run all tests
+
+> ▶️ Follow `testing-execution.md`
+
+```bash
+julia --project -e 'using Pkg; Pkg.test("CTFlows")' 2>&1 | tee /tmp/ctflows_inplace_final.log
+grep -E "Error|Fail|Test Summary" /tmp/ctflows_inplace_final.log
+```
+
+**Attendu** : toutes les suites passent, zéro failure, zéro error.
+
+---
+
+## Files summary
+
+**New :** aucun fichier créé.
+
+**Modified :**
+- `src/Common/abstract_trait.jl` — `AbstractMutabilityTrait`, `InPlace`, `OutOfPlace`  (`architecture.md`)
+- `src/Common/traits.jl` — `has_mutability_trait`, `mutability_trait`, `is_inplace`, `is_outofplace`, update `_caller_function_name`  (`modules.md`, `exceptions.md`)
+- `src/Common/Common.jl` — exports  (`modules.md`)
+- `src/Data/abstract_vector_field.jl` — troisième param `MD`, accessors  (`architecture.md`)
+- `src/Data/vector_field.jl` — param `MD`, auto-detect, calls IP  (`architecture.md`, `modules.md`)
+- `src/Data/hamiltonian_vector_field.jl` — idem  (`architecture.md`, `modules.md`)
+- `src/Systems/vector_field_system.jl` — champ `rhs_oop_finalize`, constructeurs IP/OOP, `rhs_oop(sys, bool)`  (`architecture.md`)
+- `src/Systems/hamiltonian_vector_field_system.jl` — idem  (`architecture.md`)
+- `ext/CTFlowsSciML.jl` — `rhs_oop(system, false)` + warning  (`modules.md`)
+- `test/suite/common/test_abstract_trait.jl` — `AbstractMutabilityTrait` tests  (`testing-creation.md`)
+- `test/suite/common/test_traits.jl` — mutability trait tests  (`testing-creation.md`)
+- `test/suite/data/test_abstract_vector_field.jl` — mutability accessor tests  (`testing-creation.md`)
+- `test/suite/data/test_vector_field.jl` — InPlace VF tests  (`testing-creation.md`)
+- `test/suite/data/test_hamiltonian_vector_field.jl` — InPlace HVF tests  (`testing-creation.md`)
+- `test/suite/systems/test_vector_field_system.jl` — InPlace system tests  (`testing-creation.md`)
+- `test/suite/systems/test_hamiltonian_vector_field_system.jl` — InPlace system tests  (`testing-creation.md`)
+- `test/suite/extensions/test_sciml_extension.jl` — intégration InPlace  (`testing-creation.md`)
+
+**Deleted :** aucun.
+
+---
+
+## Notes de design
+
+- **Détection auto** : `first(methods(f)).nargs - 1` donne l'arité positionnelle. Si `f` a plusieurs méthodes avec des arités différentes, `first` prend la plus récente/spécifique. Cas ambigu → `IncorrectArgument`.
+- **HVF InPlace** : `f!(dx, dp, x, p, ...)` (sorties séparées, +2 args). Le RHS SciML splite `u` et `du` en views via `_ham_split`.
+- **rhs_oop_finalize** : pour InPlace VF + u0 immutable (SVector), retourne `typeof(u)(dx)` pour convertir MVector → SVector. Pour OOP VF : `rhs_oop_finalize = rhs_oop` (même objet, pas de surcoût).
+- **Warning** : émis dans `rhs_oop(sys, false)` quand le VF est InPlace, pour guider vers l'usage OOP.
+- **Scalaires** : non supportés pour InPlace (pas de sens pour `similar(scalar)`). Aucune modification n'est nécessaire ; l'erreur viendra naturellement de `similar`.

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -39,14 +39,17 @@ include(joinpath(@__DIR__, "internal_norm.jl"))
 @reexport import CTModels.OCP: is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable
 
 export AbstractTag
-export AbstractTrait, AbstractModeTrait, AbstractContentTrait, PointTrait, TrajectoryTrait, StateTrait, HamiltonianTrait
+export AbstractTrait, AbstractModeTrait, AbstractContentTrait, AbstractMutabilityTrait
+export PointTrait, TrajectoryTrait, StateTrait, HamiltonianTrait
+export InPlace, OutOfPlace
 export AbstractConfig, AbstractPointConfig, AbstractTrajectoryConfig, AbstractStateConfig, AbstractHamiltonianConfig
 export StatePointConfig, StateTrajectoryConfig, HamiltonianPointConfig, HamiltonianTrajectoryConfig
 export tspan, initial_condition, initial_state, initial_costate
 export VariableDependence, Fixed, NonFixed
 export ODEParameters
-export has_time_dependence_trait, has_variable_dependence_trait
-export time_dependence, variable_dependence
+export has_time_dependence_trait, has_variable_dependence_trait, has_mutability_trait
+export time_dependence, variable_dependence, mutability_trait
+export is_inplace, is_outofplace
 export __is_autonomous, __is_variable, __variable, __unsafe
 export deepvalue, real_norm
 

--- a/src/Common/abstract_trait.jl
+++ b/src/Common/abstract_trait.jl
@@ -6,7 +6,7 @@ Abstract base type for trait markers in CTFlows.
 Traits are empty marker types used as type parameters to encode configuration
 properties at compile time. Unlike tags (which mark extension implementations),
 traits encode semantic properties of the configuration itself (e.g., integration
-mode, content type).
+mode, content type, mutability).
 
 # Trait Pattern
 
@@ -35,7 +35,7 @@ true
 julia> PointTrait <: Common.AbstractModeTrait
 true
 
-julia> # Used as type parameter in configs:
+julia> # Used as type parameters in configs:
 julia> StatePointConfig <: Common.AbstractConfig{<:Any, PointTrait, StateTrait}
 true
 \`\`\`
@@ -46,7 +46,7 @@ true
 - All trait types have zero runtime overhead (empty structs)
 - The trait pattern enables static dispatch on configuration properties
 
-See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.AbstractModeTrait`](@ref), [`CTFlows.Common.AbstractContentTrait`](@ref).
+See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.AbstractModeTrait`](@ref), [`CTFlows.Common.AbstractContentTrait`](@ref), [`CTFlows.Common.AbstractMutabilityTrait`](@ref).
 """
 abstract type AbstractTrait end
 
@@ -119,6 +119,85 @@ true
 See also: [`CTFlows.Common.StateTrait`](@ref), [`CTFlows.Common.HamiltonianTrait`](@ref), [`CTFlows.Common.AbstractConfig`](@ref).
 """
 abstract type AbstractContentTrait <: AbstractTrait end
+
+# =============================================================================
+# Mutability traits (in-place vs out-of-place function evaluation)
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Abstract trait for mutability characteristics of function evaluation.
+
+Distinguishes between in-place functions (which modify a pre-allocated buffer)
+and out-of-place functions (which allocate and return new results).
+
+Subtypes must implement:
+- `InPlace`: For functions that write to a mutable buffer
+- `OutOfPlace`: For functions that return newly allocated results
+
+# Example
+\`\`\`julia-repl
+julia> using CTFlows.Common
+
+julia> InPlace() isa AbstractMutabilityTrait
+true
+
+julia> OutOfPlace() isa AbstractMutabilityTrait
+true
+\`\`\`
+
+See also: [`CTFlows.Common.InPlace`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
+"""
+abstract type AbstractMutabilityTrait <: AbstractTrait end
+
+"""
+$(TYPEDEF)
+
+Trait for in-place function evaluation.
+
+Indicates that a function modifies a pre-allocated buffer passed as an argument,
+rather than allocating and returning a new result. This pattern is used for
+performance-critical code where avoiding allocations is important.
+
+# Example
+\`\`\`julia-repl
+julia> using CTFlows.Common
+
+julia> ip = InPlace()
+InPlace()
+
+julia> ip isa AbstractMutabilityTrait
+true
+\`\`\`
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
+"""
+struct InPlace <: AbstractMutabilityTrait end
+
+"""
+$(TYPEDEF)
+
+Trait for out-of-place function evaluation.
+
+Indicates that a function allocates and returns a new result, rather than
+modifying a pre-allocated buffer. This is the default pattern in Julia and
+is suitable for most use cases.
+
+# Example
+\`\`\`julia-repl
+julia> using CTFlows.Common
+
+julia> oop = OutOfPlace()
+OutOfPlace()
+
+julia> oop isa AbstractMutabilityTrait
+true
+\`\`\`
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.InPlace`](@ref).
+"""
+struct OutOfPlace <: AbstractMutabilityTrait end
 
 # =============================================================================
 # Concrete mode tags

--- a/src/Common/traits.jl
+++ b/src/Common/traits.jl
@@ -57,7 +57,8 @@ function _caller_function_name()
         if func_str != "_caller_function_name" &&
            !startswith(func_str, "#") &&
            func_str != "has_time_dependence_trait" &&
-           func_str != "has_variable_dependence_trait"
+           func_str != "has_variable_dependence_trait" &&
+           func_str != "has_mutability_trait"
             return func_name
         end
     end
@@ -175,6 +176,65 @@ function variable_dependence(obj::Any)
 end
 
 # =============================================================================
+# Mutability trait functions
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Check if the object has the mutability trait.
+
+This fallback method throws an error indicating the object does not support
+mutability queries. Concrete types that have the trait should implement
+`has_mutability_trait(obj::MyType) = true`.
+
+The calling function name is automatically detected from the stacktrace
+for better error messages.
+
+# Arguments
+- `obj::Any`: The object to check.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): Always, indicating the object does not have the trait.
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.mutability_trait`](@ref).
+"""
+function has_mutability_trait(obj::Any)
+    source_method = _caller_function_name()
+    throw(Exceptions.IncorrectArgument(
+        "Cannot call $(source_method) on object of type $(typeof(obj)): no mutability trait";
+        suggestion = "Implement has_mutability_trait(obj::$(typeof(obj))) = true and mutability_trait(obj::$(typeof(obj))) to enable mutability trait support.",
+        context = "Mutability trait not available",
+    ))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the mutability trait value for the object.
+
+This fallback method throws an error indicating the method is not implemented.
+Concrete types that have the trait should implement `mutability_trait(obj::MyType)`
+to return the specific trait value (`InPlace` or `OutOfPlace`).
+
+# Arguments
+- `obj::Any`: The object to query.
+
+# Throws
+- [`CTBase.Exceptions.NotImplemented`](@extref): Always, indicating the method must be implemented.
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.has_mutability_trait`](@ref).
+"""
+function mutability_trait(obj::Any)
+    throw(Exceptions.NotImplemented(
+        "mutability_trait not implemented for $(typeof(obj))";
+        required_method = "mutability_trait(obj::$(typeof(obj)))",
+        suggestion = "Implement mutability_trait for your concrete object type to return the specific mutability trait (InPlace or OutOfPlace).",
+        context = "Mutability trait - required method implementation",
+    ))
+end
+
+# =============================================================================
 # Trait accessors
 # =============================================================================
 
@@ -200,7 +260,7 @@ See also: [`CTModels.OCP.TimeDependence`](@extref), [`CTFlows.Common.time_depend
 """
 function OCP.is_autonomous(obj::Any)
     has_time_dependence_trait(obj)
-    return OCP.is_autonomous(time_dependence(obj))
+    return time_dependence(obj) === OCP.Autonomous
 end
 
 """
@@ -225,7 +285,7 @@ See also: [`CTModels.OCP.TimeDependence`](@extref), [`CTFlows.Common.time_depend
 """
 function OCP.is_nonautonomous(obj::Any)
     has_time_dependence_trait(obj)
-    return OCP.is_nonautonomous(time_dependence(obj))
+    return time_dependence(obj) === OCP.NonAutonomous
 end
 
 """
@@ -250,7 +310,7 @@ See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.variable
 """
 function OCP.is_variable(obj::Any)
     has_variable_dependence_trait(obj)
-    return OCP.is_variable(variable_dependence(obj))
+    return variable_dependence(obj) === NonFixed
 end
 
 """
@@ -275,7 +335,7 @@ See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.variable
 """
 function OCP.is_nonvariable(obj::Any)
     has_variable_dependence_trait(obj)
-    return OCP.is_nonvariable(variable_dependence(obj))
+    return variable_dependence(obj) === Fixed
 end
 
 """
@@ -300,95 +360,60 @@ See also: [`CTFlows.Common.is_variable`](@ref), [`CTFlows.Common.VariableDepende
 """
 function OCP.has_variable(obj::Any)
     has_variable_dependence_trait(obj)
-    return OCP.is_variable(variable_dependence(obj))
+    return variable_dependence(obj) === NonFixed
+end
+
+# =============================================================================
+# Mutability trait accessors
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return true if the object uses in-place function evaluation.
+
+Checks that the object has the mutability trait, then returns true
+if `mutability_trait(obj)` is `InPlace`.
+
+# Arguments
+- `obj::Any`: The object to check.
+
+# Returns
+- `Bool`: true if the object uses in-place evaluation.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): If the object does not support mutability queries.
+- [`CTBase.Exceptions.NotImplemented`](@extref): If `mutability_trait` is not implemented for the object type.
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.mutability_trait`](@ref).
+"""
+function is_inplace(obj::Any)
+    has_mutability_trait(obj)
+    return mutability_trait(obj) === InPlace
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Return true for the `Autonomous` trait type.
+Return true if the object uses out-of-place function evaluation.
+
+Checks that the object has the mutability trait, then returns true
+if `mutability_trait(obj)` is `OutOfPlace`.
+
+# Arguments
+- `obj::Any`: The object to check.
 
 # Returns
-- `Bool`: true for `Autonomous`, false for `NonAutonomous`.
+- `Bool`: true if the object uses out-of-place evaluation.
 
-See also: [`CTModels.OCP.Autonomous`](@extref), [`CTModels.OCP.NonAutonomous`](@extref).
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): If the object does not support mutability queries.
+- [`CTBase.Exceptions.NotImplemented`](@extref): If `mutability_trait` is not implemented for the object type.
+
+See also: [`CTFlows.Common.AbstractMutabilityTrait`](@ref), [`CTFlows.Common.mutability_trait`](@ref).
 """
-function OCP.is_autonomous(::Type{OCP.Autonomous})
-    return true
+function is_outofplace(obj::Any)
+    has_mutability_trait(obj)
+    return mutability_trait(obj) === OutOfPlace
 end
 
-function OCP.is_autonomous(::Type{OCP.NonAutonomous})
-    return false
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Return true for the `NonAutonomous` trait type.
-
-# Returns
-- `Bool`: true for `NonAutonomous`, false for `Autonomous`.
-
-See also: [`CTModels.OCP.NonAutonomous`](@extref), [`CTModels.OCP.Autonomous`](@extref).
-"""
-function OCP.is_nonautonomous(::Type{OCP.Autonomous})
-    return false
-end
-
-function OCP.is_nonautonomous(::Type{OCP.NonAutonomous})
-    return true
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Return true for the `NonFixed` trait type.
-
-# Returns
-- `Bool`: true for `NonFixed`, false for `Fixed`.
-
-See also: [`CTFlows.Common.NonFixed`](@ref), [`CTFlows.Common.Fixed`](@ref).
-"""
-function OCP.is_variable(::Type{NonFixed})
-    return true
-end
-
-function OCP.is_variable(::Type{Fixed})
-    return false
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Return true for the `NonFixed` trait type (alias for `is_variable`).
-
-# Returns
-- `Bool`: true for `NonFixed`, false for `Fixed`.
-
-See also: [`CTFlows.Common.is_variable`](@ref), [`CTFlows.Common.NonFixed`](@ref).
-"""
-function OCP.has_variable(::Type{NonFixed})
-    return true
-end
-
-function OCP.has_variable(::Type{Fixed})
-    return false
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Return true for the `Fixed` trait type.
-
-# Returns
-- `Bool`: true for `Fixed`, false for `NonFixed`.
-
-See also: [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
-"""
-function OCP.is_nonvariable(::Type{Fixed})
-    return true
-end
-
-function OCP.is_nonvariable(::Type{NonFixed})
-    return false
-end

--- a/src/Data/Data.jl
+++ b/src/Data/Data.jl
@@ -10,6 +10,7 @@ module Data
 
 # 1. External-package imports (qualified, pollution-free)
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+import CTBase.Exceptions
 
 # ==============================================================================
 # Internal sibling-submodule imports

--- a/src/Data/abstract_vector_field.jl
+++ b/src/Data/abstract_vector_field.jl
@@ -3,14 +3,15 @@ $(TYPEDEF)
 
 Abstract type for all vector fields in CTFlows.
 
-An `AbstractVectorField` represents a vector field function with time-dependence
-and variable-dependence traits encoded in the type parameters.
+An `AbstractVectorField` represents a vector field function with time-dependence,
+variable-dependence, and mutability traits encoded in the type parameters.
 
 # Contract
 
 All subtypes must have type parameters:
 - `TD <: Common.TimeDependence`: `Autonomous` or `NonAutonomous`
 - `VD <: Common.VariableDependence`: `Fixed` or `NonFixed`
+- `MD <: Common.AbstractMutabilityTrait`: `InPlace` or `OutOfPlace`
 
 Trait accessors are implemented at the abstract level and work for all subtypes.
 
@@ -21,19 +22,20 @@ using CTFlows.Data
 using CTFlows.Common
 
 # Define a concrete vector field
-struct MyVectorField{F, TD, VD} <: AbstractVectorField{TD, VD}
+struct MyVectorField{F, TD, VD, MD} <: AbstractVectorField{TD, VD, MD}
     f::F
 end
 
 # Trait accessors work automatically
-vf = MyVectorField(x -> -x, Autonomous, Fixed)
+vf = MyVectorField(x -> -x, Autonomous, Fixed, OutOfPlace)
 Common.time_dependence(vf)  # Returns Autonomous
 Common.variable_dependence(vf)  # Returns Fixed
+Common.mutability_trait(vf)  # Returns OutOfPlace
 \`\`\`
 
-See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.time_dependence`](@ref), [`CTFlows.Common.variable_dependence`](@ref).
+See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.time_dependence`](@ref), [`CTFlows.Common.variable_dependence`](@ref), [`CTFlows.Common.mutability_trait`](@ref).
 """
-abstract type AbstractVectorField{TD<:Common.TimeDependence, VD<:Common.VariableDependence} end
+abstract type AbstractVectorField{TD<:Common.TimeDependence, VD<:Common.VariableDependence, MD<:Common.AbstractMutabilityTrait} end
 
 # =============================================================================
 # Trait accessors for AbstractVectorField
@@ -66,6 +68,18 @@ Common.has_variable_dependence_trait(::AbstractVectorField) = true
 """
 $(TYPEDSIGNATURES)
 
+Indicate that `AbstractVectorField` has the mutability trait.
+
+This implementation declares that all vector fields support mutability queries.
+Concrete `AbstractVectorField` instances have their mutability encoded in the type parameter `MD`.
+
+See also: [`CTFlows.Common.mutability_trait`](@ref), [`CTFlows.Data.AbstractVectorField`](@ref).
+"""
+Common.has_mutability_trait(::AbstractVectorField) = true
+
+"""
+$(TYPEDSIGNATURES)
+
 Extract the time dependence trait from an AbstractVectorField.
 
 # Returns
@@ -85,7 +99,7 @@ Common.time_dependence(hvf)  # Returns NonAutonomous
 
 See also: [`CTFlows.Common.has_time_dependence_trait`](@ref), [`CTFlows.Common.is_autonomous`](@ref).
 """
-function Common.time_dependence(vf::AbstractVectorField{TD, <:VariableDependence}) where {TD <: TimeDependence}
+function Common.time_dependence(vf::AbstractVectorField{TD, <:VariableDependence, <:AbstractMutabilityTrait}) where {TD <: TimeDependence}
     return TD
 end
 
@@ -111,6 +125,32 @@ Common.variable_dependence(hvf)  # Returns NonFixed
 
 See also: [`CTFlows.Common.has_variable_dependence_trait`](@ref), [`CTFlows.Common.is_variable`](@ref).
 """
-function Common.variable_dependence(vf::AbstractVectorField{<:TimeDependence, VD}) where {VD <: VariableDependence}
+function Common.variable_dependence(vf::AbstractVectorField{<:TimeDependence, VD, <:AbstractMutabilityTrait}) where {VD <: VariableDependence}
     return VD
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract the mutability trait from an AbstractVectorField.
+
+# Returns
+- `Type{<:AbstractMutabilityTrait}`: The mutability trait type (InPlace or OutOfPlace).
+
+# Example
+\`\`\`julia
+using CTFlows.Data
+using CTFlows.Common
+
+vf = Data.VectorField((dx, x) -> (dx .= -x; nothing))
+Common.mutability_trait(vf)  # Returns InPlace
+
+vf2 = Data.VectorField(x -> -x)
+Common.mutability_trait(vf2)  # Returns OutOfPlace
+\`\`\`
+
+See also: [`CTFlows.Common.has_mutability_trait`](@ref), [`CTFlows.Common.is_inplace`](@ref).
+"""
+function Common.mutability_trait(vf::AbstractVectorField{<:TimeDependence, <:VariableDependence, MD}) where {MD <: AbstractMutabilityTrait}
+    return MD
 end

--- a/src/Data/hamiltonian_vector_field.jl
+++ b/src/Data/hamiltonian_vector_field.jl
@@ -2,7 +2,7 @@
 $(TYPEDEF)
 
 Parametric container for a Hamiltonian vector field function together with its
-time-dependence and variable-dependence traits.
+time-dependence, variable-dependence, and mutability traits.
 
 The function returns a tuple `(dx, dp)` representing the derivatives of state `x`
 and costate `p` according to Hamiltonian dynamics.
@@ -11,6 +11,7 @@ and costate `p` according to Hamiltonian dynamics.
 - `F`: concrete type of the wrapped function.
 - `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
 - `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+- `MD <: AbstractMutabilityTrait`: `InPlace` or `OutOfPlace`.
 
 # Fields
 - `f::F`: the Hamiltonian vector field function.
@@ -26,16 +27,90 @@ HamiltonianVectorField((x, p, v) -> ...; variable = true)                # f(x, 
 HamiltonianVectorField((t, x, p, v) -> ...; autonomous = false, variable = true)
 ```
 
+The mutability trait (InPlace/OutOfPlace) is auto-detected from the function signature.
+
 # Call Signatures
 
 Every `HamiltonianVectorField` is callable via its **natural** signature (matching the
 traits), and via a **uniform** signature `(t, x, p, v)` that ignores the
 unused arguments.
 
-See also: [`CTFlows.Data.AbstractVectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+For InPlace Hamiltonian vector fields, the natural signature includes the derivative
+buffers as the first two arguments (e.g., `(dx, dp, x, p)` for Autonomous/Fixed).
+
+See also: [`CTFlows.Data.AbstractVectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.AbstractMutabilityTrait`](@ref).
 """
-struct HamiltonianVectorField{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence} <: AbstractVectorField{TD, VD}
+struct HamiltonianVectorField{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, MD<:Common.AbstractMutabilityTrait} <: AbstractVectorField{TD, VD, MD}
     f::F
+end
+
+# =============================================================================
+# Internal helpers for mutability detection
+# =============================================================================
+
+"""
+    _oop_arity_hvf(::Type{Autonomous}, ::Type{Fixed}) -> Int
+
+Return the out-of-place arity for Autonomous/Fixed Hamiltonian vector fields (2: x, p).
+"""
+_oop_arity_hvf(::Type{Autonomous}, ::Type{Fixed}) = 2
+
+"""
+    _oop_arity_hvf(::Type{NonAutonomous}, ::Type{Fixed}) -> Int
+
+Return the out-of-place arity for NonAutonomous/Fixed Hamiltonian vector fields (3: t, x, p).
+"""
+_oop_arity_hvf(::Type{NonAutonomous}, ::Type{Fixed}) = 3
+
+"""
+    _oop_arity_hvf(::Type{Autonomous}, ::Type{NonFixed}) -> Int
+
+Return the out-of-place arity for Autonomous/NonFixed Hamiltonian vector fields (3: x, p, v).
+"""
+_oop_arity_hvf(::Type{Autonomous}, ::Type{NonFixed}) = 3
+
+"""
+    _oop_arity_hvf(::Type{NonAutonomous}, ::Type{NonFixed}) -> Int
+
+Return the out-of-place arity for NonAutonomous/NonFixed Hamiltonian vector fields (4: t, x, p, v).
+"""
+_oop_arity_hvf(::Type{NonAutonomous}, ::Type{NonFixed}) = 4
+
+"""
+    _detect_mutability_hvf(f::Function, TD, VD) -> Type{<:AbstractMutabilityTrait}
+
+Detect the mutability trait from the Hamiltonian vector field function signature.
+
+Compares the function arity to the expected out-of-place arity and in-place arity
+(arity + 2 for HamiltonianVectorField, which has two output buffers). Returns `InPlace` or `OutOfPlace` accordingly.
+
+# Arguments
+- `f::Function`: The Hamiltonian vector-field function.
+- `TD`: Time dependence trait type.
+- `VD`: Variable dependence trait type.
+
+# Returns
+- `Type{InPlace}` or `Type{OutOfPlace}`.
+
+# Throws
+- `Exceptions.IncorrectArgument`: If the arity is ambiguous or invalid.
+"""
+function _detect_mutability_hvf(f::Function, TD, VD)
+    arity = first(methods(f)).nargs - 1
+    oop_arity = _oop_arity_hvf(TD, VD)
+    ip_arity = oop_arity + 2  # HamiltonianVectorField has two output buffers (dx, dp)
+
+    if arity == oop_arity
+        return OutOfPlace
+    elseif arity == ip_arity
+        return InPlace
+    else
+        throw(Exceptions.IncorrectArgument(
+            "Invalid function arity: expected $oop_arity (out-of-place) or $ip_arity (in-place), got $arity";
+            suggestion = "Ensure your function signature matches the expected pattern for the given traits.",
+            context = "HamiltonianVectorField mutability detection",
+        ))
+    end
 end
 
 """
@@ -59,12 +134,14 @@ julia> hvf = HamiltonianVectorField((x, p) -> (x, -p))  # Uses defaults: is_auto
 HamiltonianVectorField
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#1"
 
 julia> hvf = HamiltonianVectorField((t, x, p) -> (t .* x, -p); is_autonomous=false)
 HamiltonianVectorField
   time_dependence: NonAutonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#2"
 ```
 
@@ -73,17 +150,25 @@ See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.Autono
 function HamiltonianVectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
     TD = is_autonomous ? Common.Autonomous : Common.NonAutonomous
     VD = is_variable ? Common.NonFixed : Common.Fixed
-    return HamiltonianVectorField{typeof(f), TD, VD}(f)
+    MD = _detect_mutability_hvf(f, TD, VD)
+    return HamiltonianVectorField{typeof(f), TD, VD, MD}(f)
 end
 
 # =============================================================================
 # Natural call signatures - one per trait combination
 # =============================================================================
 
-(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed})(x, p) = H.f(x, p)
-(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed})(t, x, p) = H.f(t, x, p)
-(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed})(x, p, v) = H.f(x, p, v)
-(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.NonFixed})(t, x, p, v) = H.f(t, x, p, v)
+# OutOfPlace signatures (existing)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed, OutOfPlace})(x, p) = H.f(x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed, OutOfPlace})(t, x, p) = H.f(t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed, OutOfPlace})(x, p, v) = H.f(x, p, v)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.NonFixed, OutOfPlace})(t, x, p, v) = H.f(t, x, p, v)
+
+# InPlace signatures (new)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed, InPlace})(dx, dp, x, p) = H.f(dx, dp, x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed, InPlace})(dx, dp, t, x, p) = H.f(dx, dp, t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed, InPlace})(dx, dp, x, p, v) = H.f(dx, dp, x, p, v)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.NonFixed, InPlace})(dx, dp, t, x, p, v) = H.f(dx, dp, t, x, p, v)
 
 # =============================================================================
 # Uniform (t, x, p, v) call - used by HamiltonianVectorFieldSystem.rhs
@@ -91,9 +176,15 @@ end
 # (NonAutonomous, NonFixed) is already covered by the natural signature above.
 # =============================================================================
 
-(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed})(t, x, p, v) = H.f(x, p)
-(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed})(t, x, p, v) = H.f(t, x, p)
-(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed})(t, x, p, v) = H.f(x, p, v)
+# OutOfPlace uniform signatures (existing)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed, OutOfPlace})(t, x, p, v) = H.f(x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed, OutOfPlace})(t, x, p, v) = H.f(t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed, OutOfPlace})(t, x, p, v) = H.f(x, p, v)
+
+# InPlace uniform signatures (new)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.Fixed, InPlace})(dx, dp, t, x, p, v) = H.f(dx, dp, x, p)
+(H::HamiltonianVectorField{<:Function, Common.NonAutonomous, Common.Fixed, InPlace})(dx, dp, t, x, p, v) = H.f(dx, dp, t, x, p)
+(H::HamiltonianVectorField{<:Function, Common.Autonomous, Common.NonFixed, InPlace})(dx, dp, t, x, p, v) = H.f(dx, dp, x, p, v)
 
 
 # =============================================================================
@@ -105,7 +196,7 @@ $(TYPEDSIGNATURES)
 
 Display a compact representation of a HamiltonianVectorField.
 
-Shows the type name, time dependence, variable dependence, and function type.
+Shows the type name, time dependence, variable dependence, mutability, and function type.
 
 # Arguments
 - `io::IO`: The IO stream to write to.
@@ -113,10 +204,11 @@ Shows the type name, time dependence, variable dependence, and function type.
 
 See also: [`CTFlows.Data.HamiltonianVectorField`](@ref).
 """
-function Base.show(io::IO, hvf::HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
+function Base.show(io::IO, hvf::HamiltonianVectorField{F, TD, VD, MD}) where {F, TD, VD, MD}
     println(io, "HamiltonianVectorField")
     println(io, "  time_dependence: ", nameof(TD))
     println(io, "  variable_dependence: ", nameof(VD))
+    println(io, "  mutability: ", nameof(MD))
     print(io, "  function: ", typeof(hvf.f))
 end
 
@@ -134,6 +226,6 @@ Delegates to the compact show method.
 
 See also: [`CTFlows.Data.HamiltonianVectorField`](@ref).
 """
-function Base.show(io::IO, ::MIME"text/plain", hvf::HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
+function Base.show(io::IO, ::MIME"text/plain", hvf::HamiltonianVectorField{F, TD, VD, MD}) where {F, TD, VD, MD}
     show(io, hvf)
 end

--- a/src/Data/vector_field.jl
+++ b/src/Data/vector_field.jl
@@ -2,12 +2,13 @@
 $(TYPEDEF)
 
 Parametric container for a vector-field function together with its
-time-dependence and variable-dependence traits.
+time-dependence, variable-dependence, and mutability traits.
 
 # Type Parameters
 - `F`: concrete type of the wrapped function.
 - `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
 - `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+- `MD <: AbstractMutabilityTrait`: `InPlace` or `OutOfPlace`.
 
 # Fields
 - `f::F`: the vector-field function.
@@ -23,6 +24,8 @@ VectorField((x, v) -> ...; variable = true)                # f(x, v)
 VectorField((t, x, v) -> ...; autonomous = false, variable = true)
 ```
 
+The mutability trait (InPlace/OutOfPlace) is auto-detected from the function signature.
+
 # Call Signatures
 
 Every `VectorField` is callable via its **natural** signature (matching the
@@ -30,10 +33,82 @@ traits), and via a **uniform** signature `(t, x, v)` that ignores the
 unused arguments — this uniform form is used internally to build the right-hand
 side of the ODE in a trait-agnostic way.
 
-See also: [`CTFlows.Data.AbstractVectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+For InPlace vector fields, the natural signature includes the derivative buffer
+as the first argument (e.g., `(dx, x)` for Autonomous/Fixed).
+
+See also: [`CTFlows.Data.AbstractVectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.AbstractMutabilityTrait`](@ref).
 """
-struct VectorField{F<:Function, TD<:TimeDependence, VD<:VariableDependence} <: AbstractVectorField{TD, VD}
+struct VectorField{F<:Function, TD<:TimeDependence, VD<:VariableDependence, MD<:AbstractMutabilityTrait} <: AbstractVectorField{TD, VD, MD}
     f::F
+end
+
+# =============================================================================
+# Internal helpers for mutability detection
+# =============================================================================
+
+"""
+    _oop_arity_vf(::Type{Autonomous}, ::Type{Fixed}) -> Int
+
+Return the out-of-place arity for Autonomous/Fixed vector fields (1: x).
+"""
+_oop_arity_vf(::Type{Autonomous}, ::Type{Fixed}) = 1
+
+"""
+    _oop_arity_vf(::Type{NonAutonomous}, ::Type{Fixed}) -> Int
+
+Return the out-of-place arity for NonAutonomous/Fixed vector fields (2: t, x).
+"""
+_oop_arity_vf(::Type{NonAutonomous}, ::Type{Fixed}) = 2
+
+"""
+    _oop_arity_vf(::Type{Autonomous}, ::Type{NonFixed}) -> Int
+
+Return the out-of-place arity for Autonomous/NonFixed vector fields (2: x, v).
+"""
+_oop_arity_vf(::Type{Autonomous}, ::Type{NonFixed}) = 2
+
+"""
+    _oop_arity_vf(::Type{NonAutonomous}, ::Type{NonFixed}) -> Int
+
+Return the out-of-place arity for NonAutonomous/NonFixed vector fields (3: t, x, v).
+"""
+_oop_arity_vf(::Type{NonAutonomous}, ::Type{NonFixed}) = 3
+
+"""
+    _detect_mutability_vf(f::Function, TD, VD) -> Type{<:AbstractMutabilityTrait}
+
+Detect the mutability trait from the function signature.
+
+Compares the function arity to the expected out-of-place arity and in-place arity
+(arity + 1 for VectorField). Returns `InPlace` or `OutOfPlace` accordingly.
+
+# Arguments
+- `f::Function`: The vector-field function.
+- `TD`: Time dependence trait type.
+- `VD`: Variable dependence trait type.
+
+# Returns
+- `Type{InPlace}` or `Type{OutOfPlace}`.
+
+# Throws
+- `Exceptions.IncorrectArgument`: If the arity is ambiguous or invalid.
+"""
+function _detect_mutability_vf(f::Function, TD, VD)
+    arity = first(methods(f)).nargs - 1
+    oop_arity = _oop_arity_vf(TD, VD)
+    ip_arity = oop_arity + 1
+
+    if arity == oop_arity
+        return OutOfPlace
+    elseif arity == ip_arity
+        return InPlace
+    else
+        throw(Exceptions.IncorrectArgument(
+            "Invalid function arity: expected $oop_arity (out-of-place) or $ip_arity (in-place), got $arity";
+            suggestion = "Ensure your function signature matches the expected pattern for the given traits.",
+            context = "VectorField mutability detection",
+        ))
+    end
 end
 
 """
@@ -57,12 +132,14 @@ julia> vf = VectorField(x -> -x)  # Uses defaults: is_autonomous=true, is_variab
 VectorField
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#1"
 
 julia> vf = VectorField((t, x) -> t .* x; is_autonomous=false)
 VectorField
   time_dependence: NonAutonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#2"
 \`\`\`
 
@@ -71,17 +148,25 @@ See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref
 function VectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
     TD = is_autonomous ? Autonomous : NonAutonomous
     VD = is_variable ? NonFixed : Fixed
-    return VectorField{typeof(f), TD, VD}(f)
+    MD = _detect_mutability_vf(f, TD, VD)
+    return VectorField{typeof(f), TD, VD, MD}(f)
 end
 
 # =============================================================================
 # Natural call signatures - one per trait combination
 # =============================================================================
 
-(F::VectorField{<:Function, Autonomous, Fixed})(x) = F.f(x)
-(F::VectorField{<:Function, NonAutonomous, Fixed})(t, x) = F.f(t, x)
-(F::VectorField{<:Function, Autonomous, NonFixed})(x, v) = F.f(x, v)
-(F::VectorField{<:Function, NonAutonomous, NonFixed})(t, x, v) = F.f(t, x, v)
+# OutOfPlace signatures (existing)
+(F::VectorField{<:Function, Autonomous, Fixed, OutOfPlace})(x) = F.f(x)
+(F::VectorField{<:Function, NonAutonomous, Fixed, OutOfPlace})(t, x) = F.f(t, x)
+(F::VectorField{<:Function, Autonomous, NonFixed, OutOfPlace})(x, v) = F.f(x, v)
+(F::VectorField{<:Function, NonAutonomous, NonFixed, OutOfPlace})(t, x, v) = F.f(t, x, v)
+
+# InPlace signatures (new)
+(F::VectorField{<:Function, Autonomous, Fixed, InPlace})(dx, x) = F.f(dx, x)
+(F::VectorField{<:Function, NonAutonomous, Fixed, InPlace})(dx, t, x) = F.f(dx, t, x)
+(F::VectorField{<:Function, Autonomous, NonFixed, InPlace})(dx, x, v) = F.f(dx, x, v)
+(F::VectorField{<:Function, NonAutonomous, NonFixed, InPlace})(dx, t, x, v) = F.f(dx, t, x, v)
 
 # =============================================================================
 # Uniform (t, x, v) call - used by VectorFieldSystem.rhs
@@ -89,9 +174,15 @@ end
 # (NonAutonomous, NonFixed) is already covered by the natural signature above.
 # =============================================================================
 
-(F::VectorField{<:Function, Autonomous, Fixed})(t, x, v) = F.f(x)
-(F::VectorField{<:Function, NonAutonomous, Fixed})(t, x, v) = F.f(t, x)
-(F::VectorField{<:Function, Autonomous, NonFixed})(t, x, v) = F.f(x, v)
+# OutOfPlace uniform signatures (existing)
+(F::VectorField{<:Function, Autonomous, Fixed, OutOfPlace})(t, x, v) = F.f(x)
+(F::VectorField{<:Function, NonAutonomous, Fixed, OutOfPlace})(t, x, v) = F.f(t, x)
+(F::VectorField{<:Function, Autonomous, NonFixed, OutOfPlace})(t, x, v) = F.f(x, v)
+
+# InPlace uniform signatures (new)
+(F::VectorField{<:Function, Autonomous, Fixed, InPlace})(dx, t, x, v) = F.f(dx, x)
+(F::VectorField{<:Function, NonAutonomous, Fixed, InPlace})(dx, t, x, v) = F.f(dx, t, x)
+(F::VectorField{<:Function, Autonomous, NonFixed, InPlace})(dx, t, x, v) = F.f(dx, x, v)
 
 # =============================================================================
 # Base.show
@@ -102,7 +193,7 @@ $(TYPEDSIGNATURES)
 
 Display a compact representation of a VectorField.
 
-Shows the type name, time dependence, variable dependence, and function type.
+Shows the type name, time dependence, variable dependence, mutability, and function type.
 
 # Arguments
 - `io::IO`: The IO stream to write to.
@@ -110,10 +201,11 @@ Shows the type name, time dependence, variable dependence, and function type.
 
 See also: [`CTFlows.Data.VectorField`](@ref).
 """
-function Base.show(io::IO, vf::VectorField{F, TD, VD}) where {F, TD, VD}
+function Base.show(io::IO, vf::VectorField{F, TD, VD, MD}) where {F, TD, VD, MD}
     println(io, "VectorField")
     println(io, "  time_dependence: ", nameof(TD))
     println(io, "  variable_dependence: ", nameof(VD))
+    println(io, "  mutability: ", nameof(MD))
     print(io, "  function: ", typeof(vf.f))
 end
 
@@ -131,6 +223,6 @@ Delegates to the compact show method.
 
 See also: [`CTFlows.Data.VectorField`](@ref).
 """
-function Base.show(io::IO, ::MIME"text/plain", vf::VectorField{F, TD, VD}) where {F, TD, VD}
+function Base.show(io::IO, ::MIME"text/plain", vf::VectorField{F, TD, VD, MD}) where {F, TD, VD, MD}
     show(io, vf)
 end

--- a/src/Systems/abstract_system.jl
+++ b/src/Systems/abstract_system.jl
@@ -279,7 +279,7 @@ du = rhs_oop_func(u, p, t)  # du = [3.0, 8.0]
 
 See also: [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Systems.AbstractSystem`](@ref).
 """
-function rhs_oop(system::AbstractSystem)
+function rhs_oop(system::AbstractSystem, ::Bool = true)
     throw(
         Exceptions.NotImplemented(
             "AbstractSystem rhs_oop method not implemented";

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -10,13 +10,16 @@ performance. If `N=nothing`, the dimension is inferred at runtime.
 - `F`: concrete type of the wrapped HamiltonianVectorField function.
 - `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
 - `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+- `MD <: AbstractMutabilityTrait`: `InPlace` or `OutOfPlace`.
 - `RHS`: type of the pre-computed in-place right-hand side function.
 - `OOPROHS`: type of the pre-computed out-of-place right-hand side function.
+- `FINRHS`: type of the finalize closure for in-place vector fields, or `Nothing`.
 
 # Fields
-- `hvf::HamiltonianVectorField{F, TD, VD}`: the underlying Hamiltonian vector field.
+- `hvf::HamiltonianVectorField{F, TD, VD, MD}`: the underlying Hamiltonian vector field.
 - `rhs::RHS`: the pre-computed in-place right-hand side closure with signature `(du, u, p, t) -> nothing`.
 - `rhs_oop::OOPROHS`: the pre-computed out-of-place right-hand side closure with signature `(u, p, t) -> du`.
+- `rhs_oop_finalize::FINRHS`: the finalize closure for in-place vector fields with immutable initial conditions, or `nothing` for out-of-place vector fields.
 
 # Example
 ```julia-repl
@@ -26,47 +29,69 @@ julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable
 HamiltonianVectorField
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#1"
 
 julia> sys = HamiltonianVectorFieldSystem(hvf, 3)  # with known dimension
 HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   n_state: 3
-  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed, OutOfPlace}
 
 julia> sys = HamiltonianVectorFieldSystem(hvf)  # without dimension
 HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   n_state: unknown
-  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
+  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed, OutOfPlace}
 ```
 
 See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.AbstractHamiltonianSystem`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
 """
-struct HamiltonianVectorFieldSystem{N, F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, RHS<:Function, OOPROHS<:Function} <: AbstractHamiltonianSystem{TD, VD}
-    hvf::Data.HamiltonianVectorField{F, TD, VD}
+struct HamiltonianVectorFieldSystem{N, F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, MD<:Common.AbstractMutabilityTrait, RHS<:Function, OOPROHS<:Function, FINRHS} <: AbstractHamiltonianSystem{TD, VD}
+    hvf::Data.HamiltonianVectorField{F, TD, VD, MD}
     rhs::RHS
     rhs_oop::OOPROHS
+    rhs_oop_finalize::FINRHS
 end
 
 # =============================================================================
 # Constructors
 # =============================================================================
 
-# Constructor with known dimension N
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD}, n_state::Int) where {F, TD, VD}
-    rhs = _build_rhs(hvf, Val(n_state))
-    rhs_oop = _build_oop_rhs(hvf, Val(n_state))
-    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, typeof(rhs), typeof(rhs_oop)}(hvf, rhs, rhs_oop)
+# OutOfPlace, with known dimension N
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, n_state::Int) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(n_state))
+    rhs_oop          = _build_oop_rhs(hvf, Val(n_state))
+    rhs_oop_finalize = nothing
+    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(hvf, rhs, rhs_oop, rhs_oop_finalize)
 end
 
-# Constructor without dimension (N=nothing)
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD}) where {F, TD, VD}
-    rhs = _build_rhs(hvf, Val(nothing))
-    rhs_oop = _build_oop_rhs(hvf, Val(nothing))
-    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, typeof(rhs), typeof(rhs_oop)}(hvf, rhs, rhs_oop)
+# InPlace, with known dimension N
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, n_state::Int) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(n_state))
+    rhs_oop          = _build_oop_rhs(hvf, Val(n_state))
+    rhs_oop_finalize = _build_finalize_rhs_hvf_ip(hvf, Val(n_state))
+    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(hvf, rhs, rhs_oop, rhs_oop_finalize)
+end
+
+# OutOfPlace, without dimension (N=nothing)
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(nothing))
+    rhs_oop          = _build_oop_rhs(hvf, Val(nothing))
+    rhs_oop_finalize = nothing
+    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(hvf, rhs, rhs_oop, rhs_oop_finalize)
+end
+
+# InPlace, without dimension (N=nothing)
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(nothing))
+    rhs_oop          = _build_oop_rhs(hvf, Val(nothing))
+    rhs_oop_finalize = _build_finalize_rhs_hvf_ip(hvf, Val(nothing))
+    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(hvf, rhs, rhs_oop, rhs_oop_finalize)
 end
 
 # =============================================================================
@@ -135,7 +160,7 @@ end
 # Internal helpers for building RHS (in-place)
 # =============================================================================
 
-function _build_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
+function _build_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (du, u, λ, t)
         x, p = _ham_split(u, N)
         dx, dp = hvf(t, x, p, λ.variable)
@@ -144,11 +169,11 @@ function _build_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
     end
 end
 
-function _build_rhs(hvf::Data.HamiltonianVectorField, ::Val{nothing})
+function _build_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (du, u, λ, t)
-        x, p = _ham_split(u, nothing)
-        dx, dp = hvf(t, x, p, λ.variable)
-        _ham_assign!(du, dx, dp, nothing)
+        x, p   = _ham_split(u,  N)
+        dx, dp = _ham_split(du, N)  # mutable views into du — hvf writes directly into du, no _ham_assign! needed
+        hvf(dx, dp, t, x, p, λ.variable)
         return nothing
     end
 end
@@ -157,7 +182,7 @@ end
 # Internal helpers for building RHS (out-of-place for SVector)
 # =============================================================================
 
-function _build_oop_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
+function _build_oop_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (u, λ, t)
         x, p = _ham_split(u, N)
         dx, dp = hvf(t, x, p, λ.variable)
@@ -165,11 +190,25 @@ function _build_oop_rhs(hvf::Data.HamiltonianVectorField, ::Val{N}) where N
     end
 end
 
-function _build_oop_rhs(hvf::Data.HamiltonianVectorField, ::Val{nothing})
+function _build_oop_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (u, λ, t)
-        x, p = _ham_split(u, nothing)
-        dx, dp = hvf(t, x, p, λ.variable)
+        x, p   = _ham_split(u, N)
+        dx, dp = similar(x), similar(p)
+        hvf(dx, dp, t, x, p, λ.variable)
         return vcat(dx, dp)
+    end
+end
+
+# =============================================================================
+# Internal helpers for building finalize RHS (in-place with immutable u0)
+# =============================================================================
+
+function _build_finalize_rhs_hvf_ip(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, ::Val{N}) where {F, TD, VD, N}
+    return function (u, λ, t)
+        x, p   = _ham_split(u, N)
+        dx, dp = similar(x), similar(p)
+        hvf(dx, dp, t, x, p, λ.variable)
+        return typeof(u)(vcat(dx, dp))
     end
 end
 
@@ -209,28 +248,54 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Out-of-place right-hand side for a `HamiltonianVectorFieldSystem`. Returns the pre-computed
-closure stored in the system, which has signature `(u, p, t) -> du` and splits the combined
-state `u` into `(x, p)` halves, calls the underlying Hamiltonian vector field, and
-concatenates `(dx, dp)`.
+Out-of-place right-hand side for an `OutOfPlace` `HamiltonianVectorFieldSystem`.
+
+Returns the pre-computed closure with signature `(u, p, t) -> du`. The optional
+`is_u0_mutable` argument is accepted but ignored: for out-of-place Hamiltonian vector
+fields `rhs_oop` is always the correct callable regardless of u0 mutability.
 
 # Arguments
-- `sys::HamiltonianVectorFieldSystem`: The system for which to return the RHS function.
+- `sys::HamiltonianVectorFieldSystem{..., OutOfPlace, ...}`: The out-of-place system.
+- `::Bool`: Ignored. Accepted for API uniformity with the `InPlace` method.
 
 # Returns
 - `Function`: The pre-computed closure with signature `(u, p, t) -> du`.
 
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref).
+"""
+function rhs_oop(sys::HamiltonianVectorFieldSystem{N, F, TD, VD, OutOfPlace, RHS, OOPROHS, Nothing}, ::Bool = true) where {N, F, TD, VD, RHS, OOPROHS}
+    return sys.rhs_oop
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place right-hand side for an `InPlace` `HamiltonianVectorFieldSystem`, dispatching on u0 mutability.
+
+For in-place Hamiltonian vector fields the appropriate callable depends on whether the
+initial condition `u0` is mutable:
+- **`is_u0_mutable = true`** (default): returns `rhs_oop`, which allocates mutable buffers
+  for `dx` and `dp` and returns `vcat(dx, dp)`. Correct when `u0` is a `Vector`.
+- **`is_u0_mutable = false`**: returns `rhs_oop_finalize`, which fills mutable buffers then
+  converts back via `typeof(u)(vcat(dx, dp))`. Correct when `u0` is immutable (e.g. `SVector`).
+  A one-time performance warning is emitted.
+
+# Arguments
+- `sys::HamiltonianVectorFieldSystem{..., InPlace, ...}`: The in-place system.
+- `is_u0_mutable::Bool`: `true` if u0 is mutable, `false` if immutable. Defaults to `true`.
+
+# Returns
+- `Function`: The appropriate closure with signature `(u, p, t) -> du`.
+
 # Notes
-- The closure is computed once at construction time for performance.
-- Multiple calls to `rhs_oop` return the same function object.
-- This method is used for immutable array types like `StaticArrays.SVector`.
-- The RHS splits `u` into state `x` and costate `p` halves: `x = u[1:N]`, `p = u[N+1:2N]`.
-- If `N=nothing`, the split uses `n = length(u) ÷ 2` at runtime.
+- Prefer out-of-place Hamiltonian vector fields when u0 is a `StaticArrays.SVector`.
 
 See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref).
 """
-function rhs_oop(sys::HamiltonianVectorFieldSystem)
-    return sys.rhs_oop
+function rhs_oop(sys::HamiltonianVectorFieldSystem{N, F, TD, VD, InPlace, RHS, OOPROHS, FINRHS}, is_u0_mutable::Bool = true) where {N, F, TD, VD, RHS, OOPROHS, FINRHS}
+    is_u0_mutable && return sys.rhs_oop
+    @warn "InPlace HamiltonianVectorField with immutable u0 (e.g. SVector): consider using an out-of-place function for better performance."
+    return sys.rhs_oop_finalize
 end
 
 # =============================================================================
@@ -300,7 +365,7 @@ $(TYPEDSIGNATURES)
 
 Display a compact representation of a HamiltonianVectorFieldSystem.
 
-Shows the type name, time dependence, variable dependence, state dimension, and
+Shows the type name, time dependence, variable dependence, mutability, state dimension, and
 the underlying Hamiltonian vector field type.
 
 # Arguments
@@ -309,10 +374,11 @@ the underlying Hamiltonian vector field type.
 
 See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
 """
-function Base.show(io::IO, sys::HamiltonianVectorFieldSystem{N, F, TD, VD, RHS, OOPROHS}) where {N, F, TD, VD, RHS, OOPROHS}
+function Base.show(io::IO, sys::HamiltonianVectorFieldSystem{N, F, TD, VD, MD, RHS, OOPROHS, FINRHS}) where {N, F, TD, VD, MD, RHS, OOPROHS, FINRHS}
     println(io, "HamiltonianVectorFieldSystem")
     println(io, "  time_dependence: ", nameof(TD))
     println(io, "  variable_dependence: ", nameof(VD))
+    println(io, "  mutability: ", nameof(MD))
     if N === nothing
         println(io, "  n_state: unknown")
     else
@@ -335,6 +401,6 @@ Delegates to the compact show method.
 
 See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
 """
-function Base.show(io::IO, ::MIME"text/plain", sys::HamiltonianVectorFieldSystem{N, F, TD, VD, RHS, OOPROHS}) where {N, F, TD, VD, RHS, OOPROHS}
+function Base.show(io::IO, ::MIME"text/plain", sys::HamiltonianVectorFieldSystem{N, F, TD, VD, MD, RHS, OOPROHS, FINRHS}) where {N, F, TD, VD, MD, RHS, OOPROHS, FINRHS}
     show(io, sys)
 end

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -7,9 +7,10 @@ time via the `variable` kwarg and threaded through `ODEProblem`'s `p` slot
 wrapped in a `Common.ODEParameters` struct.
 
 # Fields
-- `vf::VectorField{F, TD, VD}`: the underlying vector field.
+- `vf::VectorField{F, TD, VD, MD}`: the underlying vector field.
 - `rhs::RHS`: the pre-computed in-place right-hand side closure with signature `(du, u, p, t) -> nothing`.
 - `rhs_oop::OOPROHS`: the pre-computed out-of-place right-hand side closure with signature `(u, p, t) -> du`.
+- `rhs_oop_finalize::FINRHS`: the finalize closure for in-place vector fields with immutable initial conditions, or `nothing` for out-of-place vector fields.
 
 # Example
 \`\`\`julia-repl
@@ -19,29 +20,73 @@ julia> vf = VectorField(x -> -x; autonomous=true, variable=false)
 VectorField
   time_dependence: Autonomous
   variable_dependence: Fixed
+  mutability: OutOfPlace
   function: var"#1"
 
 julia> sys = VectorFieldSystem(vf)
 VectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
-  vector_field: VectorField{var"#1", Autonomous, Fixed}
+  mutability: OutOfPlace
+  vector_field: VectorField{var"#1", Autonomous, Fixed, OutOfPlace}
 \`\`\`
 
 See also: [`CTFlows.Systems.AbstractSystem`](@ref), [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.TimeDependence`](@ref), [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """
-struct VectorFieldSystem{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, RHS<:Function, OOPROHS<:Function} <: AbstractStateSystem{TD, VD}
-    vf::Data.VectorField{F, TD, VD}
+struct VectorFieldSystem{F<:Function, TD<:Common.TimeDependence, VD<:Common.VariableDependence, MD<:Common.AbstractMutabilityTrait, RHS<:Function, OOPROHS<:Function, FINRHS} <: AbstractStateSystem{TD, VD}
+    vf::Data.VectorField{F, TD, VD, MD}
     rhs::RHS
     rhs_oop::OOPROHS
+    rhs_oop_finalize::FINRHS
+end
 
-    function VectorFieldSystem(vf::Data.VectorField{F, TD, VD}) where {F, TD, VD}
-        rhs = function (du, u, λ, t)
-            du .= vf(t, u, λ.variable)
-            return nothing
-        end
-        rhs_oop = (u, λ, t) -> vf(t, u, λ.variable)
-        return new{F, TD, VD, typeof(rhs), typeof(rhs_oop)}(vf, rhs, rhs_oop)
+# =============================================================================
+# Constructors
+# =============================================================================
+
+function VectorFieldSystem(vf::Data.VectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
+    rhs              = _build_rhs_vf_oop(vf)
+    rhs_oop          = _build_oop_rhs_vf_oop(vf)
+    rhs_oop_finalize = nothing
+    return VectorFieldSystem{F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(vf, rhs, rhs_oop, rhs_oop_finalize)
+end
+
+function VectorFieldSystem(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
+    rhs              = _build_rhs_vf_ip(vf)
+    rhs_oop          = _build_oop_rhs_vf_ip(vf)
+    rhs_oop_finalize = _build_finalize_rhs_vf_ip(vf)
+    return VectorFieldSystem{F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(vf, rhs, rhs_oop, rhs_oop_finalize)
+end
+
+# =============================================================================
+# Internal helpers: RHS builders
+# =============================================================================
+
+function _build_rhs_vf_oop(vf::Data.VectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
+    return (du, u, λ, t) -> (du .= vf(t, u, λ.variable); nothing)
+end
+
+function _build_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
+    return (du, u, λ, t) -> (vf(du, t, u, λ.variable); nothing)
+end
+
+function _build_oop_rhs_vf_oop(vf::Data.VectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
+    return (u, λ, t) -> vf(t, u, λ.variable)
+end
+
+function _build_oop_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
+    return function (u, λ, t)
+        dx = similar(u)
+        vf(dx, t, u, λ.variable)
+        return dx
+    end
+end
+
+function _build_finalize_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
+    return function (u, λ, t)
+        dx = similar(u)
+        vf(dx, t, u, λ.variable)
+        return typeof(u)(dx)
     end
 end
 
@@ -89,42 +134,55 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Out-of-place right-hand side for a `VectorFieldSystem`. Returns the pre-computed
-closure stored in the system, which has signature `(u, p, t) -> du` and uses
-the uniform `(t, x, v)` call on the underlying `VectorField`, where `p`
-is a `Common.ODEParameters` wrapper containing the variable (or `nothing`
-for `Fixed` systems).
+Out-of-place right-hand side for an `OutOfPlace` `VectorFieldSystem`.
+
+Returns the pre-computed closure with signature `(u, p, t) -> du`. The optional
+`is_u0_mutable` argument is accepted but ignored: for out-of-place vector fields
+`rhs_oop` is always the correct callable regardless of u0 mutability.
 
 # Arguments
-- `sys::VectorFieldSystem`: The system for which to return the RHS function.
+- `sys::VectorFieldSystem{..., OutOfPlace, ...}`: The out-of-place system.
+- `::Bool`: Ignored. Accepted for API uniformity with the `InPlace` method.
 
 # Returns
 - `Function`: The pre-computed closure with signature `(u, p, t) -> du`.
 
-# Example
-```julia
-using CTFlows.Systems, CTFlows.Common
+See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref).
+"""
+function rhs_oop(sys::VectorFieldSystem{F, TD, VD, OutOfPlace, RHS, OOPROHS, Nothing}, ::Bool = true) where {F, TD, VD, RHS, OOPROHS}
+    return sys.rhs_oop
+end
 
-vf = VectorField(x -> -x; autonomous=true, variable=false)
-sys = VectorFieldSystem(vf)
-rhs_oop = Systems.rhs_oop(sys)
+"""
+$(TYPEDSIGNATURES)
 
-u = [1.0, 2.0]
-p = Common.ODEParameters(nothing)
-du = rhs_oop(u, p, 0.0)
-# du is [-1.0, -2.0]
-```
+Out-of-place right-hand side for an `InPlace` `VectorFieldSystem`, dispatching on u0 mutability.
+
+For in-place vector fields the appropriate callable depends on whether the initial
+condition `u0` is mutable:
+- **`is_u0_mutable = true`** (default): returns `rhs_oop`, which allocates a mutable
+  buffer and returns it. Correct when `u0` is a `Vector` or similar mutable array.
+- **`is_u0_mutable = false`**: returns `rhs_oop_finalize`, which allocates a mutable
+  buffer, fills it via the in-place call, then converts back to `typeof(u)`. Correct
+  when `u0` is immutable (e.g. `StaticArrays.SVector`). A one-time performance
+  warning is emitted in this case.
+
+# Arguments
+- `sys::VectorFieldSystem{..., InPlace, ...}`: The in-place system.
+- `is_u0_mutable::Bool`: `true` if u0 is mutable, `false` if immutable. Defaults to `true`.
+
+# Returns
+- `Function`: The appropriate closure with signature `(u, p, t) -> du`.
 
 # Notes
-- The closure is computed once at construction time for performance.
-- Multiple calls to `rhs_oop` return the same function object.
-- This method is used for immutable array types like `StaticArrays.SVector`.
-- The closure uses the uniform `(t, x, v)` signature to work with all trait combinations.
+- Prefer out-of-place vector fields when u0 is a `StaticArrays.SVector` for best performance.
 
-See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
+See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.rhs`](@ref).
 """
-function rhs_oop(sys::VectorFieldSystem)
-    return sys.rhs_oop
+function rhs_oop(sys::VectorFieldSystem{F, TD, VD, InPlace, RHS, OOPROHS, FINRHS}, is_u0_mutable::Bool = true) where {F, TD, VD, RHS, OOPROHS, FINRHS}
+    is_u0_mutable && return sys.rhs_oop
+    @warn "InPlace VectorField with immutable u0 (e.g. SVector): consider using an out-of-place function for better performance."
+    return sys.rhs_oop_finalize
 end
 
 # =============================================================================
@@ -136,7 +194,7 @@ $(TYPEDSIGNATURES)
 
 Display a compact representation of a VectorFieldSystem.
 
-Shows the type name, time dependence, variable dependence, and the underlying vector field type.
+Shows the type name, time dependence, variable dependence, mutability, and the underlying vector field type.
 
 # Arguments
 - `io::IO`: The IO stream to write to.
@@ -144,10 +202,11 @@ Shows the type name, time dependence, variable dependence, and the underlying ve
 
 See also: [`CTFlows.Systems.VectorFieldSystem`](@ref).
 """
-function Base.show(io::IO, sys::VectorFieldSystem{F, TD, VD, RHS, OOPROHS}) where {F, TD, VD, RHS, OOPROHS}
+function Base.show(io::IO, sys::VectorFieldSystem{F, TD, VD, MD, RHS, OOPROHS, FINRHS}) where {F, TD, VD, MD, RHS, OOPROHS, FINRHS}
     println(io, "VectorFieldSystem")
-    println(io, "  time_dependence: ", TD)
-    println(io, "  variable_dependence: ", VD)
+    println(io, "  time_dependence: ", nameof(TD))
+    println(io, "  variable_dependence: ", nameof(VD))
+    println(io, "  mutability: ", nameof(MD))
     print(io, "  vector_field: ", typeof(sys.vf))
 end
 
@@ -165,6 +224,6 @@ Delegates to the compact show method.
 
 See also: [`CTFlows.Systems.VectorFieldSystem`](@ref).
 """
-function Base.show(io::IO, ::MIME"text/plain", sys::VectorFieldSystem{F, TD, VD, RHS, OOPROHS}) where {F, TD, VD, RHS, OOPROHS}
+function Base.show(io::IO, ::MIME"text/plain", sys::VectorFieldSystem{F, TD, VD, MD, RHS, OOPROHS, FINRHS}) where {F, TD, VD, MD, RHS, OOPROHS, FINRHS}
     show(io, sys)
 end

--- a/test/suite/common/test_abstract_trait.jl
+++ b/test/suite/common/test_abstract_trait.jl
@@ -55,6 +55,20 @@ function test_abstract_trait()
                     Test.@test Common.AbstractContentTrait <: Common.AbstractTrait
                 end
             end
+
+            Test.@testset "AbstractMutabilityTrait" begin
+                Test.@testset "AbstractMutabilityTrait is exported" begin
+                    Test.@test isdefined(Common, :AbstractMutabilityTrait)
+                end
+
+                Test.@testset "AbstractMutabilityTrait is abstract" begin
+                    Test.@test isabstracttype(Common.AbstractMutabilityTrait)
+                end
+
+                Test.@testset "AbstractMutabilityTrait subtypes AbstractTrait" begin
+                    Test.@test Common.AbstractMutabilityTrait <: Common.AbstractTrait
+                end
+            end
         end
 
         # ====================================================================
@@ -137,6 +151,44 @@ function test_abstract_trait()
                     Test.@test Common.HamiltonianTrait <: Common.AbstractContentTrait
                 end
             end
+
+            Test.@testset "InPlace" begin
+                Test.@testset "InPlace is exported" begin
+                    Test.@test isdefined(Common, :InPlace)
+                end
+
+                Test.@testset "InPlace is concrete" begin
+                    Test.@test !isabstracttype(Common.InPlace)
+                end
+
+                Test.@testset "InPlace instantiates" begin
+                    ip = Common.InPlace()
+                    Test.@test ip isa Common.InPlace
+                end
+
+                Test.@testset "InPlace subtypes AbstractMutabilityTrait" begin
+                    Test.@test Common.InPlace <: Common.AbstractMutabilityTrait
+                end
+            end
+
+            Test.@testset "OutOfPlace" begin
+                Test.@testset "OutOfPlace is exported" begin
+                    Test.@test isdefined(Common, :OutOfPlace)
+                end
+
+                Test.@testset "OutOfPlace is concrete" begin
+                    Test.@test !isabstracttype(Common.OutOfPlace)
+                end
+
+                Test.@testset "OutOfPlace instantiates" begin
+                    oop = Common.OutOfPlace()
+                    Test.@test oop isa Common.OutOfPlace
+                end
+
+                Test.@testset "OutOfPlace subtypes AbstractMutabilityTrait" begin
+                    Test.@test Common.OutOfPlace <: Common.AbstractMutabilityTrait
+                end
+            end
         end
 
         # ====================================================================
@@ -149,6 +201,8 @@ function test_abstract_trait()
                 Test.@test Common.TrajectoryTrait <: Common.AbstractTrait
                 Test.@test Common.StateTrait <: Common.AbstractTrait
                 Test.@test Common.HamiltonianTrait <: Common.AbstractTrait
+                Test.@test Common.InPlace <: Common.AbstractTrait
+                Test.@test Common.OutOfPlace <: Common.AbstractTrait
             end
 
             Test.@testset "Mode traits are distinct from content traits" begin
@@ -165,8 +219,9 @@ function test_abstract_trait()
 
         Test.@testset "Exports Verification" begin
             Test.@testset "Exported trait types" begin
-                for sym in (:AbstractTrait, :AbstractModeTrait, :AbstractContentTrait,
-                           :PointTrait, :TrajectoryTrait, :StateTrait, :HamiltonianTrait)
+                for sym in (:AbstractTrait, :AbstractModeTrait, :AbstractContentTrait, :AbstractMutabilityTrait,
+                           :PointTrait, :TrajectoryTrait, :StateTrait, :HamiltonianTrait,
+                           :InPlace, :OutOfPlace)
                     Test.@test isdefined(Common, sym)
                 end
             end

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -178,32 +178,22 @@ function test_common_module()
         Test.@testset "Trait Accessor Functions" begin
             Test.@testset "is_autonomous is exported" begin
                 Test.@test isdefined(Common, :is_autonomous)
-                Test.@test Common.is_autonomous(Common.Autonomous) === true
-                Test.@test Common.is_autonomous(Common.NonAutonomous) === false
             end
 
             Test.@testset "is_nonautonomous is exported" begin
                 Test.@test isdefined(Common, :is_nonautonomous)
-                Test.@test Common.is_nonautonomous(Common.Autonomous) === false
-                Test.@test Common.is_nonautonomous(Common.NonAutonomous) === true
             end
 
             Test.@testset "is_variable is exported" begin
                 Test.@test isdefined(Common, :is_variable)
-                Test.@test Common.is_variable(Common.Fixed) === false
-                Test.@test Common.is_variable(Common.NonFixed) === true
             end
 
             Test.@testset "is_nonvariable is exported" begin
                 Test.@test isdefined(Common, :is_nonvariable)
-                Test.@test Common.is_nonvariable(Common.Fixed) === true
-                Test.@test Common.is_nonvariable(Common.NonFixed) === false
             end
 
             Test.@testset "has_variable is exported" begin
                 Test.@test isdefined(Common, :has_variable)
-                Test.@test Common.has_variable(Common.Fixed) === false
-                Test.@test Common.has_variable(Common.NonFixed) === true
             end
         end
 

--- a/test/suite/common/test_traits.jl
+++ b/test/suite/common/test_traits.jl
@@ -45,6 +45,27 @@ struct FakeNonFixed end
 Common.has_variable_dependence_trait(::FakeNonFixed) = true
 Common.variable_dependence(::FakeNonFixed) = Common.NonFixed
 
+"""
+Fake type for testing mutability trait pattern with InPlace.
+"""
+struct FakeInPlace end
+
+Common.has_mutability_trait(::FakeInPlace) = true
+Common.mutability_trait(::FakeInPlace) = Common.InPlace
+
+"""
+Fake type for testing mutability trait pattern with OutOfPlace.
+"""
+struct FakeOutOfPlace end
+
+Common.has_mutability_trait(::FakeOutOfPlace) = true
+Common.mutability_trait(::FakeOutOfPlace) = Common.OutOfPlace
+
+"""
+Fake type for testing mutability trait without the trait.
+"""
+struct FakeNoMutability end
+
 # ==============================================================================
 # Test function
 # ==============================================================================
@@ -160,15 +181,6 @@ function test_traits()
                 Test.@test Common.is_nonautonomous(obj) === true
             end
 
-            Test.@testset "is_autonomous dispatches on trait value" begin
-                Test.@test Common.is_autonomous(Common.Autonomous) === true
-                Test.@test Common.is_autonomous(Common.NonAutonomous) === false
-            end
-
-            Test.@testset "is_nonautonomous dispatches on trait value" begin
-                Test.@test Common.is_nonautonomous(Common.Autonomous) === false
-                Test.@test Common.is_nonautonomous(Common.NonAutonomous) === true
-            end
         end
 
         # ====================================================================
@@ -194,20 +206,35 @@ function test_traits()
                 Test.@test Common.has_variable(obj) === true
             end
 
-            Test.@testset "is_variable dispatches on trait value" begin
-                Test.@test Common.is_variable(Common.Fixed) === false
-                Test.@test Common.is_variable(Common.NonFixed) === true
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Mutability Trait Pattern
+        # ====================================================================
+
+        Test.@testset "Mutability Trait Pattern" begin
+            Test.@testset "FakeInPlace trait implementation" begin
+                obj = FakeInPlace()
+                Test.@test Common.has_mutability_trait(obj) === true
+                Test.@test Common.mutability_trait(obj) === Common.InPlace
+                Test.@test Common.is_inplace(obj) === true
+                Test.@test Common.is_outofplace(obj) === false
             end
 
-            Test.@testset "is_nonvariable dispatches on trait value" begin
-                Test.@test Common.is_nonvariable(Common.Fixed) === true
-                Test.@test Common.is_nonvariable(Common.NonFixed) === false
+            Test.@testset "FakeOutOfPlace trait implementation" begin
+                obj = FakeOutOfPlace()
+                Test.@test Common.has_mutability_trait(obj) === true
+                Test.@test Common.mutability_trait(obj) === Common.OutOfPlace
+                Test.@test Common.is_inplace(obj) === false
+                Test.@test Common.is_outofplace(obj) === true
             end
 
-            Test.@testset "has_variable alias for CTModels compatibility" begin
-                Test.@test Common.has_variable(Common.Fixed) === false
-                Test.@test Common.has_variable(Common.NonFixed) === true
+            Test.@testset "FakeNoMutability throws errors" begin
+                obj = FakeNoMutability()
+                Test.@test_throws Exceptions.IncorrectArgument Common.is_inplace(obj)
+                Test.@test_throws Exceptions.NotImplemented Common.mutability_trait(obj)
             end
+
         end
     end
 end

--- a/test/suite/data/test_abstract_vector_field.jl
+++ b/test/suite/data/test_abstract_vector_field.jl
@@ -11,7 +11,7 @@ const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 # Fake type for contract testing (defined at module top-level per testing-creation.md)
 # ==============================================================================
 
-struct FakeVectorField{TD, VD} <: Data.AbstractVectorField{TD, VD} end
+struct FakeVectorField{TD, VD, MD} <: Data.AbstractVectorField{TD, VD, MD} end
 
 # ==============================================================================
 # Test function
@@ -34,7 +34,7 @@ function test_abstract_vector_field()
             end
 
             Test.@testset "FakeVectorField subtypes AbstractVectorField" begin
-                fake = FakeVectorField{Common.Autonomous, Common.Fixed}()
+                fake = FakeVectorField{Common.Autonomous, Common.Fixed, Common.OutOfPlace}()
                 Test.@test fake isa Data.AbstractVectorField
             end
         end
@@ -45,25 +45,25 @@ function test_abstract_vector_field()
 
         Test.@testset "Trait Accessors on Abstract Type" begin
             Test.@testset "has_time_dependence_trait returns true" begin
-                fake = FakeVectorField{Common.Autonomous, Common.Fixed}()
+                fake = FakeVectorField{Common.Autonomous, Common.Fixed, Common.OutOfPlace}()
                 Test.@test Common.has_time_dependence_trait(fake) === true
             end
 
             Test.@testset "has_variable_dependence_trait returns true" begin
-                fake = FakeVectorField{Common.Autonomous, Common.Fixed}()
+                fake = FakeVectorField{Common.Autonomous, Common.Fixed, Common.OutOfPlace}()
                 Test.@test Common.has_variable_dependence_trait(fake) === true
             end
 
             Test.@testset "time_dependence returns correct trait" begin
-                fake_aut = FakeVectorField{Common.Autonomous, Common.Fixed}()
-                fake_nonaut = FakeVectorField{Common.NonAutonomous, Common.Fixed}()
+                fake_aut = FakeVectorField{Common.Autonomous, Common.Fixed, Common.OutOfPlace}()
+                fake_nonaut = FakeVectorField{Common.NonAutonomous, Common.Fixed, Common.OutOfPlace}()
                 Test.@test Common.time_dependence(fake_aut) === Common.Autonomous
                 Test.@test Common.time_dependence(fake_nonaut) === Common.NonAutonomous
             end
 
             Test.@testset "variable_dependence returns correct trait" begin
-                fake_fixed = FakeVectorField{Common.Autonomous, Common.Fixed}()
-                fake_nonfixed = FakeVectorField{Common.Autonomous, Common.NonFixed}()
+                fake_fixed = FakeVectorField{Common.Autonomous, Common.Fixed, Common.OutOfPlace}()
+                fake_nonfixed = FakeVectorField{Common.Autonomous, Common.NonFixed, Common.OutOfPlace}()
                 Test.@test Common.variable_dependence(fake_fixed) === Common.Fixed
                 Test.@test Common.variable_dependence(fake_nonfixed) === Common.NonFixed
             end

--- a/test/suite/extensions/test_flow_callables_sciml.jl
+++ b/test/suite/extensions/test_flow_callables_sciml.jl
@@ -32,6 +32,15 @@ const HSYS_N1  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC, 1)         #
 const HSYS_N2  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC, 2)         # N=2 (for SVector)
 const ATOL = 1e-5
 
+# InPlace variants (same dynamics, different function signature)
+const VF_DECAY_IP = Data.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+const SYS_DECAY_IP = Systems.VectorFieldSystem(VF_DECAY_IP)
+
+const HVF_HARMONIC_IP = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= p; dp .= -x); is_autonomous=true, is_variable=false)
+const HSYS_IP_NO_N = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP)
+const HSYS_IP_N1   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP, 1)
+const HSYS_IP_N2   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP, 2)
+
 # ==============================================================================
 # Test function
 # ==============================================================================
@@ -270,6 +279,43 @@ function test_flow_callables_sciml()
                 hflow = Flows.build_flow(HSYS_N2, INTEG)
                 sol = hflow((0.0, π/2), SA[1.0, 0.0], SA[0.0, 1.0])
                 Test.@test sol isa Solutions.HamiltonianVectorFieldSolution
+            end
+        end
+        # ====================================================================
+        # INTEGRATION TESTS - InPlace StateFlow
+        # ====================================================================
+
+        Test.@testset "InPlace StateFlow" begin
+            flow = Flows.build_flow(SYS_DECAY_IP, INTEG)
+
+            Test.@testset "IP VF + Vector u0 (no warning)" begin
+                xf = flow(0.0, [1.0, 2.0], 1.0)
+                Test.@test xf ≈ [exp(-1.0), 2*exp(-1.0)]  atol=ATOL
+            end
+
+            Test.@testset "IP VF + SVector u0 (warns)" begin
+                xf = Test.@test_logs (:warn, r"InPlace VectorField") flow(0.0, SA[1.0, 2.0], 1.0)
+                Test.@test xf ≈ [exp(-1.0), 2*exp(-1.0)]  atol=ATOL
+            end
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - InPlace HamiltonianFlow
+        # ====================================================================
+
+        Test.@testset "InPlace HamiltonianFlow" begin
+            Test.@testset "IP HVF + Vector u0 (no warning)" begin
+                hflow = Flows.build_flow(HSYS_IP_N1, INTEG)
+                xf, pf = hflow(0.0, 1.0, 0.0, π/2)
+                Test.@test xf ≈ 0.0   atol=ATOL
+                Test.@test pf ≈ -1.0  atol=ATOL
+            end
+
+            Test.@testset "IP HVF + SVector u0 (warns)" begin
+                hflow = Flows.build_flow(HSYS_IP_N2, INTEG)
+                xf, pf = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") hflow(0.0, SA[1.0, 0.0], SA[0.0, 1.0], π/2)
+                Test.@test xf ≈ [0.0, 1.0]   atol=ATOL
+                Test.@test pf ≈ [-1.0, 0.0]  atol=ATOL
             end
         end
     end

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -17,6 +17,7 @@ struct FakeTag <: Common.AbstractTag end
 # Get extension to access SciML integrator
 using SciMLBase: SciMLBase, ODEProblem
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
+import StaticArrays: SA
 const CTFlowsSciML = Base.get_extension(CTFlows, :CTFlowsSciML)
 const CTFlowsOrdinaryDiffEqTsit5 = Base.get_extension(CTFlows, :CTFlowsOrdinaryDiffEqTsit5)
 
@@ -362,6 +363,124 @@ function test_sciml_extension()
                 flow_sol = Solutions.build_solution(result, sys, config)
 
                 Test.@test flow_sol isa Solutions.VectorFieldSolution
+            end
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - InPlace VF × mutable/immutable u0
+        # ====================================================================
+
+        Test.@testset "InPlace VF — SciML integration" begin
+            integ = Integrators.SciML(maxiters=10000, reltol=1e-8, abstol=1e-10)
+            # ODE: dx/dt = -x  →  x(t) = x₀ · e^{-t}
+
+            Test.@testset "OOP VF + mutable Vector u0" begin
+                vf  = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                u0  = [1.0, 2.0]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf ≈ exp(-1.0) .* [1.0, 2.0]  atol=1e-5
+            end
+
+            Test.@testset "OOP VF + SVector u0" begin
+                vf  = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                u0  = SA[1.0, 2.0]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf ≈ exp(-1.0) .* [1.0, 2.0]  atol=1e-5
+            end
+
+            Test.@testset "IP VF + mutable Vector u0" begin
+                vf  = Data.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                u0  = [1.0, 2.0]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf ≈ exp(-1.0) .* [1.0, 2.0]  atol=1e-5
+            end
+
+            Test.@testset "IP VF + SVector u0 (warns, uses rhs_oop_finalize)" begin
+                vf  = Data.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                u0  = SA[1.0, 2.0]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Test.@test_logs (:warn, r"InPlace VectorField") Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf ≈ exp(-1.0) .* [1.0, 2.0]  atol=1e-5
+            end
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - InPlace HVF × mutable/immutable u0
+        # ====================================================================
+
+        Test.@testset "InPlace HVF — SciML integration" begin
+            integ = Integrators.SciML(maxiters=10000, reltol=1e-8, abstol=1e-10)
+            # ODE: dx/dt = x, dp/dt = -p  →  x(t)=x₀·eᵗ, p(t)=p₀·e^{-t}
+
+            Test.@testset "OOP HVF + mutable Vector u0" begin
+                hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                u0  = [1.0, 0.5]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf[1] ≈ exp(1.0)       atol=1e-5
+                Test.@test xf[2] ≈ 0.5*exp(-1.0)  atol=1e-5
+            end
+
+            Test.@testset "OOP HVF + SVector u0" begin
+                hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                u0  = SA[1.0, 0.5]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf[1] ≈ exp(1.0)       atol=1e-5
+                Test.@test xf[2] ≈ 0.5*exp(-1.0)  atol=1e-5
+            end
+
+            Test.@testset "IP HVF + mutable Vector u0" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                u0  = [1.0, 0.5]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf[1] ≈ exp(1.0)       atol=1e-5
+                Test.@test xf[2] ≈ 0.5*exp(-1.0)  atol=1e-5
+            end
+
+            Test.@testset "IP HVF + SVector u0 (warns, uses rhs_oop_finalize)" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                u0  = SA[1.0, 0.5]
+                config = Common.StatePointConfig(0.0, u0, 1.0)
+                prob = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") Integrators.build_problem(integ, sys, config; variable=nothing)
+                opts = Integrators.build_options(integ, config)
+                result = Integrators.solve_problem(integ, prob, opts)
+                xf = Solutions.final_state(result)
+                Test.@test xf[1] ≈ exp(1.0)       atol=1e-5
+                Test.@test xf[2] ≈ 0.5*exp(-1.0)  atol=1e-5
             end
         end
 

--- a/test/suite/solutions/test_building_solutions.jl
+++ b/test/suite/solutions/test_building_solutions.jl
@@ -35,7 +35,7 @@ function test_building_solutions()
 
         Test.@testset "build_solution - StatePointConfig" begin
             Test.@testset "vector initial condition returns final state" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.StatePointConfig(0.0, [1.0, 2.0], 1.0)
                 
@@ -45,7 +45,7 @@ function test_building_solutions()
             end
 
             Test.@testset "scalar initial condition unwraps length-1 vector" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[3.0], [1.5]])
                 config = Common.StatePointConfig(0.0, 3.0, 1.0)
                 
@@ -61,7 +61,7 @@ function test_building_solutions()
 
         Test.@testset "build_solution - StateTrajectoryConfig" begin
             Test.@testset "returns VectorFieldSolution wrapping result" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.StateTrajectoryConfig((0.0, 1.0), [1.0, 2.0])
                 
@@ -70,7 +70,7 @@ function test_building_solutions()
             end
 
             Test.@testset "VectorFieldSolution contains correct result" begin
-                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=false, is_variable=false))
+                sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
                 config = Common.StateTrajectoryConfig((0.0, 1.0), [1.0, 2.0])
                 
@@ -86,7 +86,7 @@ function test_building_solutions()
         Test.@testset "build_solution - HamiltonianPointConfig" begin
             Test.@testset "scalar initial condition returns tuple of scalars" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=false, is_variable=false),
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
                     1
                 )
                 result = FakeIntegrationResult([[1.0, 0.5], [0.5, 0.25]])
@@ -99,7 +99,7 @@ function test_building_solutions()
 
             Test.@testset "vector initial condition returns tuple of vectors" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=false, is_variable=false),
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
                     2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
@@ -113,7 +113,7 @@ function test_building_solutions()
             Test.@testset "vector initial condition uses correct dimension split" begin
                 # Test the bug fix: should use length(initial_state) not length(initial_condition)
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=false, is_variable=false),
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
                     3
                 )
                 # Final state has 6 elements: 3 state + 3 costate
@@ -133,7 +133,7 @@ function test_building_solutions()
         Test.@testset "build_solution - HamiltonianTrajectoryConfig" begin
             Test.@testset "returns HamiltonianVectorFieldSolution wrapping result" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=false, is_variable=false),
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
                     2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
@@ -145,7 +145,7 @@ function test_building_solutions()
 
             Test.@testset "HamiltonianVectorFieldSolution contains correct result" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=false, is_variable=false),
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
                     2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -285,6 +285,78 @@ function test_hamiltonian_vector_field_system()
         end
 
         # ====================================================================
+        # UNIT TESTS - InPlace HamiltonianVectorField
+        # ====================================================================
+
+        Test.@testset "InPlace HamiltonianVectorField" begin
+            Test.@testset "OOP: rhs_oop_finalize is Nothing" begin
+                hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                Test.@test sys.rhs_oop_finalize === nothing
+            end
+
+            Test.@testset "IP: rhs_oop_finalize is Function" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                Test.@test sys.rhs_oop_finalize isa Function
+            end
+
+            Test.@testset "IP: rhs fills du via views (no _ham_assign! needed)" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                u   = [1.0, 2.0, 3.0, 4.0]
+                du  = zeros(4)
+                p   = Common.ODEParameters(nothing)
+                Systems.rhs(sys)(du, u, p, 0.0)
+                Test.@test du[1:2] ≈ [1.0, 2.0]
+                Test.@test du[3:4] ≈ [-3.0, -4.0]
+            end
+
+            Test.@testset "IP: rhs_oop(sys, true) === sys.rhs_oop" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                Test.@test Systems.rhs_oop(sys, true) === sys.rhs_oop
+            end
+
+            Test.@testset "IP: rhs_oop(sys, false) === sys.rhs_oop_finalize and warns" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                f   = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") Systems.rhs_oop(sys, false)
+                Test.@test f === sys.rhs_oop_finalize
+            end
+
+            Test.@testset "IP: rhs_oop(sys, true) returns mutable Vector" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                f   = Systems.rhs_oop(sys, true)
+                u   = [1.0, 2.0, 3.0, 4.0]
+                p   = Common.ODEParameters(nothing)
+                du  = f(u, p, 0.0)
+                Test.@test du[1:2] ≈ [1.0, 2.0]
+                Test.@test du[3:4] ≈ [-3.0, -4.0]
+                Test.@test du isa Vector
+            end
+
+            Test.@testset "IP: rhs_oop_finalize returns SVector for SVector u" begin
+                hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                f   = sys.rhs_oop_finalize
+                u   = SA[1.0, 2.0, 3.0, 4.0]
+                p   = Common.ODEParameters(nothing)
+                du  = f(u, p, 0.0)
+                Test.@test du ≈ SA[1.0, 2.0, -3.0, -4.0]
+                Test.@test du isa StaticArrays.SVector
+            end
+
+            Test.@testset "OOP: rhs_oop(sys, false) still returns sys.rhs_oop" begin
+                hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                Test.@test Systems.rhs_oop(sys, true)  === sys.rhs_oop
+                Test.@test Systems.rhs_oop(sys, false) === sys.rhs_oop
+            end
+        end
+
+        # ====================================================================
         # UNIT TESTS - Validation
         # ====================================================================
 

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -3,7 +3,7 @@ module TestVectorFieldSystem
 import Test
 import CTFlows.Systems
 import CTFlows.Common
-import StaticArrays: SA
+import StaticArrays: SA, StaticArrays
 
 const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
@@ -226,6 +226,74 @@ function test_vector_field_system()
                 p = Common.ODEParameters(nothing)
                 du = rhs_oop(u, p, 0.0)
                 Test.@test du == SA[-1.0-2.0im, -3.0-4.0im]
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - InPlace VectorField
+        # ====================================================================
+
+        Test.@testset "InPlace VectorField" begin
+            Test.@testset "OOP: rhs_oop_finalize is Nothing" begin
+                vf  = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                Test.@test sys.rhs_oop_finalize === nothing
+            end
+
+            Test.@testset "IP: rhs_oop_finalize is Function" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                Test.@test sys.rhs_oop_finalize isa Function
+            end
+
+            Test.@testset "IP: rhs fills du via in-place call" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                du  = zeros(2)
+                p   = Common.ODEParameters(nothing)
+                Systems.rhs(sys)(du, [1.0, 2.0], p, 0.0)
+                Test.@test du ≈ [-1.0, -2.0]
+            end
+
+            Test.@testset "IP: rhs_oop(sys, true) === sys.rhs_oop" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                Test.@test Systems.rhs_oop(sys, true) === sys.rhs_oop
+            end
+
+            Test.@testset "IP: rhs_oop(sys, false) === sys.rhs_oop_finalize and warns" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                f   = Test.@test_logs (:warn, r"InPlace VectorField") Systems.rhs_oop(sys, false)
+                Test.@test f === sys.rhs_oop_finalize
+            end
+
+            Test.@testset "IP: rhs_oop(sys, true) returns mutable Vector" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                f   = Systems.rhs_oop(sys, true)
+                p   = Common.ODEParameters(nothing)
+                du  = f([1.0, 2.0], p, 0.0)
+                Test.@test du ≈ [-1.0, -2.0]
+                Test.@test du isa Vector
+            end
+
+            Test.@testset "IP: rhs_oop_finalize returns SVector for SVector u" begin
+                vf  = Systems.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                f   = sys.rhs_oop_finalize
+                u   = SA[1.0, 2.0]
+                p   = Common.ODEParameters(nothing)
+                du  = f(u, p, 0.0)
+                Test.@test du ≈ SA[-1.0, -2.0]
+                Test.@test du isa StaticArrays.SVector
+            end
+
+            Test.@testset "OOP: rhs_oop(sys, false) still returns sys.rhs_oop" begin
+                vf  = Systems.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+                sys = Systems.VectorFieldSystem(vf)
+                Test.@test Systems.rhs_oop(sys, true)  === sys.rhs_oop
+                Test.@test Systems.rhs_oop(sys, false) === sys.rhs_oop
             end
         end
 


### PR DESCRIPTION
Add InPlace/OutOfPlace mutability trait and full pipeline support for in-place vector fields ((du, x) -> du .= f(x) style) alongside the existing out-of-place style (x -> f(x)).

Common
- Add AbstractMutabilityTrait, InPlace, OutOfPlace to abstract_trait.jl
- Add trait functions: mutability_trait, is_inplace, is_outofplace, has_mutability_trait to traits.jl
- Export new types and functions from Common.jl

Data
- Add MD <: AbstractMutabilityTrait type parameter to AbstractVectorField, VectorField, and HamiltonianVectorField
- Auto-detect mutability from function arity at construction time
- Update call operators for both IP and OOP signatures

Systems
- Add MD type parameter to VectorFieldSystem and HamiltonianVectorFieldSystem
- Add rhs_oop_finalize field: closure for IP systems with immutable u0 (e.g. SVector) that allocates, calls the IP function, then converts back to typeof(u0)
- Add rhs_oop(sys, is_u0_mutable::Bool) dispatch
- Unify _build_rhs Val{N}/Val{nothing} variants into Val{N} where N
- Document that InPlace _build_rhs needs no _ham_assign! since views into du suffice

Extension CTFlowsSciML
- Call rhs_oop(system, false) for immutable u0, enabling IP vector fields to work correctly with SVector initial conditions

Tests: 1365 tests passing
- Common: AbstractMutabilityTrait, InPlace, OutOfPlace, trait functions
- Systems VFS/HVFS: IP construction, rhs/rhs_oop/rhs_oop_finalize closure identity mocks, Vector/SVector dispatch
- SciML extension: all OOP/IP x Vector/SVector combinations for VF and HVF
- Flow callables: IP VF/HVF + Vector/SVector, @test_logs for warning capture