### PR TITLE
Robust mutability detection enhancement

### DIFF
--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -50,7 +50,7 @@ export ODEParameters
 export has_time_dependence_trait, has_variable_dependence_trait, has_mutability_trait
 export time_dependence, variable_dependence, mutability_trait
 export is_inplace, is_outofplace
-export __is_autonomous, __is_variable, __variable, __unsafe
+export __is_autonomous, __is_variable, __variable, __unsafe, __is_inplace
 export deepvalue, real_norm
 
 end # module Common

--- a/src/Common/default.jl
+++ b/src/Common/default.jl
@@ -41,3 +41,18 @@ Returns `false` by default, meaning ODE solver retcodes are checked and
 failures throw exceptions unless explicitly bypassed.
 """
 __unsafe()::Bool = false
+
+"""
+$(TYPEDSIGNATURES)
+
+Default value for in-place flag in vector field constructors.
+
+Returns `nothing` by default, meaning mutability is auto-detected from
+the function signature unless specified otherwise.
+
+# Returns
+- `Nothing`: The default value for the `is_inplace` parameter.
+
+See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref).
+"""
+__is_inplace() = nothing

--- a/src/Data/hamiltonian_vector_field.jl
+++ b/src/Data/hamiltonian_vector_field.jl
@@ -84,6 +84,9 @@ Detect the mutability trait from the Hamiltonian vector field function signature
 Compares the function arity to the expected out-of-place arity and in-place arity
 (arity + 2 for HamiltonianVectorField, which has two output buffers). Returns `InPlace` or `OutOfPlace` accordingly.
 
+If the function has multiple methods, throws a `PreconditionError` indicating that
+auto-detection is ambiguous and the user should specify `is_inplace` explicitly.
+
 # Arguments
 - `f::Function`: The Hamiltonian vector-field function.
 - `TD`: Time dependence trait type.
@@ -93,9 +96,27 @@ Compares the function arity to the expected out-of-place arity and in-place arit
 - `Type{InPlace}` or `Type{OutOfPlace}`.
 
 # Throws
-- `Exceptions.IncorrectArgument`: If the arity is ambiguous or invalid.
+- `Exceptions.PreconditionError`: If the function has multiple methods, making automatic arity detection ambiguous.
+- `Exceptions.IncorrectArgument`: If the arity is invalid (does not match expected out-of-place or in-place arity).
+
+# Notes
+- This function is called automatically by the `HamiltonianVectorField` constructor when `is_inplace` is `nothing`.
+- Users can bypass auto-detection by specifying `is_inplace=true` or `is_inplace=false` explicitly in the constructor.
+- HamiltonianVectorField has two output buffers (dx, dp), so the in-place arity is `oop_arity + 2`.
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.InPlace`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
 """
 function _detect_mutability_hvf(f::Function, TD, VD)
+    method_count = length(methods(f))
+    if method_count > 1
+        throw(Exceptions.PreconditionError(
+            "Cannot auto-detect mutability: function has multiple methods";
+            reason = "The function has $method_count methods, making automatic arity detection ambiguous",
+            suggestion = "Specify `is_inplace=true` or `is_inplace=false` explicitly in the constructor",
+            context = "HamiltonianVectorField mutability detection",
+        ))
+    end
+
     arity = first(methods(f)).nargs - 1
     oop_arity = _oop_arity_hvf(TD, VD)
     ip_arity = oop_arity + 2  # HamiltonianVectorField has two output buffers (dx, dp)
@@ -122,6 +143,7 @@ Construct a `HamiltonianVectorField` with trait flags.
 - `f::Function`: The Hamiltonian vector field function returning `(dx, dp)`.
 - `is_autonomous::Bool`: If true, system is autonomous (default: `Common.__is_autonomous()`).
 - `is_variable::Bool`: If true, system depends on variable parameters (default: `Common.__is_variable()`).
+- `is_inplace::Union{Bool, Nothing}`: If true, function is in-place; if false, function is out-of-place; if `nothing`, mutability is auto-detected from function signature (default: `Common.__is_inplace()`).
 
 # Returns
 - `HamiltonianVectorField`: A HamiltonianVectorField with appropriate traits.
@@ -143,14 +165,33 @@ HamiltonianVectorField
   variable_dependence: Fixed
   mutability: OutOfPlace
   function: var"#2"
+
+julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); is_inplace=true)  # Explicit in-place
+HamiltonianVectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  mutability: InPlace
+  function: var"#3"
 ```
 
-See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
+# Notes
+- If `is_inplace` is `nothing` (default), the mutability is auto-detected from the function signature by checking the number of arguments.
+- If the function has multiple methods, auto-detection will fail with a `PreconditionError`. In this case, specify `is_inplace` explicitly.
+
+See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref), [`CTFlows.Common.InPlace`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
 """
-function HamiltonianVectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
+function HamiltonianVectorField(f; 
+    is_autonomous::Bool = Common.__is_autonomous(), 
+    is_variable::Bool = Common.__is_variable(), 
+    is_inplace::Union{Bool, Nothing} = Common.__is_inplace()
+)
     TD = is_autonomous ? Common.Autonomous : Common.NonAutonomous
     VD = is_variable ? Common.NonFixed : Common.Fixed
-    MD = _detect_mutability_hvf(f, TD, VD)
+    MD = if is_inplace === nothing
+        _detect_mutability_hvf(f, TD, VD)
+    else
+        is_inplace ? InPlace : OutOfPlace
+    end
     return HamiltonianVectorField{typeof(f), TD, VD, MD}(f)
 end
 

--- a/src/Data/vector_field.jl
+++ b/src/Data/vector_field.jl
@@ -82,6 +82,9 @@ Detect the mutability trait from the function signature.
 Compares the function arity to the expected out-of-place arity and in-place arity
 (arity + 1 for VectorField). Returns `InPlace` or `OutOfPlace` accordingly.
 
+If the function has multiple methods, throws a `PreconditionError` indicating that
+auto-detection is ambiguous and the user should specify `is_inplace` explicitly.
+
 # Arguments
 - `f::Function`: The vector-field function.
 - `TD`: Time dependence trait type.
@@ -91,9 +94,26 @@ Compares the function arity to the expected out-of-place arity and in-place arit
 - `Type{InPlace}` or `Type{OutOfPlace}`.
 
 # Throws
-- `Exceptions.IncorrectArgument`: If the arity is ambiguous or invalid.
+- `Exceptions.PreconditionError`: If the function has multiple methods, making automatic arity detection ambiguous.
+- `Exceptions.IncorrectArgument`: If the arity is invalid (does not match expected out-of-place or in-place arity).
+
+# Notes
+- This function is called automatically by the `VectorField` constructor when `is_inplace` is `nothing`.
+- Users can bypass auto-detection by specifying `is_inplace=true` or `is_inplace=false` explicitly in the constructor.
+
+See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.InPlace`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
 """
 function _detect_mutability_vf(f::Function, TD, VD)
+    method_count = length(methods(f))
+    if method_count > 1
+        throw(Exceptions.PreconditionError(
+            "Cannot auto-detect mutability: function has multiple methods";
+            reason = "The function has $method_count methods, making automatic arity detection ambiguous",
+            suggestion = "Specify `is_inplace=true` or `is_inplace=false` explicitly in the constructor",
+            context = "VectorField mutability detection",
+        ))
+    end
+
     arity = first(methods(f)).nargs - 1
     oop_arity = _oop_arity_vf(TD, VD)
     ip_arity = oop_arity + 1
@@ -120,6 +140,7 @@ Construct a `VectorField` with trait flags.
 - `f::Function`: The vector-field function.
 - `is_autonomous::Bool`: If true, system is autonomous (default: `Common.__is_autonomous()`).
 - `is_variable::Bool`: If true, system depends on variable parameters (default: `Common.__is_variable()`).
+- `is_inplace::Union{Bool, Nothing}`: If true, function is in-place; if false, function is out-of-place; if `nothing`, mutability is auto-detected from function signature (default: `Common.__is_inplace()`).
 
 # Returns
 - `VectorField`: A VectorField with appropriate traits.
@@ -141,14 +162,33 @@ VectorField
   variable_dependence: Fixed
   mutability: OutOfPlace
   function: var"#2"
+
+julia> vf = VectorField(x -> -x; is_inplace=true)  # Explicit in-place
+VectorField
+  time_dependence: Autonomous
+  variable_dependence: Fixed
+  mutability: InPlace
+  function: var"#3"
 \`\`\`
 
-See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
+# Notes
+- If `is_inplace` is `nothing` (default), the mutability is auto-detected from the function signature by checking the number of arguments.
+- If the function has multiple methods, auto-detection will fail with a `PreconditionError`. In this case, specify `is_inplace` explicitly.
+
+See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Common.Autonomous`](@ref), [`CTFlows.Common.NonAutonomous`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref), [`CTFlows.Common.InPlace`](@ref), [`CTFlows.Common.OutOfPlace`](@ref).
 """
-function VectorField(f; is_autonomous::Bool = Common.__is_autonomous(), is_variable::Bool = Common.__is_variable())
+function VectorField(f; 
+    is_autonomous::Bool = Common.__is_autonomous(), 
+    is_variable::Bool = Common.__is_variable(), 
+    is_inplace::Union{Bool, Nothing} = Common.__is_inplace()
+)
     TD = is_autonomous ? Autonomous : NonAutonomous
     VD = is_variable ? NonFixed : Fixed
-    MD = _detect_mutability_vf(f, TD, VD)
+    MD = if is_inplace === nothing
+        _detect_mutability_vf(f, TD, VD)
+    else
+        is_inplace ? InPlace : OutOfPlace
+    end
     return VectorField{typeof(f), TD, VD, MD}(f)
 end
 

--- a/test/suite/common/test_default.jl
+++ b/test/suite/common/test_default.jl
@@ -33,6 +33,10 @@ function test_default()
             Test.@testset "__unsafe returns false" begin
                 Test.@test Common.__unsafe() === false
             end
+
+            Test.@testset "__is_inplace returns nothing" begin
+                Test.@test Common.__is_inplace() === nothing
+            end
         end
     end
 end

--- a/test/suite/data/test_hamiltonian_vector_field.jl
+++ b/test/suite/data/test_hamiltonian_vector_field.jl
@@ -3,9 +3,15 @@ module TestHamiltonianVectorField
 import Test
 import CTFlows.Data: Data
 import CTFlows.Common: Common
+import CTBase.Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# TOP-LEVEL: Fake function with multiple methods for testing
+_multi_method_hvf(x::Int, p) = (x, -p)
+_multi_method_hvf(x::Float64, p) = (x, -p)
+_multi_method_hvf(x::AbstractVector, p) = (x, -p)
 
 function test_hamiltonian_vector_field()
     Test.@testset "Hamiltonian Vector Field Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -123,6 +129,41 @@ function test_hamiltonian_vector_field()
             hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
             # Just check that show doesn't throw
             Test.@test_nowarn sprint(show, hvf)
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Explicit is_inplace parameter
+        # ====================================================================
+
+        Test.@testset "Explicit is_inplace parameter" begin
+            Test.@testset "is_inplace=true creates InPlace HamiltonianVectorField" begin
+                # Define an out-of-place function but force InPlace
+                f(x, p) = (x, -p)
+                hvf = Data.HamiltonianVectorField(f; is_inplace=true)
+                Test.@test Common.mutability_trait(hvf) === Common.InPlace
+            end
+
+            Test.@testset "is_inplace=false creates OutOfPlace HamiltonianVectorField" begin
+                # Define an in-place function but force OutOfPlace
+                f(x, p) = (x, -p)
+                hvf = Data.HamiltonianVectorField(f; is_inplace=false)
+                Test.@test Common.mutability_trait(hvf) === Common.OutOfPlace
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - PreconditionError for multiple methods
+        # ====================================================================
+
+        Test.@testset "PreconditionError for multiple methods" begin
+            Test.@testset "Throws PreconditionError when is_inplace is not specified" begin
+                Test.@test_throws Exceptions.PreconditionError Data.HamiltonianVectorField(_multi_method_hvf)
+            end
+
+            Test.@testset "No error when is_inplace is explicitly specified" begin
+                hvf = Data.HamiltonianVectorField(_multi_method_hvf; is_inplace=false)
+                Test.@test Common.mutability_trait(hvf) === Common.OutOfPlace
+            end
         end
     end
 end

--- a/test/suite/data/test_vector_field.jl
+++ b/test/suite/data/test_vector_field.jl
@@ -3,9 +3,15 @@ module TestVectorField
 import Test
 import CTFlows.Data
 import CTFlows.Common
+import CTBase.Exceptions
 
 const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+# TOP-LEVEL: Fake function with multiple methods for testing
+_multi_method_f(x::Int) = -x
+_multi_method_f(x::Float64) = -x
+_multi_method_f(x::AbstractVector) = -x
 
 # ==============================================================================
 # Test function
@@ -293,6 +299,41 @@ function test_vector_field()
         Test.@testset "Exports Verification" begin
             Test.@testset "Exported types" begin
                 Test.@test isdefined(Data, :VectorField)
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Explicit is_inplace parameter
+        # ====================================================================
+
+        Test.@testset "Explicit is_inplace parameter" begin
+            Test.@testset "is_inplace=true creates InPlace VectorField" begin
+                # Define an out-of-place function but force InPlace
+                f(x) = -x
+                vf = Data.VectorField(f; is_inplace=true)
+                Test.@test Common.mutability_trait(vf) === Common.InPlace
+            end
+
+            Test.@testset "is_inplace=false creates OutOfPlace VectorField" begin
+                # Define an in-place function but force OutOfPlace
+                f(x) = -x
+                vf = Data.VectorField(f; is_inplace=false)
+                Test.@test Common.mutability_trait(vf) === Common.OutOfPlace
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - PreconditionError for multiple methods
+        # ====================================================================
+
+        Test.@testset "PreconditionError for multiple methods" begin
+            Test.@testset "Throws PreconditionError when is_inplace is not specified" begin
+                Test.@test_throws Exceptions.PreconditionError Data.VectorField(_multi_method_f)
+            end
+
+            Test.@testset "No error when is_inplace is explicitly specified" begin
+                vf = Data.VectorField(_multi_method_f; is_inplace=false)
+                Test.@test Common.mutability_trait(vf) === Common.OutOfPlace
             end
         end
     end


### PR DESCRIPTION
Add explicit is_inplace parameter to VectorField and HamiltonianVectorField constructors to handle functions with multiple methods.

- Add Common.__is_inplace() returning nothing as default
- Export __is_inplace from Common module
- Add is_inplace::Union{Bool, Nothing} parameter to constructors
- Modify _detect_mutability_vf and _detect_mutability_hvf to check method count
- Throw PreconditionError when function has multiple methods
- Add tests for explicit is_inplace parameter and PreconditionError handling
- Update docstrings for all modified functions