### PR TITLE
Refactor: convert state_dimension to keyword argument with Union{Int,…

### DIFF
--- a/ext/CTFlowsStaticArrays.jl
+++ b/ext/CTFlowsStaticArrays.jl
@@ -21,7 +21,7 @@ using CTFlowsStaticArrays  # Loads this extension
 
 # Now HamiltonianFlow works efficiently with SVector
 hvf = HamiltonianVectorField((x, p) -> (p, -x); autonomous=true, variable=false)
-sys = HamiltonianVectorFieldSystem(hvf, 2)  # N=2 known
+sys = HamiltonianVectorFieldSystem(hvf; state_dimension=2)  # N=2 known
 flow = build_flow(sys, SciML())
 xf, pf = flow(0.0, SA[1.0, 0.0], SA[0.0, 1.0], π/2)
 

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -50,7 +50,7 @@ export ODEParameters
 export has_time_dependence_trait, has_variable_dependence_trait, has_mutability_trait
 export time_dependence, variable_dependence, mutability_trait
 export is_inplace, is_outofplace
-export __is_autonomous, __is_variable, __variable, __unsafe, __is_inplace
+export __is_autonomous, __is_variable, __variable, __unsafe, __is_inplace, __state_dimension
 export deepvalue, real_norm
 
 end # module Common

--- a/src/Common/default.jl
+++ b/src/Common/default.jl
@@ -56,3 +56,19 @@ the function signature unless specified otherwise.
 See also: [`CTFlows.Data.VectorField`](@ref), [`CTFlows.Data.HamiltonianVectorField`](@ref).
 """
 __is_inplace() = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
+Default value for state dimension parameter in Hamiltonian system constructors.
+
+Returns `nothing` by default, meaning the state dimension is not specified
+and will be inferred at runtime. When specified as an integer, the dimension
+is stored as a type parameter for compile-time validation and performance.
+
+# Returns
+- `Nothing`: The default value for the `state_dimension` parameter.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTFlows.Systems.build_system`](@ref).
+"""
+__state_dimension() = nothing

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -45,6 +45,7 @@ This constructor builds a complete Hamiltonian flow by:
 
 # Arguments
 - `data::CTFlows.Data.HamiltonianVectorField`: The Hamiltonian vector field defining the system dynamics.
+- `state_dimension::Union{Int, Nothing}`: The state dimension (number of state variables, not including costates). Defaults to `nothing`.
 - `opts...`: Keyword options passed to the integrator's strategy.
 
 # Returns
@@ -56,44 +57,14 @@ using CTFlows.Data, CTFlows.Flows, CTFlows.Common
 
 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
 flow = Flows.Flow(hvf; reltol=1e-8)
+flow_with_dim = Flows.Flow(hvf; state_dimension=3, reltol=1e-8)
 ```
 
 See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_system`](@ref), [`CTFlows.Integrators.build_integrator`](@ref).
 """
-function Flow(data::Data.HamiltonianVectorField; opts...)
-    system = Systems.build_system(data)
+function Flow(data::Data.HamiltonianVectorField; state_dimension::Union{Int, Nothing}=Common.__state_dimension(), opts...)
+    system = Systems.build_system(data; state_dimension=state_dimension)
     integrator = Integrators.build_integrator(; opts...)
     return build_flow(system, integrator)
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-High-level constructor for `HamiltonianFlow` from Hamiltonian vector field data with known state dimension.
-
-This constructor builds a complete Hamiltonian flow with a known state dimension for
-type stability and validation. The dimension is stored as a type parameter.
-
-# Arguments
-- `data::CTFlows.Data.HamiltonianVectorField`: The Hamiltonian vector field defining the system dynamics.
-- `n_state::Int`: The state dimension (number of state variables, not including costates).
-- `opts...`: Keyword options passed to the integrator's strategy.
-
-# Returns
-- `CTFlows.Flows.HamiltonianFlow`: The complete Hamiltonian flow ready for integration.
-
-# Example
-```julia
-using CTFlows.Data, CTFlows.Flows, CTFlows.Common
-
-hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
-flow = Flows.Flow(hvf, 3; reltol=1e-8)  # with known state dimension
-```
-
-See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_system`](@ref), [`CTFlows.Integrators.build_integrator`](@ref).
-"""
-function Flow(data::Data.HamiltonianVectorField, n_state::Int; opts...)
-    system = Systems.build_system(data, n_state)
-    integrator = Integrators.build_integrator(; opts...)
-    return build_flow(system, integrator)
-end

--- a/src/Systems/building.jl
+++ b/src/Systems/building.jl
@@ -39,17 +39,18 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build a `HamiltonianVectorFieldSystem` from a `HamiltonianVectorField` without known state dimension.
+Build a `HamiltonianVectorFieldSystem` from a `HamiltonianVectorField`.
 
 Constructs a concrete Hamiltonian system that wraps the Hamiltonian vector field with
-a pre-computed right-hand side function for integration. The state dimension is not
-specified and will be inferred at runtime.
+a pre-computed right-hand side function for integration. The state dimension can be
+specified for type stability and performance, or left as `nothing` to be inferred at runtime.
 
 # Arguments
 - `hvf::Data.HamiltonianVectorField`: The Hamiltonian vector field to wrap into a system.
+- `state_dimension::Union{Int, Nothing}`: The state dimension (number of state variables, not including costates). Defaults to `nothing`.
 
 # Returns
-- `HamiltonianVectorFieldSystem`: A concrete Hamiltonian system with unknown dimension.
+- `HamiltonianVectorFieldSystem`: A concrete Hamiltonian system.
 
 # Example
 ```julia-repl
@@ -65,52 +66,20 @@ julia> sys = build_system(hvf)
 HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
-  n_state: unknown
+  state_dimension: unknown
   hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
-```
 
-See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
-"""
-function build_system(hvf::Data.HamiltonianVectorField)
-    return HamiltonianVectorFieldSystem(hvf)
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Build a `HamiltonianVectorFieldSystem` from a `HamiltonianVectorField` with known state dimension.
-
-Constructs a concrete Hamiltonian system that wraps the Hamiltonian vector field with
-a pre-computed right-hand side function for integration. The state dimension `n_state`
-is stored as a type parameter for compile-time validation and performance.
-
-# Arguments
-- `hvf::Data.HamiltonianVectorField`: The Hamiltonian vector field to wrap into a system.
-- `n_state::Int`: The state dimension (number of state variables, not including costates).
-
-# Returns
-- `HamiltonianVectorFieldSystem`: A concrete Hamiltonian system with known dimension.
-
-# Example
-```julia-repl
-julia> using CTFlows.Systems, CTFlows.Common
-
-julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
-HamiltonianVectorField
-  time_dependence: Autonomous
-  variable_dependence: Fixed
-  function: var"#1"
-
-julia> sys = build_system(hvf, 3)
+julia> sys = build_system(hvf; state_dimension=3)
 HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
-  n_state: 3
+  state_dimension: 3
   hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed}
 ```
 
 See also: [`CTFlows.Data.HamiltonianVectorField`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
 """
-function build_system(hvf::Data.HamiltonianVectorField, n_state::Int)
-    return HamiltonianVectorFieldSystem(hvf, n_state)
+function build_system(hvf::Data.HamiltonianVectorField; state_dimension::Union{Int, Nothing}=Common.__state_dimension())
+    return HamiltonianVectorFieldSystem(hvf; state_dimension=state_dimension)
 end
+

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -37,7 +37,7 @@ HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
   mutability: OutOfPlace
-  n_state: 3
+  state_dimension: 3
   hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed, OutOfPlace}
 
 julia> sys = HamiltonianVectorFieldSystem(hvf)  # without dimension
@@ -45,7 +45,7 @@ HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
   mutability: OutOfPlace
-  n_state: unknown
+  state_dimension: unknown
   hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed, OutOfPlace}
 ```
 
@@ -62,36 +62,20 @@ end
 # Constructors
 # =============================================================================
 
-# OutOfPlace, with known dimension N
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, n_state::Int) where {F, TD, VD}
-    rhs              = _build_rhs(hvf, Val(n_state))
-    rhs_oop          = _build_oop_rhs(hvf, Val(n_state))
+# OutOfPlace, with optional dimension
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}; state_dimension::Union{Int, Nothing}=Common.__state_dimension()) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(state_dimension))
+    rhs_oop          = _build_oop_rhs(hvf, Val(state_dimension))
     rhs_oop_finalize = nothing
-    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(hvf, rhs, rhs_oop, rhs_oop_finalize)
+    return HamiltonianVectorFieldSystem{state_dimension, F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(hvf, rhs, rhs_oop, rhs_oop_finalize)
 end
 
-# InPlace, with known dimension N
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, n_state::Int) where {F, TD, VD}
-    rhs              = _build_rhs(hvf, Val(n_state))
-    rhs_oop          = _build_oop_rhs(hvf, Val(n_state))
-    rhs_oop_finalize = _build_finalize_rhs_hvf_ip(hvf, Val(n_state))
-    return HamiltonianVectorFieldSystem{n_state, F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(hvf, rhs, rhs_oop, rhs_oop_finalize)
-end
-
-# OutOfPlace, without dimension (N=nothing)
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
-    rhs              = _build_rhs(hvf, Val(nothing))
-    rhs_oop          = _build_oop_rhs(hvf, Val(nothing))
-    rhs_oop_finalize = nothing
-    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, OutOfPlace, typeof(rhs), typeof(rhs_oop), Nothing}(hvf, rhs, rhs_oop, rhs_oop_finalize)
-end
-
-# InPlace, without dimension (N=nothing)
-function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}) where {F, TD, VD}
-    rhs              = _build_rhs(hvf, Val(nothing))
-    rhs_oop          = _build_oop_rhs(hvf, Val(nothing))
-    rhs_oop_finalize = _build_finalize_rhs_hvf_ip(hvf, Val(nothing))
-    return HamiltonianVectorFieldSystem{nothing, F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(hvf, rhs, rhs_oop, rhs_oop_finalize)
+# InPlace, with optional dimension
+function HamiltonianVectorFieldSystem(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}; state_dimension::Union{Int, Nothing}=Common.__state_dimension()) where {F, TD, VD}
+    rhs              = _build_rhs(hvf, Val(state_dimension))
+    rhs_oop          = _build_oop_rhs(hvf, Val(state_dimension))
+    rhs_oop_finalize = _build_finalize_rhs_hvf_ip(hvf, Val(state_dimension))
+    return HamiltonianVectorFieldSystem{state_dimension, F, TD, VD, InPlace, typeof(rhs), typeof(rhs_oop), typeof(rhs_oop_finalize)}(hvf, rhs, rhs_oop, rhs_oop_finalize)
 end
 
 # =============================================================================

--- a/test/suite/extensions/test_flow_callables_sciml.jl
+++ b/test/suite/extensions/test_flow_callables_sciml.jl
@@ -28,8 +28,8 @@ const INTEG = Integrators.SciML()
 # Solution: x(t) = x0 cos(t) + p0 sin(t),  p(t) = -x0 sin(t) + p0 cos(t)
 const HVF_HARMONIC = Data.HamiltonianVectorField((x, p) -> (p, -x); is_autonomous=true, is_variable=false)
 const HSYS_NO_N = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC)           # N=nothing
-const HSYS_N1  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC, 1)         # N=1 (scalar)
-const HSYS_N2  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC, 2)         # N=2 (for SVector)
+const HSYS_N1  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC; state_dimension=1)         # N=1 (scalar)
+const HSYS_N2  = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC; state_dimension=2)         # N=2 (for SVector)
 const ATOL = 1e-5
 
 # InPlace variants (same dynamics, different function signature)
@@ -38,8 +38,8 @@ const SYS_DECAY_IP = Systems.VectorFieldSystem(VF_DECAY_IP)
 
 const HVF_HARMONIC_IP = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= p; dp .= -x); is_autonomous=true, is_variable=false)
 const HSYS_IP_NO_N = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP)
-const HSYS_IP_N1   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP, 1)
-const HSYS_IP_N2   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP, 2)
+const HSYS_IP_N1   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP; state_dimension=1)
+const HSYS_IP_N2   = Systems.HamiltonianVectorFieldSystem(HVF_HARMONIC_IP; state_dimension=2)
 
 # ==============================================================================
 # Test function

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -433,7 +433,7 @@ function test_sciml_extension()
 
             Test.@testset "OOP HVF + mutable Vector u0" begin
                 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=1)
                 u0  = [1.0, 0.5]
                 config = Common.StatePointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
@@ -446,7 +446,7 @@ function test_sciml_extension()
 
             Test.@testset "OOP HVF + SVector u0" begin
                 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=1)
                 u0  = SA[1.0, 0.5]
                 config = Common.StatePointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
@@ -459,7 +459,7 @@ function test_sciml_extension()
 
             Test.@testset "IP HVF + mutable Vector u0" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=1)
                 u0  = [1.0, 0.5]
                 config = Common.StatePointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
@@ -472,7 +472,7 @@ function test_sciml_extension()
 
             Test.@testset "IP HVF + SVector u0 (warns, uses rhs_oop_finalize)" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 1)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=1)
                 u0  = SA[1.0, 0.5]
                 config = Common.StatePointConfig(0.0, u0, 1.0)
                 prob = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") Integrators.build_problem(integ, sys, config; variable=nothing)

--- a/test/suite/solutions/test_building_solutions.jl
+++ b/test/suite/solutions/test_building_solutions.jl
@@ -86,8 +86,8 @@ function test_building_solutions()
         Test.@testset "build_solution - HamiltonianPointConfig" begin
             Test.@testset "scalar initial condition returns tuple of scalars" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
-                    1
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false);
+                    state_dimension=1
                 )
                 result = FakeIntegrationResult([[1.0, 0.5], [0.5, 0.25]])
                 config = Common.HamiltonianPointConfig(0.0, 1.0, 0.5, 1.0)
@@ -99,8 +99,8 @@ function test_building_solutions()
 
             Test.@testset "vector initial condition returns tuple of vectors" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
-                    2
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false);
+                    state_dimension=2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
                 config = Common.HamiltonianPointConfig(0.0, [1.0, 2.0], [0.5, 0.3], 1.0)
@@ -113,8 +113,8 @@ function test_building_solutions()
             Test.@testset "vector initial condition uses correct dimension split" begin
                 # Test the bug fix: should use length(initial_state) not length(initial_condition)
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
-                    3
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false);
+                    state_dimension=3
                 )
                 # Final state has 6 elements: 3 state + 3 costate
                 result = FakeIntegrationResult([[1.0, 2.0, 3.0, 0.5, 0.6, 0.7], [0.5, 1.0, 1.5, 0.25, 0.3, 0.35]])
@@ -133,8 +133,8 @@ function test_building_solutions()
         Test.@testset "build_solution - HamiltonianTrajectoryConfig" begin
             Test.@testset "returns HamiltonianVectorFieldSolution wrapping result" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
-                    2
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false);
+                    state_dimension=2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
                 config = Common.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 2.0], [0.5, 0.3])
@@ -145,8 +145,8 @@ function test_building_solutions()
 
             Test.@testset "HamiltonianVectorFieldSolution contains correct result" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
-                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false),
-                    2
+                    Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false);
+                    state_dimension=2
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
                 config = Common.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 2.0], [0.5, 0.3])

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -27,7 +27,7 @@ function test_hamiltonian_vector_field_system()
             Test.@test Systems.state_dimension(sys1) === nothing
             
             # From HamiltonianVectorField with dimension
-            sys2 = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            sys2 = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=3)
             Test.@test sys2 isa Systems.HamiltonianVectorFieldSystem
             Test.@test Systems.state_dimension(sys2) == 3
         end
@@ -45,7 +45,7 @@ function test_hamiltonian_vector_field_system()
             Test.@test Systems.state_dimension(sys1) === nothing
             
             # With dimension
-            sys2 = Systems.build_system(hvf, 3)
+            sys2 = Systems.build_system(hvf; state_dimension=3)
             Test.@test sys2 isa Systems.HamiltonianVectorFieldSystem
             Test.@test Systems.state_dimension(sys2) == 3
         end
@@ -167,7 +167,7 @@ function test_hamiltonian_vector_field_system()
             Test.@test dp_c == SA[-5.0-6.0im, -7.0-8.0im]
 
             # Call rhs_oop with SVector and N=2 (type-stable with extension)
-            sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+            sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
             rhs_oop = Systems.rhs_oop(sys)
             u = SA[1.0, 2.0, 3.0, 4.0]
             p_param = Common.ODEParameters(nothing)
@@ -274,7 +274,7 @@ function test_hamiltonian_vector_field_system()
             hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
 
             # With N known
-            sys1 = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+            sys1 = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
             Test.@test sys1.rhs_oop isa Function
             Test.@test Systems.rhs_oop(sys1) === sys1.rhs_oop
 
@@ -291,19 +291,19 @@ function test_hamiltonian_vector_field_system()
         Test.@testset "InPlace HamiltonianVectorField" begin
             Test.@testset "OOP: rhs_oop_finalize is Nothing" begin
                 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 Test.@test sys.rhs_oop_finalize === nothing
             end
 
             Test.@testset "IP: rhs_oop_finalize is Function" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 Test.@test sys.rhs_oop_finalize isa Function
             end
 
             Test.@testset "IP: rhs fills du via views (no _ham_assign! needed)" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 u   = [1.0, 2.0, 3.0, 4.0]
                 du  = zeros(4)
                 p   = Common.ODEParameters(nothing)
@@ -314,20 +314,20 @@ function test_hamiltonian_vector_field_system()
 
             Test.@testset "IP: rhs_oop(sys, true) === sys.rhs_oop" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 Test.@test Systems.rhs_oop(sys, true) === sys.rhs_oop
             end
 
             Test.@testset "IP: rhs_oop(sys, false) === sys.rhs_oop_finalize and warns" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 f   = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") Systems.rhs_oop(sys, false)
                 Test.@test f === sys.rhs_oop_finalize
             end
 
             Test.@testset "IP: rhs_oop(sys, true) returns mutable Vector" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 f   = Systems.rhs_oop(sys, true)
                 u   = [1.0, 2.0, 3.0, 4.0]
                 p   = Common.ODEParameters(nothing)
@@ -339,7 +339,7 @@ function test_hamiltonian_vector_field_system()
 
             Test.@testset "IP: rhs_oop_finalize returns SVector for SVector u" begin
                 hvf = Data.HamiltonianVectorField((dx, dp, x, p) -> (dx .= x; dp .= -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 f   = sys.rhs_oop_finalize
                 u   = SA[1.0, 2.0, 3.0, 4.0]
                 p   = Common.ODEParameters(nothing)
@@ -350,7 +350,7 @@ function test_hamiltonian_vector_field_system()
 
             Test.@testset "OOP: rhs_oop(sys, false) still returns sys.rhs_oop" begin
                 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
-                sys = Systems.HamiltonianVectorFieldSystem(hvf, 2)
+                sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=2)
                 Test.@test Systems.rhs_oop(sys, true)  === sys.rhs_oop
                 Test.@test Systems.rhs_oop(sys, false) === sys.rhs_oop
             end
@@ -364,7 +364,7 @@ function test_hamiltonian_vector_field_system()
             hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
 
             # System with known dimension
-            sys = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            sys = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=3)
 
             # Correct dimension (vector)
             Test.@test Systems._check_state_dimension(sys, [1.0, 2.0, 3.0]) == true
@@ -405,7 +405,7 @@ function test_hamiltonian_vector_field_system()
             end
 
             Test.@testset "With dimension" begin
-                sys2 = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+                sys2 = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=3)
                 io = IOBuffer()
                 show(io, sys2)
                 str = String(take!(io))
@@ -431,7 +431,7 @@ function test_hamiltonian_vector_field_system()
         Test.@testset "Type parameter N" begin
             hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
             
-            sys_with_n = Systems.HamiltonianVectorFieldSystem(hvf, 3)
+            sys_with_n = Systems.HamiltonianVectorFieldSystem(hvf; state_dimension=3)
             Test.@test Systems.state_dimension(sys_with_n) == 3
             
             sys_without_n = Systems.HamiltonianVectorFieldSystem(hvf)


### PR DESCRIPTION
… Nothing} type constraint

- Add __state_dimension() default function in Common/default.jl
- Export __state_dimension from Common/Common.jl
- Merge duplicate constructors into single constructors with state_dimension as keyword argument:
  - Flow constructor in Flows/building.jl
  - build_system function in Systems/building.jl
  - HamiltonianVectorFieldSystem constructors in Systems/hamiltonian_vector_field_system.jl
- Add type constraint Union{Int, Nothing} for type stability
- Update all test files to use keyword syntax
- Update extension file CTFlowsStaticArrays.jl example
- All 1403 tests pass