### PR TITLE
Refactor: unify coercion functions into Common.make_coerce

### DIFF
--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -14,6 +14,7 @@ module Common
 # External package imports
 # ==============================================================================
 
+import Base: only
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 import CTBase.Exceptions
 import CTModels.OCP
@@ -49,6 +50,6 @@ export AbstractCache
 export NotProvided
 export ODEParameters, variable, cache
 export __is_autonomous, __is_variable, __variable, __unsafe, __is_inplace, __hvf_inplace, _variable_costate
-export deepvalue, real_norm, scalarize
+export deepvalue, real_norm, make_coerce
 
 end # module Common

--- a/src/Common/helpers.jl
+++ b/src/Common/helpers.jl
@@ -1,5 +1,34 @@
-function scalarize(x::AbstractVector, ::Number) 
-    @assert length(x) == 1
-    return x[1]
-end
-scalarize(x, ::Any) = x
+"""
+    make_coerce(x) -> coerce_fn
+
+Return a coercion function for the given shape.
+
+For scalars (`Number`), returns `only` which extracts a single element from a 1-element vector.
+For arrays (`AbstractVector`, `AbstractMatrix`), returns `identity` which is a no-op.
+
+# Arguments
+- `x`: A value whose type determines the coercion strategy.
+
+# Returns
+- `Function`: A coercion function with signature `(y) -> coerced_y`.
+
+# Example
+```julia-repl
+julia> using CTFlows.Common
+
+julia> coerce_scalar = make_coerce(1.0)
+julia> coerce_scalar([5.0])
+5.0
+
+julia> coerce_vector = make_coerce([1.0, 2.0])
+julia> coerce_vector([3.0, 4.0])
+2-element Vector{Float64}:
+ 3.0
+ 4.0
+```
+
+See also: [`CTFlows.Systems.build_rhs`](@ref), [`CTFlows.Systems.build_oop_rhs`](@ref).
+"""
+make_coerce(::Number) = only
+make_coerce(::AbstractVector) = identity
+make_coerce(::AbstractMatrix) = identity

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -554,7 +554,7 @@ function call_variable_costate(
     t0  = Configs.initial_time(config) 
     x0  = Configs.initial_state(config)
     p0  = Configs.initial_costate(config)
-    pv0 = Common.scalarize(zeros(eltype(x0), length(variable)), variable)
+    pv0 = Common.make_coerce(variable)(zeros(eltype(x0), length(variable)))
     tf  = Configs.final_time(config)
     config_aug = Configs.AugmentedHamiltonianPointConfig(t0, x0, p0, pv0, tf)
     return call(flow, config_aug; variable=variable, unsafe=unsafe)

--- a/src/Solutions/building.jl
+++ b/src/Solutions/building.jl
@@ -29,7 +29,7 @@ function build_solution(
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult, 
 )
-    return Common.scalarize(Integrators.final_state(result), Configs.initial_state(config))
+    return Common.make_coerce(Configs.initial_state(config))(Integrators.final_state(result))
 end
 
 """
@@ -85,9 +85,9 @@ For Hamiltonian systems, `n_p = n_x` always, so the augmented state is `[x; p; p
 function _aug_split_solution(u, x0, pv0)
     n = length(x0)
     return (
-        Common.scalarize(u[1:n], x0), 
-        Common.scalarize(u[n+1:2n], x0), 
-        Common.scalarize(u[2n+1:end], pv0),
+        Common.make_coerce(x0)(u[1:n]),
+        Common.make_coerce(x0)(u[n+1:2n]),
+        Common.make_coerce(pv0)(u[2n+1:end]),
     )
 end
 
@@ -126,7 +126,7 @@ function build_solution(
     u = Integrators.final_state(result)
     x0 = Configs.initial_state(config)
     x, p = Solutions._ham_split_solution(u, x0)
-    return (Common.scalarize(x, x0), Common.scalarize(p, x0))
+    return (Common.make_coerce(x0)(x), Common.make_coerce(x0)(p))
 end
 
 """

--- a/src/Systems/hamiltonian_system.jl
+++ b/src/Systems/hamiltonian_system.jl
@@ -87,8 +87,8 @@ ensuring correct handling of scalar, vector, and matrix inputs.
 """
 function build_rhs(sys::HamiltonianSystem, x0, p0)
     N = _state_dim(x0)
-    cx = _make_coerce(x0)
-    cp = _make_coerce(p0)
+    cx = Common.make_coerce(x0)
+    cp = Common.make_coerce(p0)
     h, backend = sys.h, sys.backend
     return function (du, u, λ, t)
         x, p   = _ham_split(u, N)
@@ -116,8 +116,8 @@ ensuring correct handling of scalar, vector, and matrix inputs.
 """
 function build_oop_rhs(sys::HamiltonianSystem, x0, p0)
     N = _state_dim(x0)
-    cx = _make_coerce(x0)
-    cp = _make_coerce(p0)
+    cx = Common.make_coerce(x0)
+    cp = Common.make_coerce(p0)
     h, backend = sys.h, sys.backend
     return function (u, λ, t)
         x, p   = _ham_split(u, N)

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -65,17 +65,6 @@ _state_dim(::Number) = 1
 _state_dim(x::AbstractVector) = length(x)
 _state_dim(x::AbstractMatrix) = size(x, 1)
 
-"""
-    _make_coerce(::Number) = only
-    _make_coerce(::AbstractVector) = identity
-    _make_coerce(::AbstractMatrix) = identity
-
-Return a coercion function for the given shape. For scalars, `only` extracts
-a single element from a 1-element vector. For arrays, `identity` is a no-op.
-"""
-_make_coerce(::Number) = only
-_make_coerce(::AbstractVector) = identity
-_make_coerce(::AbstractMatrix) = identity
 
 # =============================================================================
 # Internal helpers for split/assign (dispatch on array type)
@@ -168,11 +157,11 @@ ensuring correct handling of scalar, vector, and matrix inputs.
 - `AbstractIPHVFRHS`: A functor with signature `(du, u, λ, t) -> nothing`.
 """
 function build_rhs(sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.OutOfPlace}, x0, p0) where {F, TD, VD}
-    return IPHVFOoPRHS(sys.hvf, _state_dim(x0), _make_coerce(x0), _make_coerce(p0))
+    return IPHVFOoPRHS(sys.hvf, _state_dim(x0), Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 function build_rhs(sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.InPlace}, x0, p0) where {F, TD, VD}
-    return IPHVFIpRHS(sys.hvf, _state_dim(x0), _make_coerce(x0), _make_coerce(p0))
+    return IPHVFIpRHS(sys.hvf, _state_dim(x0), Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 """
@@ -192,15 +181,15 @@ ensuring correct handling of scalar, vector, and matrix inputs.
 - `AbstractOoPHVFRHS`: A functor with signature `(u, λ, t) -> du`.
 """
 function build_oop_rhs(sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.OutOfPlace}, x0, p0) where {F, TD, VD}
-    return OoPHVFOoPRHS(sys.hvf, _state_dim(x0), _make_coerce(x0), _make_coerce(p0))
+    return OoPHVFOoPRHS(sys.hvf, _state_dim(x0), Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 function build_oop_rhs(sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.InPlace}, x0, p0) where {F, TD, VD}
     if !ismutable(x0)
         @warn "InPlace HamiltonianVectorField with immutable u0 (e.g. SVector): consider using an out-of-place function for better performance."
-        return OoPHVFIpFinalizeRHS(sys.hvf, _state_dim(x0), _make_coerce(x0), _make_coerce(p0))
+        return OoPHVFIpFinalizeRHS(sys.hvf, _state_dim(x0), Common.make_coerce(x0), Common.make_coerce(p0))
     end
-    return OoPHVFIpRHS(sys.hvf, _state_dim(x0), _make_coerce(x0), _make_coerce(p0))
+    return OoPHVFIpRHS(sys.hvf, _state_dim(x0), Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 # =============================================================================

--- a/test/suite/flows/test_variable_costate_flows.jl
+++ b/test/suite/flows/test_variable_costate_flows.jl
@@ -73,7 +73,7 @@ end
 # Analytical solution: x(t) = x0 + p0 * (t-t0) / sum(v), p(t) = p0, pv(t) = pv0 - sum(p0^2) * (t-t0) / (2 * sum(v)^2)
 H_LINEAR(x, p, v) = sum(abs2, p) / (2 * sum(v))
 function solve_linear(t, t0, x0, p0, v)
-    pv0 = Common.scalarize(zeros(length(v)), v)
+    pv0 = Common.make_coerce(v)(zeros(length(v)))
     dt  = t - t0
     sv  = sum(v)
     x   = x0 .+ p0 .* (dt / sv)


### PR DESCRIPTION
## Summary

This refactor unifies two duplicate coercion patterns (`_make_coerce` in Hamiltonian systems and `scalarize` in Common) into a single `Common.make_coerce` function. The change improves code consistency by using the same coercion mechanism for both RHS construction (input coercion) and solution building (output coercion), eliminating redundancy and centralizing shape normalization logic.

## Changes

- Move `_make_coerce` from `src/Systems/hamiltonian_vector_field_system.jl` and `src/Systems/hamiltonian_system.jl` to `src/Common/helpers.jl`
- Rename `_make_coerce` to `make_coerce` (public, without underscore prefix)
- Replace all uses of `Common.scalarize` with `Common.make_coerce` in solution building and flow calling
- Remove `scalarize` function entirely
- Update exports in `Common/Common.jl`
- Add docstring for `make_coerce`
- Move `using Base: only` from `helpers.jl` to `Common.jl`

## Testing

All 2511 tests pass, including:
- Core functionality tests (hamiltonian_vector_field_system, hamiltonian_system, hamiltonian_vector_field_solution, variable_costate_flows)
- Full test suite

## Files Modified

- `src/Common/Common.jl`
- `src/Common/helpers.jl`
- `src/Flows/calling.jl`
- `src/Solutions/building.jl`
- `src/Systems/hamiltonian_system.jl`
- `src/Systems/hamiltonian_vector_field_system.jl`
- `test/suite/flows/test_variable_costate_flows.jl`