### PR TITLE
Add variable accessor for ODEParameters

### DIFF
--- a/reports/hamilonian/hamiltonian_plan.md
+++ b/reports/hamilonian/hamiltonian_plan.md
@@ -82,6 +82,14 @@ end
 
 Add a convenience constructor `ODEParameters(variable) = ODEParameters(variable, nothing)` to keep all existing call sites unchanged.
 
+Add a getter for the cache:
+
+```julia
+function cache(p::ODEParameters)
+    return p.cache
+end
+```
+
 ### Step 3 — Test Checkpoint: Common traits and ODEParameters
 
 - `@testset "Unit: WithAD / WithoutAD construction"` — subtypes of `AbstractADTrait`
@@ -241,7 +249,7 @@ Update `HamiltonianVectorFieldSystem` parent type to `AbstractHamiltonianSystem{
 ### Step 14 — `src/Systems/hamiltonian_system.jl` (new file)
 
 `HamiltonianSystem` is the new type built from a scalar `Hamiltonian` and an AD backend.
-It carries `WithAD` and pre-builds RHS closures that read `λ.cache` at each ODE step.
+It carries `WithAD` and pre-builds RHS closures that read `cache(λ)` at each ODE step.
 
 ```julia
 struct HamiltonianSystem{
@@ -262,13 +270,13 @@ struct HamiltonianSystem{
 end
 ```
 
-**RHS construction** — captures `h` and `backend`; reads `λ.cache` at each step:
+**RHS construction** — captures `h` and `backend`; reads `cache(λ)` at each step:
 
 ```julia
 function _build_rhs(h, backend, ::Val{N}) where N
     return function (du, u, λ, t)
         x, p   = _ham_split(u, N)
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, λ.variable, λ.cache)
+        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, variable(λ), cache(λ))
         _ham_assign!(du, ∂p, -∂x, N)   # ẋ = ∂H/∂p,  ṗ = -∂H/∂x
         return nothing
     end
@@ -281,8 +289,8 @@ end
 function _build_rhs_augmented(h, backend, ::Val{N}) where N
     return function (du, u, λ, t)
         x, p, pv = _aug_split(u, N)
-        ∂x, ∂p  = Differentiation.hamiltonian_gradient(backend, h, t, x, p, λ.variable, λ.cache)
-        ∂v       = Differentiation.variable_gradient(backend, h, t, x, p, λ.variable, λ.cache)
+        ∂x, ∂p  = Differentiation.hamiltonian_gradient(backend, h, t, x, p, variable(λ), cache(λ))
+        ∂v       = Differentiation.variable_gradient(backend, h, t, x, p, variable(λ), cache(λ))
         _aug_assign!(du, ∂p, -∂x, -∂v, N)   # ṗv = -∂H/∂v
         return nothing
     end

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -46,7 +46,7 @@ export AbstractConfig, AbstractPointConfig, AbstractTrajectoryConfig, AbstractSt
 export StatePointConfig, StateTrajectoryConfig, HamiltonianPointConfig, HamiltonianTrajectoryConfig
 export tspan, initial_condition, initial_state, initial_costate
 export VariableDependence, Fixed, NonFixed
-export ODEParameters
+export ODEParameters, variable
 export has_time_dependence_trait, has_variable_dependence_trait, has_mutability_trait
 export time_dependence, variable_dependence, mutability_trait
 export is_inplace, is_outofplace

--- a/src/Common/ode_parameters.jl
+++ b/src/Common/ode_parameters.jl
@@ -33,10 +33,48 @@ params_nonfixed = ODEParameters(0.5)
 # Notes
 - This type is used exclusively by the SciML extension to wrap the variable
   before passing it to `ODEProblem`.
-- The RHS closure reads `p.variable` to access the actual variable value.
+- The RHS closure reads `variable(p)` to access the actual variable value.
 
 See also: [`CTFlows.Common.VariableDependence`](@ref), [`CTFlows.Common.Fixed`](@ref), [`CTFlows.Common.NonFixed`](@ref).
 """
 struct ODEParameters{V}
     variable::V
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Accessor for the variable field of `ODEParameters`.
+
+Returns the variable parameter stored in the `ODEParameters` wrapper.
+For `Fixed` systems, this is `nothing`. For `NonFixed` systems, this is
+the actual variable value (scalar or vector).
+
+# Arguments
+- `p::ODEParameters`: The ODEParameters instance.
+
+# Returns
+- The variable value (or `nothing` for Fixed systems).
+
+# Example
+\`\`\`julia-repl
+julia> using CTFlows.Common
+
+julia> params_fixed = ODEParameters(nothing)
+ODEParameters{Nothing}(nothing)
+
+julia> variable(params_fixed)
+nothing
+
+julia> params_nonfixed = ODEParameters(0.5)
+ODEParameters{Float64}(0.5)
+
+julia> variable(params_nonfixed)
+0.5
+\`\`\`
+
+See also: [`CTFlows.Common.ODEParameters`](@ref), [`CTFlows.Common.VariableDependence`](@ref).
+"""
+function variable(p::ODEParameters)
+    return p.variable
 end

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -147,7 +147,7 @@ end
 function _build_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (du, u, λ, t)
         x, p = _ham_split(u, N)
-        dx, dp = hvf(t, x, p, λ.variable)
+        dx, dp = hvf(t, x, p, variable(λ))
         _ham_assign!(du, dx, dp, N)
         return nothing
     end
@@ -157,7 +157,7 @@ function _build_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, ::Val{
     return function (du, u, λ, t)
         x, p   = _ham_split(u,  N)
         dx, dp = _ham_split(du, N)  # mutable views into du — hvf writes directly into du, no _ham_assign! needed
-        hvf(dx, dp, t, x, p, λ.variable)
+        hvf(dx, dp, t, x, p, variable(λ))
         return nothing
     end
 end
@@ -169,7 +169,7 @@ end
 function _build_oop_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, OutOfPlace}, ::Val{N}) where {F, TD, VD, N}
     return function (u, λ, t)
         x, p = _ham_split(u, N)
-        dx, dp = hvf(t, x, p, λ.variable)
+        dx, dp = hvf(t, x, p, variable(λ))
         return vcat(dx, dp)
     end
 end
@@ -178,7 +178,7 @@ function _build_oop_rhs(hvf::Data.HamiltonianVectorField{F, TD, VD, InPlace}, ::
     return function (u, λ, t)
         x, p   = _ham_split(u, N)
         dx, dp = similar(x), similar(p)
-        hvf(dx, dp, t, x, p, λ.variable)
+        hvf(dx, dp, t, x, p, variable(λ))
         return vcat(dx, dp)
     end
 end
@@ -191,7 +191,7 @@ function _build_finalize_rhs_hvf_ip(hvf::Data.HamiltonianVectorField{F, TD, VD, 
     return function (u, λ, t)
         x, p   = _ham_split(u, N)
         dx, dp = similar(x), similar(p)
-        hvf(dx, dp, t, x, p, λ.variable)
+        hvf(dx, dp, t, x, p, variable(λ))
         return typeof(u)(vcat(dx, dp))
     end
 end

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -63,21 +63,21 @@ end
 # =============================================================================
 
 function _build_rhs_vf_oop(vf::Data.VectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
-    return (du, u, λ, t) -> (du .= vf(t, u, λ.variable); nothing)
+    return (du, u, λ, t) -> (du .= vf(t, u, variable(λ)); nothing)
 end
 
 function _build_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
-    return (du, u, λ, t) -> (vf(du, t, u, λ.variable); nothing)
+    return (du, u, λ, t) -> (vf(du, t, u, variable(λ)); nothing)
 end
 
 function _build_oop_rhs_vf_oop(vf::Data.VectorField{F, TD, VD, OutOfPlace}) where {F, TD, VD}
-    return (u, λ, t) -> vf(t, u, λ.variable)
+    return (u, λ, t) -> vf(t, u, variable(λ))
 end
 
 function _build_oop_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
     return function (u, λ, t)
         dx = similar(u)
-        vf(dx, t, u, λ.variable)
+        vf(dx, t, u, variable(λ))
         return dx
     end
 end
@@ -85,7 +85,7 @@ end
 function _build_finalize_rhs_vf_ip(vf::Data.VectorField{F, TD, VD, InPlace}) where {F, TD, VD}
     return function (u, λ, t)
         dx = similar(u)
-        vf(dx, t, u, λ.variable)
+        vf(dx, t, u, variable(λ))
         return typeof(u)(dx)
     end
 end
@@ -123,7 +123,7 @@ rhs(du, u, p, 0.0)
 # Notes
 - The closure is computed once at construction time for performance.
 - Multiple calls to `rhs` return the same function object.
-- The closure reads `p.variable` to access the actual variable value.
+- The closure reads `variable(p)` to access the actual variable value.
 
 See also: [`CTFlows.Systems.VectorFieldSystem`](@ref), [`CTFlows.Systems.AbstractSystem`](@ref), [`CTFlows.Common.ODEParameters`](@ref).
 """

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -133,13 +133,13 @@ function test_common_module()
             Test.@testset "constructs with nothing" begin
                 params = Common.ODEParameters(nothing)
                 Test.@test params isa Common.ODEParameters
-                Test.@test params.variable === nothing
+                Test.@test Common.variable(params) === nothing
             end
 
             Test.@testset "constructs with value" begin
                 params = Common.ODEParameters(0.5)
                 Test.@test params isa Common.ODEParameters
-                Test.@test params.variable == 0.5
+                Test.@test Common.variable(params) == 0.5
             end
         end
 

--- a/test/suite/common/test_ode_parameters.jl
+++ b/test/suite/common/test_ode_parameters.jl
@@ -21,17 +21,38 @@ function test_ode_parameters()
 
             Test.@testset "accepts nothing for Fixed systems" begin
                 params = Common.ODEParameters(nothing)
-                Test.@test params.variable === nothing
+                Test.@test Common.variable(params) === nothing
             end
 
             Test.@testset "accepts value for NonFixed systems" begin
                 params = Common.ODEParameters(0.5)
-                Test.@test params.variable == 0.5
+                Test.@test Common.variable(params) == 0.5
             end
 
             Test.@testset "accepts vector for NonFixed systems" begin
                 params = Common.ODEParameters([1.0, 2.0])
-                Test.@test params.variable == [1.0, 2.0]
+                Test.@test Common.variable(params) == [1.0, 2.0]
+            end
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Accessor function
+        # ====================================================================
+
+        Test.@testset "Accessor function" begin
+            Test.@testset "variable accessor returns nothing" begin
+                params = Common.ODEParameters(nothing)
+                Test.@test Common.variable(params) === nothing
+            end
+
+            Test.@testset "variable accessor returns value" begin
+                params = Common.ODEParameters(0.5)
+                Test.@test Common.variable(params) == 0.5
+            end
+
+            Test.@testset "variable accessor returns vector" begin
+                params = Common.ODEParameters([1.0, 2.0])
+                Test.@test Common.variable(params) == [1.0, 2.0]
             end
         end
 

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -204,7 +204,7 @@ function test_sciml_extension()
 
                 Test.@test prob isa SciMLBase.AbstractODEProblem
                 Test.@test prob.p isa Common.ODEParameters
-                Test.@test prob.p.variable === nothing
+                Test.@test Common.variable(prob.p) === nothing
             end
             
             Test.@testset "builds ODEProblem with variable parameter" begin
@@ -221,7 +221,7 @@ function test_sciml_extension()
 
                 Test.@test prob isa SciMLBase.AbstractODEProblem
                 Test.@test prob.p isa Common.ODEParameters
-                Test.@test prob.p.variable == 0.5
+                Test.@test Common.variable(prob.p) == 0.5
             end
         end
 


### PR DESCRIPTION
- Add variable(p::ODEParameters) accessor function for better encapsulation
- Replace all direct field accesses λ.variable with variable(λ) in RHS builders
- Update tests to use accessor instead of direct field access
- Export variable from Common module
- Add comprehensive docstring for accessor function

This change improves encapsulation and provides a uniform API for accessing the variable parameter, making future refactoring easier.