### PR TITLE
rename: PointTrait→EndPointMode, TrajectoryTrait→TrajectoryMode, and derived config types

### DIFF
--- a/docs/src/flows/index.md
+++ b/docs/src/flows/index.md
@@ -31,7 +31,7 @@ Each layer has a single responsibility:
 | [Traits](traits.md) | The three trait axes shared by every layer | `Autonomous`, `Fixed`, `InPlace` |
 | [Data structures](data.md) | Wrapping your functions | `VectorField`, `Hamiltonian`, `HamiltonianVectorField` |
 | [Building a flow](building_a_flow.md) | Assembling the pipeline | `build_system`, `build_flow`, `Flow` |
-| [Integrating](integrating.md) | Calling a flow, configuration objects, integrator options | `StatePointConfig`, `StateTrajectoryConfig` |
+| [Integrating](integrating.md) | Calling a flow, configuration objects, integrator options | `StateEndPointConfig`, `StateTrajectoryConfig` |
 | [Solutions](solutions.md) | Reading the result | `state`, `costate`, `time_grid`, `plot` |
 | [Multi-phase flows](multiphase.md) | Concatenating flows with switching times | `MultiPhaseStateFlow`, `*` |
 
@@ -47,7 +47,7 @@ using CTFlows.Systems      # build_system
 using CTFlows.Integrators  # SciML, build_integrator
 using CTFlows.Solutions    # VectorFieldSolution, state, time_grid
 using CTFlows.Traits       # Autonomous, NonAutonomous, Fixed, NonFixed, InPlace, OutOfPlace
-using CTFlows.Configs      # StatePointConfig, StateTrajectoryConfig, …
+using CTFlows.Configs      # StateEndPointConfig, StateTrajectoryConfig, …
 import OrdinaryDiffEqTsit5 # activates the SciML extension
 nothing # hide
 ```

--- a/docs/src/flows/integrating.md
+++ b/docs/src/flows/integrating.md
@@ -88,9 +88,9 @@ pass them to `Flows._invoke_flow`:
 
 | Config type | Usage | Arguments |
 |---|---|---|
-| `StatePointConfig` | state final value | `(t0, x0, tf)` |
+| `StateEndPointConfig` | state final value | `(t0, x0, tf)` |
 | `StateTrajectoryConfig` | state full trajectory | `(tspan, x0)` |
-| `HamiltonianPointConfig` | state+costate final value | `(t0, x0, p0, tf)` |
+| `HamiltonianEndPointConfig` | state+costate final value | `(t0, x0, p0, tf)` |
 | `HamiltonianTrajectoryConfig` | state+costate trajectory | `(tspan, x0, p0)` |
 
 ```@example flows_integrating
@@ -160,7 +160,7 @@ typeof(integ)
 
 ## See also
 
-- [`CTFlows.Configs.StatePointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref) — state configuration objects.
-- [`CTFlows.Configs.HamiltonianPointConfig`](@ref), [`CTFlows.Configs.HamiltonianTrajectoryConfig`](@ref) — Hamiltonian configuration objects.
+- [`CTFlows.Configs.StateEndPointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref) — state configuration objects.
+- [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref), [`CTFlows.Configs.HamiltonianTrajectoryConfig`](@ref) — Hamiltonian configuration objects.
 - [`CTFlows.Configs.tspan`](@ref), [`CTFlows.Configs.initial_state`](@ref), [`CTFlows.Configs.initial_costate`](@ref) — configuration accessors.
 - [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Integrators.build_integrator`](@ref), [`CTFlows.Integrators.AbstractIntegrator`](@ref) — integrator types.

--- a/ext/CTFlowsSciMLFlows/problem_flow.jl
+++ b/ext/CTFlowsSciMLFlows/problem_flow.jl
@@ -94,7 +94,7 @@ final state, not the full trajectory.
 # Returns
 - The final state vector.
 
-See also: [`CTFlowsSciMLFlows.SciMLProblemFlow`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref).
+See also: [`CTFlowsSciMLFlows.SciMLProblemFlow`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref).
 """
 function (f::SciMLProblemFlow)(
     t0::Real,
@@ -108,7 +108,7 @@ function (f::SciMLProblemFlow)(
         kw = merge(kw, (; p = variable))
     end
     prob   = SciMLBase.remake(f.prob; kw...)
-    config = Configs.StatePointConfig(t0, x0, tf)
+    config = Configs.StateEndPointConfig(t0, x0, tf)
     opts   = Integrators.build_options(f.integrator, config)
     result = Integrators.solve_problem(f.integrator, prob, opts; unsafe)
     return Integrators.final_state(result)

--- a/ext/CTFlowsSciMLIntegrator/strategies.jl
+++ b/ext/CTFlowsSciMLIntegrator/strategies.jl
@@ -227,7 +227,7 @@ Tuple of option keys that support automatic resolution based on configuration ty
 
 These options use the `:auto` sentinel value in their metadata and are resolved
 dynamically during integrator construction:
-- For `StatePointConfig`: set to `false` (only final state needed)
+- For `StateEndPointConfig`: set to `false` (only final state needed)
 - For `StateTrajectoryConfig`: set to `true` (full trajectory storage needed)
 
 Users can override automatic resolution by providing explicit `true`/`false` values
@@ -236,7 +236,7 @@ when constructing the integrator.
 # Returns
 - `Tuple{Symbol, ...}`: The tuple of option keys supporting automatic resolution.
 
-See also: [`CTFlows.Integrators.build_sciml_integrator`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
+See also: [`CTFlows.Integrators.build_sciml_integrator`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
 """
 const _AUTO_OPTION_KEYS = (:dense, :save_everystep, :save_start)
 
@@ -248,7 +248,7 @@ Build a `SciML` integrator with validated options and pre-computed config-specif
 This function constructs a SciML integrator with automatic resolution of config-dependent
 options. Options in `_AUTO_OPTION_KEYS` support the `:auto` sentinel value, which is
 resolved based on the configuration type used during integration:
-- For `StatePointConfig` (e.g., `flow(t0, x0, tf)`): options set to `false` to minimize memory
+- For `StateEndPointConfig` (e.g., `flow(t0, x0, tf)`): options set to `false` to minimize memory
   since only the final state is needed
 - For `StateTrajectoryConfig` (e.g., `flow((t0, tf), x0)`): options set to `true` to enable
   full trajectory storage and interpolation
@@ -274,7 +274,7 @@ avoiding repeated resolution during integration.
   on the configuration type.
 
 See also: [`CTFlows.Integrators.build_options`](@ref), [`CTFlows.Integrators.SciML`](@ref),
-[`CTFlows.Configs.StatePointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
+[`CTFlows.Configs.StateEndPointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
 """
 function CTFlows.Integrators.build_sciml_integrator(
     ::Type{CTFlows.Integrators.SciMLTag}; mode::Symbol = :strict, kwargs...,
@@ -297,7 +297,7 @@ function CTFlows.Integrators.build_sciml_integrator(
         )
     end
     
-    # Pre-compute options for StatePointConfig
+    # Pre-compute options for StateEndPointConfig
     options_point = copy(raw)
     for key in _AUTO_OPTION_KEYS
         get(options_point, key, :auto) === :auto && (options_point[key] = false)
@@ -323,20 +323,20 @@ $(TYPEDSIGNATURES)
 
 Return pre-computed solver options for point integration configs.
 
-For point configs (e.g., StatePointConfig, HamiltonianPointConfig), options like
+For point configs (e.g., StateEndPointConfig, HamiltonianEndPointConfig), options like
 `dense`, `save_everystep`, and `save_start` are set to `false` to minimize memory
 since only the final state is needed.
 
 # Arguments
 - `integ::SciML`: The SciML integrator with pre-computed option caches.
-- `config::Configs.AbstractPointConfig`: The point configuration.
+- `config::Configs.AbstractEndPointConfig`: The point configuration.
 
 # Returns
 - `Dict{Symbol,Any}`: Pre-computed options optimized for point integration.
 
-See also: [`CTFlows.Integrators.build_options`](@ref), [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Configs.AbstractPointConfig`](@ref).
+See also: [`CTFlows.Integrators.build_options`](@ref), [`CTFlows.Integrators.SciML`](@ref), [`CTFlows.Configs.AbstractEndPointConfig`](@ref).
 """
-function Integrators.build_options(integ::SciML, config::Configs.AbstractPointConfig)
+function Integrators.build_options(integ::SciML, config::Configs.AbstractEndPointConfig)
     return integ.options_point
 end
 

--- a/reports/roadmap-v2.md
+++ b/reports/roadmap-v2.md
@@ -39,7 +39,7 @@ The v1 refactoring is complete. CTFlows now has a modular architecture with spec
 ⚠️ **Partial**
 
 - ✅ Multi-phase flows (module `MultiPhase/`)
-- ✅ Augmented Hamiltonian support (`AugmentedHamiltonianPointConfig`, `build_rhs_augmented`)
+- ✅ Augmented Hamiltonian support (`AugmentedHamiltonianEndPointConfig`, `build_rhs_augmented`)
 - ❌ Complete flow construction features — Closed- and open-loop encapsulation, control-free OCP, DAE support, and generic objects. See [#247](https://github.com/control-toolbox/CTFlows.jl/issues/247).
 
 ---

--- a/reports/save/SciMLBase/scimlbase_plan.md
+++ b/reports/save/SciMLBase/scimlbase_plan.md
@@ -389,7 +389,7 @@ function (f::SciMLProblemFlow)(
     prob = SciMLBase.remake(f.prob; kw...)
     opts = Integrators.build_options(
         f.integrator,
-        Common.StatePointConfig(t0, x0, tf),
+        Common.StateEndPointConfig(t0, x0, tf),
     )
     sol = SciMLBase.solve(prob; opts...)
     _check_retcode(sol, unsafe)

--- a/reports/save/concatenation/analysis.md
+++ b/reports/save/concatenation/analysis.md
@@ -212,7 +212,7 @@ f2 = Flow(sys, integrator_opts)
 f  = f1 * (t_switch, f2)
 
 # Usage identique à un flot simple
-xf       = f(t0, x0, tf)           # StatePointConfig
+xf       = f(t0, x0, tf)           # StateEndPointConfig
 sol      = f((t0, tf), x0)         # StateTrajectoryConfig
 ```
 
@@ -457,14 +457,14 @@ end
 
 ### Intégration Séquentielle dans call()
 
-Deux méthodes distinctes selon `StatePointConfig` (pas de fusion) et `StateTrajectoryConfig` (fusion progressive).
+Deux méthodes distinctes selon `StateEndPointConfig` (pas de fusion) et `StateTrajectoryConfig` (fusion progressive).
 
-#### StatePointConfig — pas de stockage intermédiaire
+#### StateEndPointConfig — pas de stockage intermédiaire
 
 ```julia
 function call(
     flow   :: Union{MultiPhaseStateFlow, MultiPhaseHamiltonianFlow},
-    config :: Common.StatePointConfig;
+    config :: Common.StateEndPointConfig;
     variable, unsafe
 )
     t0, tf    = Common.tspan(config)
@@ -542,8 +542,8 @@ end
 Construit une configuration pour une phase individuelle. Le type de config est préservé.
 
 ```julia
-function _make_phase_config(t_start, t_end, z0, ::Common.StatePointConfig)
-    return Common.StatePointConfig(t_start, z0, t_end)
+function _make_phase_config(t_start, t_end, z0, ::Common.StateEndPointConfig)
+    return Common.StateEndPointConfig(t_start, z0, t_end)
 end
 
 function _make_phase_config(t_start, t_end, z0, ::Common.StateTrajectoryConfig)
@@ -554,11 +554,11 @@ end
 #### _extract_final_state
 
 Extrait l'état final du résultat d'une phase.
-Pour `StatePointConfig`, le résultat **est** déjà l'état final.
+Pour `StateEndPointConfig`, le résultat **est** déjà l'état final.
 Pour `StateTrajectoryConfig`, l'état final est le dernier point de la trajectoire.
 
 ```julia
-_extract_final_state(result::AbstractVector) = result       # StatePointConfig → déjà l'état
+_extract_final_state(result::AbstractVector) = result       # StateEndPointConfig → déjà l'état
 _extract_final_state(result::VectorFieldSolution) = result.u[end]  # StateTrajectoryConfig
 ```
 
@@ -695,9 +695,9 @@ Note : `MultiPhaseSystem` ici n'est **pas** le `MultiPhaseSystem` de la discussi
 Les méthodes appelables (l'API publique) se comportent comme un flot simple :
 
 ```julia
-# Évaluation point (délègue à call avec StatePointConfig)
+# Évaluation point (délègue à call avec StateEndPointConfig)
 function (f::MultiPhaseStateFlow)(t0, x0, tf; variable=nothing, unsafe=false)
-    config = Common.StatePointConfig(t0, x0, tf)
+    config = Common.StateEndPointConfig(t0, x0, tf)
     return Flows.call(f, config; variable, unsafe)
 end
 
@@ -741,7 +741,7 @@ end
 
 ### 5.2 Fusion des Résultats
 
-#### StatePointConfig
+#### StateEndPointConfig
 
 Pas de fusion : on propage seulement l'état final d'une phase à l'autre. Résultat final = état final de la dernière phase.
 
@@ -923,7 +923,7 @@ end
 2. `Flow` hérite du bon sous-type abstrait selon son système
 3. `MultiPhaseStateFlow` et `MultiPhaseHamiltonianFlow` avec leurs invariants
 4. Opérateurs `*` avec `_flatten_*` pour le chaînage associatif
-5. `call()` pour `StatePointConfig` (simple)
+5. `call()` pour `StateEndPointConfig` (simple)
 6. `call()` pour `StateTrajectoryConfig` (fusion progressive)
 7. Stub `_build_merged_solution` dans `src/` + implémentation dans `CTFlowsSciML`
 8. Tests : contrats, sauts, chaînage, exactitude vs approche à la volée

--- a/reports/save/concatenation/multiphase-plan.md
+++ b/reports/save/concatenation/multiphase-plan.md
@@ -5,7 +5,7 @@ Ce plan implémente l'intégration séquentielle exacte pour la concaténation d
 ## Ce qui change et pourquoi
 
 - **`Systems`** : `AbstractStateSystem` et `AbstractHamiltonianSystem` sous `AbstractSystem`. `VectorFieldSystem <: AbstractStateSystem`. Permet la contrainte compile-time sur `S` dans `AbstractStateFlow` / `AbstractHamiltonianFlow`.
-- **`Common`** : `HamiltonianPointConfig(t0, x0, p0, tf)` et `HamiltonianTrajectoryConfig(tspan, x0, p0)`. `initial_condition` retourne `vcat(x0, p0)`.
+- **`Common`** : `HamiltonianEndPointConfig(t0, x0, p0, tf)` et `HamiltonianTrajectoryConfig(tspan, x0, p0)`. `initial_condition` retourne `vcat(x0, p0)`.
 - **`Flows`** : `AbstractStateFlow{TD,VD,S<:AbstractStateSystem}` et `AbstractHamiltonianFlow{TD,VD,S<:AbstractHamiltonianSystem}`. `Flow` renommé en `StateFlow`, `HamiltonianFlow` créé. `build_flow` dispatche selon le type de `sys`.
 - **`MultiPhase`** : Nouveau submodule (`src/MultiPhase/`). Contient `MultiPhaseSystem`, `MultiPhaseIntegrator` (wrappers passifs pour le contrat `AbstractFlow`), `MultiPhaseStateFlow`, `MultiPhaseHamiltonianFlow`, opérateurs `*`, et `call()` séquentiel.
 - **Tests** : 7 fichiers existants à mettre à jour (`Flow` → `StateFlow`). 1 nouveau fichier de tests MultiPhase.
@@ -13,7 +13,7 @@ Ce plan implémente l'intégration séquentielle exacte pour la concaténation d
 ## Graphe de dépendances après modification
 
 ```text
-Common  (+ HamiltonianPointConfig, HamiltonianTrajectoryConfig)
+Common  (+ HamiltonianEndPointConfig, HamiltonianTrajectoryConfig)
   ├── Data
   ├── Systems  (+ AbstractStateSystem, AbstractHamiltonianSystem)
   ├── Integrators
@@ -61,7 +61,7 @@ git checkout -b feature/multiphase-concatenation
 
 > 📐 Follow `architecture.md` — ISP: configs Hamiltoniens séparés.
 
-- Ajouter `struct HamiltonianPointConfig{T0, X0, P0, TF} <: AbstractConfig{X0}` avec champs `t0, x0, p0, tf`.
+- Ajouter `struct HamiltonianEndPointConfig{T0, X0, P0, TF} <: AbstractConfig{X0}` avec champs `t0, x0, p0, tf`.
 - Ajouter `struct HamiltonianTrajectoryConfig{TS, X0, P0} <: AbstractConfig{X0}` avec champs `tspan, x0, p0`.
 - Implémenter `tspan` pour les deux nouveaux types.
 - Implémenter `initial_condition` : retourne `vcat(c.x0, c.p0)`.
@@ -71,7 +71,7 @@ git checkout -b feature/multiphase-concatenation
 
 > 🏗️ Follow `modules.md` — Exports en fin de manifest.
 
-- Ajouter `HamiltonianPointConfig`, `HamiltonianTrajectoryConfig` à l'`export`.
+- Ajouter `HamiltonianEndPointConfig`, `HamiltonianTrajectoryConfig` à l'`export`.
 
 ### Step 6 — Test checkpoint 1 : Systems + Common
 
@@ -108,8 +108,8 @@ grep -E "Error|Fail|Test Summary" /tmp/ctflows_phase1.log
 - Adapter `system`, `integrator`, `build_flow` pour les deux structs :
   - `build_flow(sys::Systems.AbstractStateSystem, int)` → `StateFlow(sys, int)`
   - `build_flow(sys::Systems.AbstractHamiltonianSystem, int)` → `HamiltonianFlow(sys, int)`
-- Adapter le callable `StateFlow` : `(f::StateFlow)(t0, x0, tf; ...)` → `Common.StatePointConfig`.
-- Ajouter les callables `HamiltonianFlow` : `(f)(t0, x0, p0, tf; ...)` → `Common.HamiltonianPointConfig` et `(f)(tspan, x0, p0; ...)` → `Common.HamiltonianTrajectoryConfig`.
+- Adapter le callable `StateFlow` : `(f::StateFlow)(t0, x0, tf; ...)` → `Common.StateEndPointConfig`.
+- Ajouter les callables `HamiltonianFlow` : `(f)(t0, x0, p0, tf; ...)` → `Common.HamiltonianEndPointConfig` et `(f)(tspan, x0, p0; ...)` → `Common.HamiltonianTrajectoryConfig`.
 
 ### Step 9 — `src/Flows/building.jl`
 
@@ -188,7 +188,7 @@ grep -E "Error|Fail|Test Summary" /tmp/ctflows_phase2.log
 > 🔬 Follow `type-stability.md` — pré-allouer `t_all`/`u_all`.
 
 - `_make_phase_config`, `_extract_final_state`, `_apply_jump` (dispatch State vs Hamiltonian).
-- `call(flow, ::StatePointConfig)` : boucle séquentielle.
+- `call(flow, ::StateEndPointConfig)` : boucle séquentielle.
 - `call(flow, ::StateTrajectoryConfig)` : fusion progressive.
 - Stub `_build_merged_solution` → `ExtensionError`.
 
@@ -210,7 +210,7 @@ Créer `test/suite/multiphase/test_multiphase.jl` :
 - `@testset "Concatenation"` : `*` sans saut, avec saut, chaînage 3 phases, aplatissement.
 - `@testset "Type constraints"` : types `S` différents → `MethodError`.
 - `@testset "Validation"` : temps non croissants → `IncorrectArgument`.
-- `@testset "call StatePointConfig"` et `@testset "call StateTrajectoryConfig"` avec flot trivial.
+- `@testset "call StateEndPointConfig"` et `@testset "call StateTrajectoryConfig"` avec flot trivial.
 - `@testset "Extension stub"` : `_build_merged_solution` → `ExtensionError`.
 
 ```bash
@@ -228,7 +228,7 @@ grep -E "Error|Fail|Test Summary" /tmp/ctflows_phase3.log
 > 📚 Follow `docstrings.md` — `$(TYPEDEF)` / `$(TYPEDSIGNATURES)`, sections complètes, exemples sûrs.
 
 - `src/Systems/abstract_system.jl` — `AbstractStateSystem`, `AbstractHamiltonianSystem`
-- `src/Common/configs.jl` — `HamiltonianPointConfig`, `HamiltonianTrajectoryConfig`, `tspan`, `initial_condition`, `Base.show`
+- `src/Common/configs.jl` — `HamiltonianEndPointConfig`, `HamiltonianTrajectoryConfig`, `tspan`, `initial_condition`, `Base.show`
 - `src/Flows/abstract_flow.jl` — `AbstractStateFlow`, `AbstractHamiltonianFlow`
 - `src/Flows/flow.jl` — `StateFlow`, `HamiltonianFlow`, callables, `build_flow`
 - `src/MultiPhase/*.jl` — tous les types et fonctions publics exportés

--- a/reports/save/configs.md
+++ b/reports/save/configs.md
@@ -25,15 +25,15 @@ struct HamiltonianTag <: AbstractContentTag end
 abstract type AbstractConfig{X0, Mode<:AbstractModeTag, Content<:AbstractContentTag} end
 
 # Quatre aliases totalement symétriques — tous utilisables en dispatch ET isa
-const AbstractPointConfig{X0, C}       = AbstractConfig{X0, PointTag,      C}
+const AbstractEndPointConfig{X0, C}       = AbstractConfig{X0, PointTag,      C}
 const AbstractTrajectoryConfig{X0, C}  = AbstractConfig{X0, TrajectoryTag,  C}
 const AbstractStateConfig{X0, M}       = AbstractConfig{X0, M, StateTag}
 const AbstractHamiltonianConfig{X0, M} = AbstractConfig{X0, M, HamiltonianTag}
 
 # Types concrets subtypent DIRECTEMENT depuis AbstractConfig
-struct StatePointConfig{T0<:Real, X0, TF<:Real}          <: AbstractConfig{X0, PointTag,     StateTag}       end
+struct StateEndPointConfig{T0<:Real, X0, TF<:Real}          <: AbstractConfig{X0, PointTag,     StateTag}       end
 struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfig{X0, TrajectoryTag, StateTag}     end
-struct HamiltonianPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfig{X0, PointTag,     HamiltonianTag} end
+struct HamiltonianEndPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfig{X0, PointTag,     HamiltonianTag} end
 struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfig{X0, TrajectoryTag, HamiltonianTag} end
 ```
 
@@ -41,7 +41,7 @@ struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: Abstract
 
 | Pattern | Signification |
 |---|---|
-| `AbstractPointConfig` | tous les Point (State + Hamiltonian) |
+| `AbstractEndPointConfig` | tous les Point (State + Hamiltonian) |
 | `AbstractTrajectoryConfig` | tous les Trajectory |
 | `AbstractStateConfig` | tous les State (Point + Trajectory) |
 | `AbstractHamiltonianConfig` | tous les Hamiltonian |
@@ -63,16 +63,16 @@ struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: Abstract
 - `initial_costate` : suppression du `Union{...}`
 
 **Ce qui disparaît :**
-- `abstract type AbstractPointConfig{X0} <: AbstractConfig{X0} end` (remplacé par `const` alias)
+- `abstract type AbstractEndPointConfig{X0} <: AbstractConfig{X0} end` (remplacé par `const` alias)
 - `abstract type AbstractTrajectoryConfig{X0} <: AbstractConfig{X0} end` (remplacé par `const` alias)
-- `Union{HamiltonianPointConfig, HamiltonianTrajectoryConfig}` dans `initial_condition` et `initial_costate`
+- `Union{HamiltonianEndPointConfig, HamiltonianTrajectoryConfig}` dans `initial_condition` et `initial_costate`
 - Les 4+4+4 méthodes individuelles réduites
 
 **Ce qui est ajouté :**
 - `AbstractModeTag`, `AbstractContentTag` (intermédiaires) dans `abstract_tag.jl`
 - `PointTag`, `TrajectoryTag`, `StateTag`, `HamiltonianTag` (concrets) dans `abstract_tag.jl`
 - `AbstractStateConfig`, `AbstractHamiltonianConfig` comme nouveaux exports
-- `AbstractPointConfig`, `AbstractTrajectoryConfig` restent exportés (backward compat) mais deviennent des `const` aliases
+- `AbstractEndPointConfig`, `AbstractTrajectoryConfig` restent exportés (backward compat) mais deviennent des `const` aliases
 
 ---
 
@@ -135,7 +135,7 @@ Dans la ligne `export`, ajouter :
 - `PointTag, TrajectoryTag, StateTag, HamiltonianTag` (concrets)
 - `AbstractStateConfig, AbstractHamiltonianConfig`
 
-`AbstractPointConfig` et `AbstractTrajectoryConfig` restent dans les exports (ils deviennent des aliases mais les noms sont inchangés).
+`AbstractEndPointConfig` et `AbstractTrajectoryConfig` restent dans les exports (ils deviennent des aliases mais les noms sont inchangés).
 
 > ⛔ Do NOT write docstrings in this step.
 
@@ -154,31 +154,31 @@ Dans la ligne `export`, ajouter :
 abstract type AbstractConfig{X0, Mode<:AbstractModeTag, Content<:AbstractContentTag} end
 
 # Quatre aliases symétriques (UnionAll)
-const AbstractPointConfig{X0, C}       = AbstractConfig{X0, PointTag,      C}
+const AbstractEndPointConfig{X0, C}       = AbstractConfig{X0, PointTag,      C}
 const AbstractTrajectoryConfig{X0, C}  = AbstractConfig{X0, TrajectoryTag,  C}
 const AbstractStateConfig{X0, M}       = AbstractConfig{X0, M, StateTag}
 const AbstractHamiltonianConfig{X0, M} = AbstractConfig{X0, M, HamiltonianTag}
 ```
 
-**Section "StatePointConfig" — changer le parent :**
-- `struct StatePointConfig{T0<:Real, X0, TF<:Real} <: AbstractPointConfig{X0}` → `<: AbstractConfig{X0, PointTag, StateTag}`
+**Section "StateEndPointConfig" — changer le parent :**
+- `struct StateEndPointConfig{T0<:Real, X0, TF<:Real} <: AbstractEndPointConfig{X0}` → `<: AbstractConfig{X0, PointTag, StateTag}`
 
 **Section "StateTrajectoryConfig" — changer le parent :**
 - `struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractTrajectoryConfig{X0}` → `<: AbstractConfig{X0, TrajectoryTag, StateTag}`
 
-**Section "HamiltonianPointConfig" — changer le parent :**
-- `struct HamiltonianPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractPointConfig{X0}` → `<: AbstractConfig{X0, PointTag, HamiltonianTag}`
+**Section "HamiltonianEndPointConfig" — changer le parent :**
+- `struct HamiltonianEndPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractEndPointConfig{X0}` → `<: AbstractConfig{X0, PointTag, HamiltonianTag}`
 
 **Section "HamiltonianTrajectoryConfig" — changer le parent :**
 - `struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractTrajectoryConfig{X0}` → `<: AbstractConfig{X0, TrajectoryTag, HamiltonianTag}`
 
 **Section "Interface: tspan" — 4 méthodes → 2 + stub :**
 
-Supprimer les 4 méthodes individuelles `tspan(::StatePointConfig)`, `tspan(::HamiltonianPointConfig)`, `tspan(::StateTrajectoryConfig)`, `tspan(::HamiltonianTrajectoryConfig)`.
+Supprimer les 4 méthodes individuelles `tspan(::StateEndPointConfig)`, `tspan(::HamiltonianEndPointConfig)`, `tspan(::StateTrajectoryConfig)`, `tspan(::HamiltonianTrajectoryConfig)`.
 
 Remplacer par :
 ```julia
-function tspan(c::AbstractPointConfig)::Tuple{Real, Real}
+function tspan(c::AbstractEndPointConfig)::Tuple{Real, Real}
     return (c.t0, c.tf)
 end
 
@@ -222,7 +222,7 @@ function initial_costate(c::AbstractStateConfig)
         "initial_costate is only defined for Hamiltonian configs";
         context = "initial_costate - requires Hamiltonian config",
         reason = "config type $(typeof(c)) does not have a costate field",
-        suggestion = "use HamiltonianPointConfig or HamiltonianTrajectoryConfig instead",
+        suggestion = "use HamiltonianEndPointConfig or HamiltonianTrajectoryConfig instead",
     ))
 end
 ```
@@ -255,30 +255,30 @@ struct FakeConfigWithTspan{X0} <: Common.AbstractConfig{X0, Common.PointTag, Com
 ```julia
 Test.@testset "Trait Aliases" begin
     # Mode aliases
-    Test.@test StatePointConfig       <: Common.AbstractPointConfig
-    Test.@test HamiltonianPointConfig <: Common.AbstractPointConfig
+    Test.@test StateEndPointConfig       <: Common.AbstractEndPointConfig
+    Test.@test HamiltonianEndPointConfig <: Common.AbstractEndPointConfig
     Test.@test StateTrajectoryConfig  <: Common.AbstractTrajectoryConfig
     Test.@test HamiltonianTrajectoryConfig <: Common.AbstractTrajectoryConfig
 
     # Content aliases
-    Test.@test StatePointConfig       <: Common.AbstractStateConfig
+    Test.@test StateEndPointConfig       <: Common.AbstractStateConfig
     Test.@test StateTrajectoryConfig  <: Common.AbstractStateConfig
-    Test.@test HamiltonianPointConfig <: Common.AbstractHamiltonianConfig
+    Test.@test HamiltonianEndPointConfig <: Common.AbstractHamiltonianConfig
     Test.@test HamiltonianTrajectoryConfig <: Common.AbstractHamiltonianConfig
 
     # Negative checks
-    Test.@test !(StatePointConfig       <: Common.AbstractHamiltonianConfig)
-    Test.@test !(HamiltonianPointConfig <: Common.AbstractStateConfig)
-    Test.@test !(StatePointConfig       <: Common.AbstractTrajectoryConfig)
+    Test.@test !(StateEndPointConfig       <: Common.AbstractHamiltonianConfig)
+    Test.@test !(HamiltonianEndPointConfig <: Common.AbstractStateConfig)
+    Test.@test !(StateEndPointConfig       <: Common.AbstractTrajectoryConfig)
 end
 ```
 
 **Vérifier `tspan` unifié :**
 ```julia
 Test.@testset "tspan unified dispatch" begin
-    sp  = Common.StatePointConfig(0.0, [1.0], 1.0)
+    sp  = Common.StateEndPointConfig(0.0, [1.0], 1.0)
     st  = Common.StateTrajectoryConfig((0.0, 1.0), [1.0])
-    hp  = Common.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+    hp  = Common.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
     ht  = Common.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0], [0.5])
 
     Test.@test Common.tspan(sp) == (0.0, 1.0)
@@ -303,14 +303,14 @@ grep -E "Error|Fail|Test Summary" /tmp/ctflows_step4.log
 **`build_options` — remplacer les 4 méthodes par 2 :**
 
 Supprimer :
-- `Integrators.build_options(integ::SciML, config::Common.StatePointConfig)`
-- `Integrators.build_options(integ::SciML, config::Common.HamiltonianPointConfig)`
+- `Integrators.build_options(integ::SciML, config::Common.StateEndPointConfig)`
+- `Integrators.build_options(integ::SciML, config::Common.HamiltonianEndPointConfig)`
 - `Integrators.build_options(integ::SciML, config::Common.StateTrajectoryConfig)`
 - `Integrators.build_options(integ::SciML, config::Common.HamiltonianTrajectoryConfig)`
 
 Remplacer par :
 ```julia
-function Integrators.build_options(integ::SciML, config::Common.AbstractPointConfig)
+function Integrators.build_options(integ::SciML, config::Common.AbstractEndPointConfig)
     return integ.options_point
 end
 
@@ -332,9 +332,9 @@ end
 **`_extract_initial_state` — remplacer les 4 méthodes par 2 :**
 
 Supprimer :
-- `_extract_initial_state(config::Common.StatePointConfig)`
+- `_extract_initial_state(config::Common.StateEndPointConfig)`
 - `_extract_initial_state(config::Common.StateTrajectoryConfig)`
-- `_extract_initial_state(config::Common.HamiltonianPointConfig)`
+- `_extract_initial_state(config::Common.HamiltonianEndPointConfig)`
 - `_extract_initial_state(config::Common.HamiltonianTrajectoryConfig)`
 
 Remplacer par :
@@ -362,7 +362,7 @@ build_solution(result, sys::VectorFieldSystem, config::Common.AbstractStateConfi
 # → return final_state(result)[1]   (PointTag importé ou qualifié)
 
 # Vector State Point
-build_solution(result, sys::VectorFieldSystem, config::Common.AbstractPointConfig{<:Any, StateTag})
+build_solution(result, sys::VectorFieldSystem, config::Common.AbstractEndPointConfig{<:Any, StateTag})
 # → return final_state(result)
 
 # State Trajectory
@@ -370,7 +370,7 @@ build_solution(result, sys::VectorFieldSystem, config::Common.AbstractTrajectory
 # → return VectorFieldSolution(result)
 
 # Hamiltonian Point
-build_solution(result, sys::HamiltonianVectorFieldSystem, config::Common.AbstractPointConfig{<:Any, HamiltonianTag})
+build_solution(result, sys::HamiltonianVectorFieldSystem, config::Common.AbstractEndPointConfig{<:Any, HamiltonianTag})
 # → return _ham_split_solution(...)
 
 # Hamiltonian Trajectory
@@ -408,7 +408,7 @@ Fichiers et symboles :
 - `src/Common/abstract_tag.jl` — `PointTag`, `TrajectoryTag`, `StateTag`, `HamiltonianTag`
 - `src/Common/configs.jl` :
   - `AbstractConfig{X0, Mode, Content}` — documenter les 3 paramètres + les 4 aliases
-  - `AbstractPointConfig`, `AbstractTrajectoryConfig`, `AbstractStateConfig`, `AbstractHamiltonianConfig` — documenter comme aliases
+  - `AbstractEndPointConfig`, `AbstractTrajectoryConfig`, `AbstractStateConfig`, `AbstractHamiltonianConfig` — documenter comme aliases
   - `tspan` (2 méthodes unifiées)
   - `initial_condition` (3 méthodes : scalar state, vector state, hamiltonian)
   - `initial_costate` (2 méthodes : hamiltonian, state→PreconditionError)

--- a/reports/save/docs/index.md
+++ b/reports/save/docs/index.md
@@ -57,7 +57,7 @@ The following documents provide detailed conceptual overviews of each major them
 
 ### Traits
 CTFlows uses a trait system for compile-time dispatch. Traits are empty marker types used as type parameters to encode configuration properties:
-- **Mode traits**: PointTrait (point-to-point integration) vs TrajectoryTrait (full trajectory)
+- **Mode traits**: EndPointMode (point-to-point integration) vs TrajectoryMode (full trajectory)
 - **Content traits**: StateTrait (state only) vs HamiltonianTrait (state + costate)
 - **Time dependence**: Autonomous vs NonAutonomous
 - **Variable dependence**: Fixed vs NonFixed

--- a/reports/save/docs/solutions.md
+++ b/reports/save/docs/solutions.md
@@ -17,7 +17,7 @@ The Solutions module provides solution types and solution building functions for
 
 ## Traits
 
-Solution types inherit their trait information from the configuration parameter C. The configuration encodes mode (PointTrait vs TrajectoryTrait) and content (StateTrait vs HamiltonianTrait) traits, which determine what data is stored and how it can be accessed.
+Solution types inherit their trait information from the configuration parameter C. The configuration encodes mode (EndPointMode vs TrajectoryMode) and content (StateTrait vs HamiltonianTrait) traits, which determine what data is stored and how it can be accessed.
 
 ## Usage Pattern
 

--- a/reports/save/docs/traits.md
+++ b/reports/save/docs/traits.md
@@ -16,8 +16,8 @@ The trait pattern enables static dispatch on configuration properties without ru
 
 ### Mode Traits
 
-- `PointTrait` - Point integration mode (single endpoint evaluation)
-- `TrajectoryTrait` - Trajectory integration mode (full time evolution)
+- `EndPointMode` - Point integration mode (single endpoint evaluation)
+- `TrajectoryMode` - Trajectory integration mode (full time evolution)
 
 ### Content Traits
 
@@ -37,11 +37,11 @@ The trait pattern enables static dispatch on configuration properties without ru
 ### Configuration Types
 
 - `AbstractConfig` - Base configuration type
-- `AbstractPointConfig` - Point-mode configuration base
+- `AbstractEndPointConfig` - Point-mode configuration base
 - `AbstractTrajectoryConfig` - Trajectory-mode configuration base
-- `StatePointConfig` - State-only point configuration
+- `StateEndPointConfig` - State-only point configuration
 - `StateTrajectoryConfig` - State-only trajectory configuration
-- `HamiltonianPointConfig` - Hamiltonian point configuration
+- `HamiltonianEndPointConfig` - Hamiltonian point configuration
 - `HamiltonianTrajectoryConfig` - Hamiltonian trajectory configuration
 
 ## Traits

--- a/reports/save/documentation/plan.md
+++ b/reports/save/documentation/plan.md
@@ -30,7 +30,7 @@ Not all modules deserve a `DifferentialGeometry`-level treatment. Three tiers:
 | **Traits** | 🟡 Cross-cutting *conceptual* guide | Determines call signatures everywhere. Explain **once**, not per module. The DG traits/signatures table is an embryo of this. |
 | **Integrators** | 🟡 Configuration page | Mainly `SciML` + options. For advanced users switching backends. |
 | **Differentiation** | 🟡 Short page (or section in DG Limitations) | AD backend selection. Partly covered by `differential_geometry/limitations.md`. |
-| **Configs** | 🔴 API reference only | Pipeline plumbing (`StatePointConfig`, …). No narrative guide. |
+| **Configs** | 🔴 API reference only | Pipeline plumbing (`StateEndPointConfig`, …). No narrative guide. |
 | **Common** | 🔴 API reference only | Almost entirely internal (`__is_autonomous`, `__variable`, …). |
 
 🟢 = written guide · 🟡 = brief/config page · 🔴 = docstrings + generated API reference only
@@ -94,7 +94,7 @@ Modelled on `differential_geometry/index.md`. Contents:
 
 ### `flows/integrating.md`
 
-- Configuration objects (`StatePointConfig`, `StateTrajectoryConfig`,
+- Configuration objects (`StateEndPointConfig`, `StateTrajectoryConfig`,
   Hamiltonian variants) — what each drives.
 - Calling a flow; point-to-point vs full-trajectory.
 - Selecting / configuring an integrator (`SciML`, `Tsit5`, tolerances) — overlaps

--- a/reports/save/hamilonian/save/hamiltonian-vector-field.md
+++ b/reports/save/hamilonian/save/hamiltonian-vector-field.md
@@ -45,7 +45,7 @@ avec la variable si le flot est variable.
 
 Remarque : on pourra se poser la question de la nécessité d'avoir dans @building.jl#L23-24 @building.jl#L44-45 @building.jl#L64-65 à la fois le système et la config, qui doivent être les deux cohérents, car si on a un système hamiltonien, il faudra une config hamiltonien. Il est à noter que plus tard, nous aurons des flots construits à partir d'un problème de contrôle optimal, le flot hamiltonien et on voudra faire xf, pf = f(t0, x0, p0, tf) mais dans la version f((t0, tf), x0, p0) la solution retournée aura un type particulier : CTModels.Solution. Ce sera en fait une solution d'un problème de contrôle optimal.
 
-Remarque : pour être très cohérent, doit-on appeler les configs StatePointConfig et StateTrajectoryConfig : StateStatePointConfig et StateStateTrajectoryConfig ?
+Remarque : pour être très cohérent, doit-on appeler les configs StateEndPointConfig et StateTrajectoryConfig : StateStateEndPointConfig et StateStateTrajectoryConfig ?
 
 Pour créer une solution particulière, on aura besoin de créer l'analogue de @vector_field_solution.jl#L1-291 . De manière équivalent, il y aura à gérer l'affichage mais aussi @CTFlowsPlots.jl#L1-101 . On pourra simplement faire un layout (1, 2) pour l'état et le co-état.
 

--- a/reports/save/hamilonian/save/hamiltonian_plan.md
+++ b/reports/save/hamilonian/save/hamiltonian_plan.md
@@ -66,7 +66,7 @@ Add `AbstractCache` as a common abstract type (parallel to `AbstractTag`, `Abstr
 abstract type AbstractCache end
 ```
 
-Add a new content trait for augmented integration (used by `AugmentedHamiltonianPointConfig` — see Step 24a):
+Add a new content trait for augmented integration (used by `AugmentedHamiltonianEndPointConfig` — see Step 24a):
 
 ```julia
 struct AugmentedHamiltonianTrait <: ContentTrait end
@@ -481,7 +481,7 @@ end
 ```
 
 `config` is typed as `AbstractConfig` (not restricted to `AbstractHamiltonianConfig`) so that
-the same `prepare_cache` works when `call` is invoked with an `AugmentedHamiltonianPointConfig`
+the same `prepare_cache` works when `call` is invoked with an `AugmentedHamiltonianEndPointConfig`
 (which defines `initial_state` and `initial_costate` via its own getters — see Step 24a).
 
 Unified `call` for all `HamiltonianFlow`s — a single implementation, no duplication:
@@ -517,7 +517,7 @@ function Integrators.build_problem(integ::SciML, sys, config; variable, cache=no
 end
 ```
 
-A new overload dispatching on `AugmentedHamiltonianPointConfig` builds the augmented RHS
+A new overload dispatching on `AugmentedHamiltonianEndPointConfig` builds the augmented RHS
 **lazily** using concrete dimensions from the config, which solves the split ambiguity when
 `N = nothing`:
 
@@ -525,7 +525,7 @@ A new overload dispatching on `AugmentedHamiltonianPointConfig` builds the augme
 function Integrators.build_problem(
     integ::SciML,
     sys::Systems.HamiltonianSystem,
-    config::Common.AugmentedHamiltonianPointConfig;
+    config::Common.AugmentedHamiltonianEndPointConfig;
     variable, cache=nothing
 )
     u0  = Common.initial_condition(config)              # vcat(x0, p0, pv0)
@@ -559,8 +559,8 @@ avoids any `augmented=true` boolean on `build_problem` and lets the entire exist
 **New config struct:**
 
 ```julia
-struct AugmentedHamiltonianPointConfig{T0<:Real, X0, P0, PV0, TF<:Real} <:
-    AbstractConfigWithMaC{X0, PointTrait, AugmentedHamiltonianTrait}
+struct AugmentedHamiltonianEndPointConfig{T0<:Real, X0, P0, PV0, TF<:Real} <:
+    AbstractConfigWithMaC{X0, EndPointMode, AugmentedHamiltonianTrait}
     t0::T0
     x0::X0
     p0::P0
@@ -569,29 +569,29 @@ struct AugmentedHamiltonianPointConfig{T0<:Real, X0, P0, PV0, TF<:Real} <:
 end
 ```
 
-`tspan` is inherited from `AbstractPointConfig` (`(c.t0, c.tf)`).
+`tspan` is inherited from `AbstractEndPointConfig` (`(c.t0, c.tf)`).
 
 **Getters** (add to `configs.jl`):
 
 ```julia
-function initial_condition(c::AugmentedHamiltonianPointConfig)
+function initial_condition(c::AugmentedHamiltonianEndPointConfig)
     return vcat(c.x0, c.p0, c.pv0)   # feeds build_problem directly
 end
 
-function initial_state(c::AugmentedHamiltonianPointConfig)
+function initial_state(c::AugmentedHamiltonianEndPointConfig)
     return c.x0
 end
 
-function initial_costate(c::AugmentedHamiltonianPointConfig)
+function initial_costate(c::AugmentedHamiltonianEndPointConfig)
     return c.p0   # enables prepare_cache (WithAD) to work unchanged
 end
 
-function initial_variable_costate(c::AugmentedHamiltonianPointConfig)
+function initial_variable_costate(c::AugmentedHamiltonianEndPointConfig)
     return c.pv0
 end
 ```
 
-Export: `AugmentedHamiltonianPointConfig`, `initial_variable_costate`.
+Export: `AugmentedHamiltonianEndPointConfig`, `initial_variable_costate`.
 
 ### Step 24 — `src/Flows/calling.jl` (modified)
 
@@ -604,7 +604,7 @@ function (f::HamiltonianFlow)(
     unsafe    = Common.__unsafe(),
     augment::Bool = false,
 )
-    config = Common.HamiltonianPointConfig(t0, x0, p0, tf)
+    config = Common.HamiltonianEndPointConfig(t0, x0, p0, tf)
     augment && return call_augmented(f, config; variable=variable, unsafe=unsafe)
     return call(f, config; variable=variable, unsafe=unsafe)
 end
@@ -617,7 +617,7 @@ Implement `call_augmented` using trait dispatch — a front-end extracts both
 # Front-end: extract both traits, delegate
 function call_augmented(
     flow::HamiltonianFlow,
-    config::Common.HamiltonianPointConfig; variable, unsafe
+    config::Common.HamiltonianEndPointConfig; variable, unsafe
 )
     sys = system(flow)
     return call_augmented(
@@ -630,7 +630,7 @@ end
 # WithoutAD — any VD: clear message
 function call_augmented(
     ::Type{Common.WithoutAD}, ::Type{<:Common.VariableDependence},
-    flow::HamiltonianFlow, config::Common.HamiltonianPointConfig; variable, unsafe
+    flow::HamiltonianFlow, config::Common.HamiltonianEndPointConfig; variable, unsafe
 )
     throw(IncorrectArgument(
         "augment=true is not supported on this flow";
@@ -643,7 +643,7 @@ end
 # Any AT — Fixed: clear message
 function call_augmented(
     ::Type{<:Common.WithAD}, ::Type{Common.Fixed},
-    flow::HamiltonianFlow, config::Common.HamiltonianPointConfig; variable, unsafe
+    flow::HamiltonianFlow, config::Common.HamiltonianEndPointConfig; variable, unsafe
 )
     throw(IncorrectArgument(
         "augment=true requires a variable-dependent Hamiltonian";
@@ -656,12 +656,12 @@ end
 # WithAD + NonFixed: valid path
 function call_augmented(
     ::Type{Common.WithAD}, ::Type{Common.NonFixed},
-    flow::HamiltonianFlow, config::Common.HamiltonianPointConfig; variable, unsafe
+    flow::HamiltonianFlow, config::Common.HamiltonianEndPointConfig; variable, unsafe
 )
     sys    = system(flow)
     x0     = Common.initial_state(config)
     pv0    = zeros(eltype(x0), length(variable))
-    config_aug = Common.AugmentedHamiltonianPointConfig(
+    config_aug = Common.AugmentedHamiltonianEndPointConfig(
         config.t0, x0, Common.initial_costate(config), pv0, config.tf
     )
     return call(flow, config_aug; variable=variable, unsafe=unsafe)
@@ -670,8 +670,8 @@ end
 
 **Key simplification**: `call(flow, config_aug; ...)` reuses the existing pipeline unchanged:
 
-- `prepare_cache` uses `initial_state`/`initial_costate` on `AugmentedHamiltonianPointConfig` ✓
-- `build_problem` dispatches on `AugmentedHamiltonianPointConfig` → calls `build_rhs_augmented(sys, n_x, n_v)` ✓
+- `prepare_cache` uses `initial_state`/`initial_costate` on `AugmentedHamiltonianEndPointConfig` ✓
+- `build_problem` dispatches on `AugmentedHamiltonianEndPointConfig` → calls `build_rhs_augmented(sys, n_x, n_v)` ✓
 - `build_solution` dispatches on `AugmentedHamiltonianTrait` → returns `(xf, pf, pvf)` ✓
 
 ### Step 25 — `src/Solutions/building.jl` (modified)
@@ -696,7 +696,7 @@ _aug_split_solution(u, x0::AbstractVector, pv0::AbstractVector) = (
 function build_solution(
     result::Integrators.AbstractIntegrationResult,
     sys::Systems.AbstractHamiltonianSystem,
-    config::Common.AbstractPointConfig{X0, Common.AugmentedHamiltonianTrait}
+    config::Common.AbstractEndPointConfig{X0, Common.AugmentedHamiltonianTrait}
 ) where {X0}
     u = Integrators.final_state(result)
     return _aug_split_solution(
@@ -711,8 +711,8 @@ Returns `(xf, pf, pvf)`. `build_augmented_solution` from the original draft is *
 
 ### Step 26 — Test Checkpoint: `augment=true`
 
-- `@testset "Unit: AugmentedHamiltonianPointConfig construction"` — fields, `initial_condition`, getters
-- `@testset "Unit: prepare_cache on AugmentedHamiltonianPointConfig"` — same result as on `HamiltonianPointConfig`
+- `@testset "Unit: AugmentedHamiltonianEndPointConfig construction"` — fields, `initial_condition`, getters
+- `@testset "Unit: prepare_cache on AugmentedHamiltonianEndPointConfig"` — same result as on `HamiltonianEndPointConfig`
 - `@testset "Error: augment=true on WithoutAD flow"` — `IncorrectArgument` with message
 - `@testset "Error: augment=true on Fixed system"` — `IncorrectArgument` with message
 - `@testset "Integration: augment=true returns (xf, pf, pvf)"`
@@ -783,7 +783,7 @@ Write docstrings for all new and modified public-facing items:
 - `src/Differentiation/building.jl` — `build_ad_backend`
 - `src/Systems/hamiltonian_system.jl` — `HamiltonianSystem`, constructors, accessors
 - `src/Systems/building.jl` — new `build_system` overloads
-- `src/Common/configs.jl` — `AugmentedHamiltonianPointConfig`, `initial_variable_costate`
+- `src/Common/configs.jl` — `AugmentedHamiltonianEndPointConfig`, `initial_variable_costate`
 - `src/Flows/calling.jl` — `prepare_cache`, `call_augmented`, `augment` parameter
 - `src/Flows/building.jl` — `Flow(h::AbstractHamiltonian; ...)`
 - `src/Solutions/building.jl` — `_aug_split_solution`, `build_solution` augmented overload

--- a/reports/save/hamilonian/save/hamiltonian_plan_old.md
+++ b/reports/save/hamilonian/save/hamiltonian_plan_old.md
@@ -251,20 +251,20 @@ function (f::HamiltonianFlow)(t0, x0, p0, tf;
     augment  = false,
 )
     config = augment ?
-        Common.HamiltonianAugmentedPointConfig(t0, x0, p0, tf) :
-        Common.HamiltonianPointConfig(t0, x0, p0, tf)
+        Common.HamiltonianAugmentedEndPointConfig(t0, x0, p0, tf) :
+        Common.HamiltonianEndPointConfig(t0, x0, p0, tf)
     return call(f, config; variable=variable, unsafe=unsafe)
 end
 ```
 
-### 6.2 Nouveau `Config` : `HamiltonianAugmentedPointConfig` / `HamiltonianAugmentedTrajectoryConfig`
+### 6.2 Nouveau `Config` : `HamiltonianAugmentedEndPointConfig` / `HamiltonianAugmentedTrajectoryConfig`
 
 Ces configs signalent au `call` d'utiliser `rhs_augmented` et de découper la solution en `(xf, pf, pvf)`.
 
 ### 6.3 Adaptation de `call`
 
 ```julia
-function call(flow::HamiltonianFlow, config::HamiltonianAugmentedPointConfig; variable, unsafe)
+function call(flow::HamiltonianFlow, config::HamiltonianAugmentedEndPointConfig; variable, unsafe)
     sys  = system(flow)
     int  = integrator(flow)
     # Vérification

--- a/reports/save/hamilonian/save/plan-save.md
+++ b/reports/save/hamilonian/save/plan-save.md
@@ -7,7 +7,7 @@ This plan adds a `Hamiltonian` type that wraps a scalar Hamiltonian function `H(
 
 **New types:**
 - `Hamiltonian{F, TD, VD, MD}` in `Data` module - wrapper for scalar Hamiltonian functions
-- `HamiltonianAugmentedPointConfig` and `HamiltonianAugmentedTrajectoryConfig` in `Common` - configs for augmented integration
+- `HamiltonianAugmentedEndPointConfig` and `HamiltonianAugmentedTrajectoryConfig` in `Common` - configs for augmented integration
 
 **Modified types:**
 - `HamiltonianSystem` - add optional `rhs_augmented` field and `hamiltonian_source` field to support augmented integration
@@ -469,8 +469,8 @@ grep -E "Error|Fail|Test Summary" /tmp/phase6.log
 
 > 🏗️ Applying Modules Rule — Add new config types following existing pattern
 
-- Add `struct HamiltonianAugmentedPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfigWithMaC{X0, PointTrait, HamiltonianTrait}`
-- Add `struct HamiltonianAugmentedTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfigWithMaC{X0, TrajectoryTrait, HamiltonianTrait}`
+- Add `struct HamiltonianAugmentedEndPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfigWithMaC{X0, EndPointMode, HamiltonianTrait}`
+- Add `struct HamiltonianAugmentedTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfigWithMaC{X0, TrajectoryMode, HamiltonianTrait}`
 - Implement `Base.show` methods for both configs
 - Implement `initial_condition` to return `vcat(x0, p0, zeros(m))` (m inferred at runtime)
 
@@ -481,7 +481,7 @@ grep -E "Error|Fail|Test Summary" /tmp/phase6.log
 > 📋 Applying Architecture Rule — Augmented solution builder handles result extraction for augmented flows
 
 - Implement `_aug_split_solution(u, x0, p0, m)` helper (splits [x; p; pv] into components)
-- Implement `function build_augmented_solution(result, sys::HamiltonianSystem, config::HamiltonianAugmentedPointConfig)`
+- Implement `function build_augmented_solution(result, sys::HamiltonianSystem, config::HamiltonianAugmentedEndPointConfig)`
 - Return tuple `(xf, pf, pvf)` with appropriate types (scalar/vector based on dimensions)
 - Implement `function build_augmented_solution(result, sys::HamiltonianSystem, config::HamiltonianAugmentedTrajectoryConfig)`
 - Return wrapped result with augmented accessor methods
@@ -494,7 +494,7 @@ grep -E "Error|Fail|Test Summary" /tmp/phase6.log
 
 - Create `test/suite/common/test_augmented_configs.jl`
 - Test sections:
-  - `@testset "Unit: HamiltonianAugmentedPointConfig construction"` - with scalar/vector dimensions
+  - `@testset "Unit: HamiltonianAugmentedEndPointConfig construction"` - with scalar/vector dimensions
   - `@testset "Unit: HamiltonianAugmentedTrajectoryConfig construction"` - with scalar/vector dimensions
   - `@testset "Unit: initial_condition for augmented configs"` - correct zero-padding
   - `@testset "Unit: build_augmented_solution point"` - correct splitting
@@ -513,7 +513,7 @@ grep -E "Error|Fail|Test Summary" /tmp/phase7.log
 > 📋 Applying Architecture Rule — augment parameter on flow call is most coherent with existing variable/unsafe pattern
 
 - Modify `HamiltonianFlow` callable methods to add `augment::Bool=false` keyword argument
-- In both point and trajectory callables: if `augment=true`, build `HamiltonianAugmentedPointConfig` or `HamiltonianAugmentedTrajectoryConfig`
+- In both point and trajectory callables: if `augment=true`, build `HamiltonianAugmentedEndPointConfig` or `HamiltonianAugmentedTrajectoryConfig`
 - Add validation: if `augment=true` and system is Fixed, throw IncorrectArgument
 - Add validation: if `augment=true` and `rhs_augmented===nothing`, throw PreconditionError
 
@@ -523,7 +523,7 @@ grep -E "Error|Fail|Test Summary" /tmp/phase7.log
 
 > 🏗️ Applying Modules Rule — Add dispatch for augmented configs
 
-- Add method `function call(flow::HamiltonianFlow, config::HamiltonianAugmentedPointConfig; variable, unsafe)`
+- Add method `function call(flow::HamiltonianFlow, config::HamiltonianAugmentedEndPointConfig; variable, unsafe)`
 - Build augmented initial condition `u0 = vcat(x0, p0, zeros(m))`
 - Use `rhs_augmented` from system instead of `rhs`
 - Call `build_augmented_solution` instead of `build_solution`

--- a/reports/save/interfaces/traits_vs_abstract_types.md
+++ b/reports/save/interfaces/traits_vs_abstract_types.md
@@ -120,8 +120,8 @@ content_trait(::AbstractConfigWithMaC{X0, Mode, Content}) where {X0, Mode, Conte
 …and `build_solution` dispatches by **passing the extracted trait** as a type argument:
 
 ```julia
-build_solution(::Type{PointTrait}, ::Type{StateTrait},       config, result) = …
-build_solution(::Type{PointTrait}, ::Type{HamiltonianTrait}, config, result) = …
+build_solution(::Type{EndPointMode}, ::Type{StateTrait},       config, result) = …
+build_solution(::Type{EndPointMode}, ::Type{HamiltonianTrait}, config, result) = …
 ```
 
 **This is exactly the target pattern.** `Configs` proves CTFlows already does
@@ -173,8 +173,8 @@ const HamiltonianFlow{TD,VD,S,I} = Flow{TD,VD,HamiltonianDynamics,S,I}
 Call signatures stay cleanly dispatched via the aliases:
 
 ```julia
-(f::AbstractStateFlow)(t0, x0, tf; …)        = _invoke_flow(f, StatePointConfig(t0, x0, tf); …)
-(f::AbstractHamiltonianFlow)(t0, x0, p0, tf; …) = _invoke_flow(f, HamiltonianPointConfig(t0, x0, p0, tf); …)
+(f::AbstractStateFlow)(t0, x0, tf; …)        = _invoke_flow(f, StateEndPointConfig(t0, x0, tf); …)
+(f::AbstractHamiltonianFlow)(t0, x0, p0, tf; …) = _invoke_flow(f, HamiltonianEndPointConfig(t0, x0, p0, tf); …)
 ```
 
 Likewise on the systems side:

--- a/reports/save/v1/VectorField.md
+++ b/reports/save/v1/VectorField.md
@@ -11,8 +11,8 @@ non-autonomous (`f(x)` vs. `f(t, x)`) and fixed vs. non-fixed (with an extra var
 Two call modes are supported via the config types introduced in
 [`design.md`](design.md):
 
-- `flow(StatePointConfig(t0, x0[, p0], tf))` — returns the final state `xf` (and costate
-  `pf` if `p0` was provided). For vector fields, no costate; `StatePointConfig(t0, x0, tf)`.
+- `flow(StateEndPointConfig(t0, x0[, p0], tf))` — returns the final state `xf` (and costate
+  `pf` if `p0` was provided). For vector fields, no costate; `StateEndPointConfig(t0, x0, tf)`.
 - `flow(StateTrajectoryConfig((t0, tf), x0))` — returns a solution object containing the
   full trajectory.
 
@@ -47,12 +47,12 @@ The first implementation delivers an end-to-end vector-field flow with:
   vf = VectorField((t, x, v) -> -x .* v)
   ```
 
-- **`StatePointConfig` and `StateTrajectoryConfig`** — plain config structs (defined in `Core` or
+- **`StateEndPointConfig` and `StateTrajectoryConfig`** — plain config structs (defined in `Core` or
   `Systems`) that carry call-mode data and drive dispatch in `build_solution`. For vector
   fields only the no-costate constructors are needed in Phase 1:
 
   ```julia
-  StatePointConfig(t0, x0, tf)           # endpoint call
+  StateEndPointConfig(t0, x0, tf)           # endpoint call
   StateTrajectoryConfig((t0, tf), x0)    # trajectory call
   ```
 
@@ -62,7 +62,7 @@ The first implementation delivers an end-to-end vector-field flow with:
   - `rhs!(system)` — returns the ODE right-hand side closure `(du, u, p, t) -> nothing`,
     adapted to the `VectorField` trait (autonomous or not, fixed or not).
   - `dimensions(system)` — returns `(n_x = n,)` where `n` is the state dimension.
-  - `build_solution(raw, flow, ::StatePointConfig)` — extracts and returns the final state `xf`
+  - `build_solution(raw, flow, ::StateEndPointConfig)` — extracts and returns the final state `xf`
     from the raw `ODESolution` (i.e. `raw.u[end]`, or `raw[end]` for scalar state).
   - `build_solution(raw, flow, ::StateTrajectoryConfig)` — returns the raw `ODESolution` directly
     (Phase 1; a CTFlows wrapper is deferred).
@@ -113,7 +113,7 @@ Following `.windsurf/rules/testing.md`:
 - **Unit tests** for `VectorField` (all four trait combinations, scalar and vector state).
 - **Unit tests** for `VectorFieldSystem` (`rhs!`, `dimensions`, `build_solution` for both
   config types).
-- **Unit tests** for `StatePointConfig` and `StateTrajectoryConfig` (construction, field access).
+- **Unit tests** for `StateEndPointConfig` and `StateTrajectoryConfig` (construction, field access).
 - **Contract tests** for `SciMLIntegrator` (`id`, `metadata`, `options`, `NotImplemented`
   path for unimplemented callables).
 - **End-to-end pipeline test** (guarded by the SciML extension, using
@@ -137,14 +137,14 @@ integ = SciMLIntegrator(abstol = 1e-12, reltol = 1e-12)
 flow = build_flow(sys, integ)
 
 # Endpoint call — returns final state only
-xf = flow(StatePointConfig(0.0, [1.0], 1.0))         # ≈ [exp(-1)]
+xf = flow(StateEndPointConfig(0.0, [1.0], 1.0))         # ≈ [exp(-1)]
 
 # Trajectory call — returns raw ODESolution (Phase 1)
 sol = flow(StateTrajectoryConfig((0.0, 1.0), [1.0]))  # ODESolution
 sol(0.5)                                          # ≈ [exp(-0.5)]
 
 # High-level convenience
-xf2 = solve(sys, StatePointConfig(0.0, [1.0], 1.0), integ)
+xf2 = solve(sys, StateEndPointConfig(0.0, [1.0], 1.0), integ)
 ```
 
 ---
@@ -170,7 +170,7 @@ The following items are intentionally **not** in Phase 1:
 - **Concatenation** — `MultiPhaseSystem`, `MultiPhaseFlow`, the `∘` and `*` operators.
 - **Per-algorithm integrator strategies** — dedicated `Tsit5Integrator`,
   `Rodas4Integrator`, etc.; Phase 1 ships one generic `SciMLIntegrator`.
-- **Costate integration** — `StatePointConfig(t0, x0, p0, tf)` and
+- **Costate integration** — `StateEndPointConfig(t0, x0, p0, tf)` and
   `StateTrajectoryConfig((t0, tf), x0, p0)` for Hamiltonian and OCP flows; not relevant for
   plain vector fields.
 

--- a/reports/save/v1/critique_ctflows.md
+++ b/reports/save/v1/critique_ctflows.md
@@ -32,7 +32,7 @@ Dans `Solutions/building.jl`, `build_solution` reçoit directement une `SciMLBas
 
 ```julia
 function build_solution(ode_sol::SciMLBase.AbstractODESolution,
-                        sys::Systems.VectorFieldSystem, config::StatePointConfig)
+                        sys::Systems.VectorFieldSystem, config::StateEndPointConfig)
     final = ode_sol.u[end]   # connaissance directe de la structure SciML
     return config.x0 isa Number ? final[1] : final
 end
@@ -79,7 +79,7 @@ end
 
 ```julia
 function build_solution(result::AbstractIntegrationResult,
-                        sys::VectorFieldSystem, config::StatePointConfig)
+                        sys::VectorFieldSystem, config::StateEndPointConfig)
     return final_state(result)
 end
 
@@ -298,7 +298,7 @@ Paramétrer `AbstractConfig` avec `X0` pour rendre la distinction scalaire/vecte
 ```julia
 abstract type AbstractConfig{X0} end
 
-struct StatePointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfig{X0}
+struct StateEndPointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfig{X0}
     t0::T0
     x0::X0
     tf::TF
@@ -322,17 +322,17 @@ initial_condition(c::AbstractConfig)           = c.x0
 ```julia
 # Cas scalaire — X0 <: Number
 function build_solution(result::AbstractIntegrationResult, sys,
-                        config::StatePointConfig{<:Real, <:Number, <:Real})
+                        config::StateEndPointConfig{<:Real, <:Number, <:Real})
     return final_state(result)[1]
 end
 
 # Cas général — vecteur
-function build_solution(result::AbstractIntegrationResult, sys, config::StatePointConfig)
+function build_solution(result::AbstractIntegrationResult, sys, config::StateEndPointConfig)
     return final_state(result)
 end
 ```
 
-La distinction scalaire/vecteur ne concerne que `StatePointConfig` — pour `StateTrajectoryConfig` on retourne toujours un `VectorFieldSolution` quelle que soit la dimension, donc pas de cas particulier à gérer.
+La distinction scalaire/vecteur ne concerne que `StateEndPointConfig` — pour `StateTrajectoryConfig` on retourne toujours un `VectorFieldSolution` quelle que soit la dimension, donc pas de cas particulier à gérer.
 
 Le paramètre `X0` sur `AbstractConfig` ne crée pas de propagation gênante : écrire `AbstractConfig` sans paramètre dans une signature signifie "tout `AbstractConfig` quel que soit `X0`", ce qui est le comportement habituel de Julia.
 
@@ -380,7 +380,7 @@ Threader `unsafe` comme kwarg à travers la chaîne d'appel, exactement comme `v
 ```julia
 # Flow callable
 function (f::Flow)(t0, x0, tf; variable=nothing, unsafe=false)
-    return call(f, StatePointConfig(t0, x0, tf); variable=variable, unsafe=unsafe)
+    return call(f, StateEndPointConfig(t0, x0, tf); variable=variable, unsafe=unsafe)
 end
 
 # call

--- a/reports/save/v1/design.md
+++ b/reports/save/v1/design.md
@@ -9,7 +9,7 @@ built around one key simplification: **a single strategy family**.
 CTFlows organises its code along three concerns:
 
 - **Objects** — `AbstractSystem`, `AbstractFlow`, `AbstractSolution`, and the config types
-  `StatePointConfig` / `StateTrajectoryConfig`. They are *what* is acted upon or returned.
+  `StateEndPointConfig` / `StateTrajectoryConfig`. They are *what* is acted upon or returned.
 - **Single strategy family** — `AbstractIntegrator <: CTSolvers.Strategies.AbstractStrategy`.
   This is the only family. It controls *how* the Cauchy problem is solved.
 - **Pipelines** — `build_system`, `build_flow`, `integrate`, `build_solution`, `solve`.
@@ -36,10 +36,10 @@ is the right mechanism) and that AD configuration is best expressed as a plain
 Config types carry the call-mode data and drive dispatch in `build_solution`. They are plain
 structs, not strategies.
 
-### `StatePointConfig`
+### `StateEndPointConfig`
 
 ```julia
-struct StatePointConfig{T, X, P}
+struct StateEndPointConfig{T, X, P}
     t0::T
     x0::X
     p0::P   # nothing if no costate
@@ -49,8 +49,8 @@ end
 
 Constructors:
 
-- `StatePointConfig(t0, x0, tf)` — no costate (`p0 = nothing`)
-- `StatePointConfig(t0, x0, p0, tf)` — with costate
+- `StateEndPointConfig(t0, x0, tf)` — no costate (`p0 = nothing`)
+- `StateEndPointConfig(t0, x0, p0, tf)` — with costate
 
 **Semantics**: integrate from `t0` to `tf` starting at `x0` (and `p0` if present); return
 only the **final values** `xf` (and `pf` if present).
@@ -107,7 +107,7 @@ build_solution(raw, flow::AbstractFlow, config::AbstractConfig)
   has no further dependency on whatever produced it.
 - `dimensions` is the canonical introspection point; used by the integrator to allocate
   and by the pipeline to verify compatibility.
-- `build_solution` dispatches on `config` type: for `StatePointConfig` it extracts the final
+- `build_solution` dispatches on `config` type: for `StateEndPointConfig` it extracts the final
   state (and costate); for `StateTrajectoryConfig` it wraps the full trajectory.
 
 ### 3.2 `AbstractFlow`
@@ -122,7 +122,7 @@ abstract type AbstractFlow end
 **Required methods** (`NotImplemented` defaults):
 
 ```julia
-(flow::AbstractFlow)(config)      # dispatch on StatePointConfig or StateTrajectoryConfig
+(flow::AbstractFlow)(config)      # dispatch on StateEndPointConfig or StateTrajectoryConfig
 system(flow::AbstractFlow)        # returns the embedded AbstractSystem
 integrator(flow::AbstractFlow)    # returns the embedded AbstractIntegrator
 ```
@@ -314,8 +314,8 @@ end
 `build_solution` dispatches on the config type:
 
 ```julia
-# StatePointConfig — extract and return final values
-function build_solution(raw, flow::AbstractFlow, config::StatePointConfig)
+# StateEndPointConfig — extract and return final values
+function build_solution(raw, flow::AbstractFlow, config::StateEndPointConfig)
     # extract xf (and pf if config.p0 ≢ nothing) from raw
 end
 
@@ -346,7 +346,7 @@ end
 
 | Type | Kind | Required methods |
 | --- | --- | --- |
-| `StatePointConfig` | object (config) | constructor |
+| `StateEndPointConfig` | object (config) | constructor |
 | `StateTrajectoryConfig` | object (config) | constructor |
 | `AbstractSystem` | object | `rhs!`, `dimensions`, `build_solution` |
 | `AbstractFlow` | object | `(flow)(config)`, `system`, `integrator` |

--- a/reports/save/v1/refactor-integration-result.md
+++ b/reports/save/v1/refactor-integration-result.md
@@ -54,7 +54,7 @@ Full docstrings (TYPEDEF + TYPEDSIGNATURES, @ref cross-refs).
 ### Step 3 — `src/Solutions/building.jl`
 
 - Change both `build_solution` signatures from `ode_sol::SciMLBase.AbstractODESolution` to `result::AbstractIntegrationResult`
-- `StatePointConfig` branch: `final_state(result)` replaces `ode_sol.u[end]`
+- `StateEndPointConfig` branch: `final_state(result)` replaces `ode_sol.u[end]`
 - `StateTrajectoryConfig` branch: `VectorFieldSolution(result)` (no change to wrapping logic, just different argument type)
 - Update docstrings
 
@@ -182,7 +182,7 @@ Full docstrings (TYPEDEF + TYPEDSIGNATURES, @ref cross-refs).
 - **Functional decoupling test** (the real architectural guarantee):
   - Define `MockIntegrationResult <: Solutions.AbstractIntegrationResult` — pure Julia, zero SciML imports
   - Implement `final_state`, `times`, `evaluate_at` with deterministic test data
-  - `Solutions.build_solution(mock, sys, StatePointConfig)` → returns expected state vector
+  - `Solutions.build_solution(mock, sys, StateEndPointConfig)` → returns expected state vector
   - `Solutions.build_solution(mock, sys, StateTrajectoryConfig)` → returns `VectorFieldSolution`
   - `VectorFieldSolution(mock)` callable: `sol(0.5)` returns expected value
   - `Base.show(io, sol)` and `Base.show(io, MIME("text/plain"), sol)` run without error

--- a/reports/save/v1/simplify-build-integrator.md
+++ b/reports/save/v1/simplify-build-integrator.md
@@ -218,7 +218,7 @@ config = Common.StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
 sol = Flows.call(flow, config)
 
 # Or point-to-point integration
-config = Common.StatePointConfig((0.0, 1.0), [1.0, 0.0])
+config = Common.StateEndPointConfig((0.0, 1.0), [1.0, 0.0])
 final_state = Flows.call(flow, config)
 ```
 

--- a/src/Common/default.jl
+++ b/src/Common/default.jl
@@ -98,7 +98,7 @@ variable costate equation `ṗᵥ = -∂H/∂v` unless explicitly requested.
 # Returns
 - `Bool`: The default value for the `variable_costate` parameter.
 
-See also: [`CTFlows.Configs.AugmentedHamiltonianPointConfig`](@ref).
+See also: [`CTFlows.Configs.AugmentedHamiltonianEndPointConfig`](@ref).
 """
 __variable_costate()::Bool = false
 

--- a/src/Configs/Configs.jl
+++ b/src/Configs/Configs.jl
@@ -15,11 +15,11 @@ Configuration types encode these choices as type parameters for compile-time dis
 # Main Types
 - [`AbstractConfig`](@ref): Base configuration type
 - [`AbstractConfigWithMaC`](@ref): Configuration with mode and content traits
-- [`StatePointConfig`](@ref): Point-to-point state integration
+- [`StateEndPointConfig`](@ref): Point-to-point state integration
 - [`StateTrajectoryConfig`](@ref): Trajectory state integration
-- [`HamiltonianPointConfig`](@ref): Point-to-point Hamiltonian integration
+- [`HamiltonianEndPointConfig`](@ref): Point-to-point Hamiltonian integration
 - [`HamiltonianTrajectoryConfig`](@ref): Trajectory Hamiltonian integration
-- [`AugmentedHamiltonianPointConfig`](@ref): Augmented Hamiltonian for variable costate
+- [`AugmentedHamiltonianEndPointConfig`](@ref): Augmented Hamiltonian for variable costate
 
 # Accessors
 - [`tspan`](@ref): Time span `(t0, tf)`
@@ -61,10 +61,10 @@ include(joinpath(@__DIR__, "show.jl"))
 # ==============================================================================
 
 export AbstractConfig, AbstractConfigWithMaC
-export AbstractPointConfig, AbstractTrajectoryConfig
+export AbstractEndPointConfig, AbstractTrajectoryConfig
 export AbstractStateConfig, AbstractHamiltonianConfig, AbstractAugmentedHamiltonianConfig
-export StatePointConfig, StateTrajectoryConfig
-export HamiltonianPointConfig, HamiltonianTrajectoryConfig, AugmentedHamiltonianPointConfig
+export StateEndPointConfig, StateTrajectoryConfig
+export HamiltonianEndPointConfig, HamiltonianTrajectoryConfig, AugmentedHamiltonianEndPointConfig
 export tspan, initial_condition, initial_state, initial_costate, initial_variable_costate
 export initial_time, final_time, mode_trait, dynamics_trait
 

--- a/src/Configs/abstract.jl
+++ b/src/Configs/abstract.jl
@@ -12,7 +12,7 @@ specific integration scenarios (e.g., point-to-point, trajectory, costate).
 
 The type parameters encode:
 - `X0`: Type of the initial condition (scalar `Number` or vector `AbstractVector`)
-- `Mode`: Integration mode (`PointTrait` or `TrajectoryTrait`)
+- `Mode`: Integration mode (`EndPointMode` or `TrajectoryMode`)
 - `Dyn`: Dynamics type (`StateDynamics` or `HamiltonianDynamics`)
 
 This enables compile-time dispatch on mode and content without runtime type tests.
@@ -26,17 +26,17 @@ All subtypes must implement:
 \`\`\`julia-repl
 julia> using CTFlows.Configs
 
-julia> StatePointConfig <: Configs.AbstractConfig
+julia> StateEndPointConfig <: Configs.AbstractConfig
 true
 
-julia> StatePointConfig <: Configs.AbstractPointConfig
+julia> StateEndPointConfig <: Configs.AbstractEndPointConfig
 true
 
-julia> StatePointConfig <: Configs.AbstractStateConfig
+julia> StateEndPointConfig <: Configs.AbstractStateConfig
 true
 \`\`\`
 
-See also: [`CTFlows.Configs.AbstractPointConfig`](@ref), [`CTFlows.Configs.AbstractTrajectoryConfig`](@ref), [`CTFlows.Configs.AbstractStateConfig`](@ref), [`CTFlows.Configs.AbstractHamiltonianConfig`](@ref).
+See also: [`CTFlows.Configs.AbstractEndPointConfig`](@ref), [`CTFlows.Configs.AbstractTrajectoryConfig`](@ref), [`CTFlows.Configs.AbstractStateConfig`](@ref), [`CTFlows.Configs.AbstractHamiltonianConfig`](@ref).
 """
 abstract type AbstractConfig{X0} end
 
@@ -54,7 +54,7 @@ on integration mode (point vs trajectory) and content type (state, Hamiltonian, 
 
 # Type Parameters
 - `X0`: Type of the initial condition (scalar `Number` or vector `AbstractVector`)
-- `Mode <: AbstractModeTrait`: Integration mode trait (`PointTrait` or `TrajectoryTrait`)
+- `Mode <: AbstractModeTrait`: Integration mode trait (`EndPointMode` or `TrajectoryMode`)
 - `Dyn <: AbstractDynamicsTrait`: Dynamics trait (`StateDynamics`, `HamiltonianDynamics`, or `AugmentedHamiltonianDynamics`)
 
 # Interface Requirements
@@ -66,14 +66,14 @@ All subtypes must implement:
 \`\`\`julia-repl
 julia> using CTFlows.Configs
 
-julia> StatePointConfig <: Configs.AbstractConfigWithMaC
+julia> StateEndPointConfig <: Configs.AbstractConfigWithMaC
 true
 
-julia> HamiltonianPointConfig <: Configs.AbstractConfigWithMaC
+julia> HamiltonianEndPointConfig <: Configs.AbstractConfigWithMaC
 true
 \`\`\`
 
-See also: [`CTFlows.Configs.AbstractConfig`](@ref), [`CTFlows.Configs.AbstractPointConfig`](@ref), [`CTFlows.Configs.AbstractTrajectoryConfig`](@ref), [`CTFlows.Configs.AbstractStateConfig`](@ref), [`CTFlows.Configs.AbstractHamiltonianConfig`](@ref), [`CTFlows.Configs.AbstractAugmentedHamiltonianConfig`](@ref).
+See also: [`CTFlows.Configs.AbstractConfig`](@ref), [`CTFlows.Configs.AbstractEndPointConfig`](@ref), [`CTFlows.Configs.AbstractTrajectoryConfig`](@ref), [`CTFlows.Configs.AbstractStateConfig`](@ref), [`CTFlows.Configs.AbstractHamiltonianConfig`](@ref), [`CTFlows.Configs.AbstractAugmentedHamiltonianConfig`](@ref).
 """
 abstract type AbstractConfigWithMaC{X0, Mode<:Traits.AbstractModeTrait, Dyn<:Traits.AbstractDynamicsTrait} <: AbstractConfig{X0} end
 
@@ -89,15 +89,15 @@ enabling trait-based dispatch on the integration mode (point vs trajectory).
 - `::AbstractConfigWithMaC{X0, Mode, Content}`: Any concrete configuration subtype.
 
 # Returns
-- `Type{Mode}`: The mode trait type (e.g., `PointTrait` or `TrajectoryTrait`).
+- `Type{Mode}`: The mode trait type (e.g., `EndPointMode` or `TrajectoryMode`).
 
 # Example
 \`\`\`julia
-config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
-Configs.mode_trait(config) === Traits.PointTrait  # true
+config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
+Configs.mode_trait(config) === Traits.EndPointMode  # true
 \`\`\`
 
-See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.TrajectoryTrait`](@ref), [`CTFlows.Configs.dynamics_trait`](@ref).
+See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.TrajectoryMode`](@ref), [`CTFlows.Configs.dynamics_trait`](@ref).
 """
 function mode_trait(::AbstractConfigWithMaC{X0, Mode, Dyn}) where {X0, Mode, Dyn}
     return Mode
@@ -119,7 +119,7 @@ enabling trait-based dispatch on the integration dynamics (state, Hamiltonian, a
 
 # Example
 \`\`\`julia
-config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
 Configs.dynamics_trait(config) === Traits.HamiltonianDynamics  # true
 \`\`\`
 
@@ -134,18 +134,18 @@ $(TYPEDEF)
 
 Alias for point integration mode configurations.
 
-Matches any `AbstractConfig` with `PointTrait` as the mode parameter.
+Matches any `AbstractConfig` with `EndPointMode` as the mode parameter.
 """
-const AbstractPointConfig{X0, C} = AbstractConfigWithMaC{X0, Traits.PointTrait, C}
+const AbstractEndPointConfig{X0, C} = AbstractConfigWithMaC{X0, Traits.EndPointMode, C}
 
 """
 $(TYPEDEF)
 
 Alias for trajectory integration mode configurations.
 
-Matches any `AbstractConfig` with `TrajectoryTrait` as the mode parameter.
+Matches any `AbstractConfig` with `TrajectoryMode` as the mode parameter.
 """
-const AbstractTrajectoryConfig{X0, C} = AbstractConfigWithMaC{X0, Traits.TrajectoryTrait, C}
+const AbstractTrajectoryConfig{X0, C} = AbstractConfigWithMaC{X0, Traits.TrajectoryMode, C}
 
 """
 $(TYPEDEF)

--- a/src/Configs/concrete.jl
+++ b/src/Configs/concrete.jl
@@ -19,8 +19,8 @@ integration from a single initial condition to a specific final time.
 \`\`\`julia-repl
 julia> using CTFlows.Configs
 
-julia> config = StatePointConfig(0.0, [1.0, 0.0], 1.0)
-StatePointConfig
+julia> config = StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
+StateEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]
   tf: 1.0
@@ -28,12 +28,12 @@ StatePointConfig
 
 See also: [`CTFlows.Configs.StateTrajectoryConfig`](@ref)
 """
-struct StatePointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfigWithMaC{X0, Traits.PointTrait, Traits.StateDynamics}
+struct StateEndPointConfig{T0<:Real, X0, TF<:Real} <: AbstractConfigWithMaC{X0, Traits.EndPointMode, Traits.StateDynamics}
     t0::T0
     x0::X0
     tf::TF
-    StatePointConfig{T0, X0, TF}(t0, x0, tf) where {T0<:Real, X0, TF<:Real} = new{T0, X0, TF}(t0, x0, tf)
-    function StatePointConfig(t0::Real, x0, tf::Real)
+    StateEndPointConfig{T0, X0, TF}(t0, x0, tf) where {T0<:Real, X0, TF<:Real} = new{T0, X0, TF}(t0, x0, tf)
+    function StateEndPointConfig(t0::Real, x0, tf::Real)
         t = float(t0)
         X = eltype(x0) <: AbstractFloat ? x0 : float.(x0)
         T = float(tf)
@@ -63,9 +63,9 @@ StateTrajectoryConfig
   x0: [1.0, 0.0]
 \`\`\`
 
-See also: [`CTFlows.Configs.StatePointConfig`](@ref)
+See also: [`CTFlows.Configs.StateEndPointConfig`](@ref)
 """
-struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfigWithMaC{X0, Traits.TrajectoryTrait, Traits.StateDynamics}
+struct StateTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0} <: AbstractConfigWithMaC{X0, Traits.TrajectoryMode, Traits.StateDynamics}
     tspan::TS
     x0::X0
     StateTrajectoryConfig{TS, X0}(tspan, x0) where {TS<:Tuple{<:Real,<:Real}, X0} = new{TS, X0}(tspan, x0)
@@ -96,23 +96,23 @@ Hamiltonian framework.
 \`\`\`julia-repl
 julia> using CTFlows.Configs
 
-julia> config = HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
-HamiltonianPointConfig
+julia> config = HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+HamiltonianEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]
   p0: [0.5, 0.3]
   tf: 1.0
 \`\`\`
 
-See also: [`CTFlows.Configs.HamiltonianTrajectoryConfig`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref).
+See also: [`CTFlows.Configs.HamiltonianTrajectoryConfig`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref).
 """
-struct HamiltonianPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfigWithMaC{X0, Traits.PointTrait, Traits.HamiltonianDynamics}
+struct HamiltonianEndPointConfig{T0<:Real, X0, P0, TF<:Real} <: AbstractConfigWithMaC{X0, Traits.EndPointMode, Traits.HamiltonianDynamics}
     t0::T0
     x0::X0
     p0::P0
     tf::TF
-    HamiltonianPointConfig{T0, X0, P0, TF}(t0, x0, p0, tf) where {T0<:Real, X0, P0, TF<:Real} = new{T0, X0, P0, TF}(t0, x0, p0, tf)
-    function HamiltonianPointConfig(t0::Real, x0, p0, tf::Real)
+    HamiltonianEndPointConfig{T0, X0, P0, TF}(t0, x0, p0, tf) where {T0<:Real, X0, P0, TF<:Real} = new{T0, X0, P0, TF}(t0, x0, p0, tf)
+    function HamiltonianEndPointConfig(t0::Real, x0, p0, tf::Real)
         t = float(t0)
         X = eltype(x0) <: AbstractFloat ? x0 : float.(x0)
         P = eltype(p0) <: AbstractFloat ? p0 : float.(p0)
@@ -146,9 +146,9 @@ HamiltonianTrajectoryConfig
   p0: [0.5, 0.3]
 \`\`\`
 
-See also: [`CTFlows.Configs.HamiltonianPointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
+See also: [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
 """
-struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfigWithMaC{X0, Traits.TrajectoryTrait, Traits.HamiltonianDynamics}
+struct HamiltonianTrajectoryConfig{TS<:Tuple{<:Real,<:Real}, X0, P0} <: AbstractConfigWithMaC{X0, Traits.TrajectoryMode, Traits.HamiltonianDynamics}
     tspan::TS
     x0::X0
     p0::P0
@@ -181,8 +181,8 @@ final time in the augmented Hamiltonian framework.
 \`\`\`julia-repl
 julia> using CTFlows.Configs
 
-julia> config = AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
-AugmentedHamiltonianPointConfig
+julia> config = AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+AugmentedHamiltonianEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]
   p0: [0.5, 0.3]
@@ -190,16 +190,16 @@ AugmentedHamiltonianPointConfig
   tf: 1.0
 \`\`\`
 
-See also: [`CTFlows.Configs.HamiltonianPointConfig`](@ref), [`CTFlows.Traits.AugmentedHamiltonianDynamics`](@ref).
+See also: [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref), [`CTFlows.Traits.AugmentedHamiltonianDynamics`](@ref).
 """
-struct AugmentedHamiltonianPointConfig{T0<:Real, X0, P0, PV0, TF<:Real} <: AbstractAugmentedHamiltonianConfig{X0, Traits.PointTrait}
+struct AugmentedHamiltonianEndPointConfig{T0<:Real, X0, P0, PV0, TF<:Real} <: AbstractAugmentedHamiltonianConfig{X0, Traits.EndPointMode}
     t0::T0
     x0::X0
     p0::P0
     pv0::PV0
     tf::TF
-    AugmentedHamiltonianPointConfig{T0, X0, P0, PV0, TF}(t0, x0, p0, pv0, tf) where {T0<:Real, X0, P0, PV0, TF<:Real} = new{T0, X0, P0, PV0, TF}(t0, x0, p0, pv0, tf)
-    function AugmentedHamiltonianPointConfig(t0::Real, x0, p0, pv0, tf::Real)
+    AugmentedHamiltonianEndPointConfig{T0, X0, P0, PV0, TF}(t0, x0, p0, pv0, tf) where {T0<:Real, X0, P0, PV0, TF<:Real} = new{T0, X0, P0, PV0, TF}(t0, x0, p0, pv0, tf)
+    function AugmentedHamiltonianEndPointConfig(t0::Real, x0, p0, pv0, tf::Real)
         t = float(t0)
         X = eltype(x0) <: AbstractFloat ? x0 : float.(x0)
         P = eltype(p0) <: AbstractFloat ? p0 : float.(p0)
@@ -218,14 +218,14 @@ For augmented Hamiltonian systems, the initial condition is the concatenation of
 initial state, initial costate, and initial variable costate: `vcat(x0, p0, pv0)`.
 
 # Arguments
-- `c::AugmentedHamiltonianPointConfig`: The augmented Hamiltonian configuration.
+- `c::AugmentedHamiltonianEndPointConfig`: The augmented Hamiltonian configuration.
 
 # Returns
 - Concatenated vector `[x0; p0; pv0]`.
 
-See also: [`CTFlows.Configs.AugmentedHamiltonianPointConfig`](@ref), [`CTFlows.Configs.initial_state`](@ref), [`CTFlows.Configs.initial_costate`](@ref), [`CTFlows.Configs.initial_variable_costate`](@ref).
+See also: [`CTFlows.Configs.AugmentedHamiltonianEndPointConfig`](@ref), [`CTFlows.Configs.initial_state`](@ref), [`CTFlows.Configs.initial_costate`](@ref), [`CTFlows.Configs.initial_variable_costate`](@ref).
 """
-function initial_condition(c::AugmentedHamiltonianPointConfig)
+function initial_condition(c::AugmentedHamiltonianEndPointConfig)
     return vcat(c.x0, c.p0, c.pv0)
 end
 
@@ -237,14 +237,14 @@ Return the initial costate for augmented Hamiltonian configurations.
 Extracts the initial costate field from the augmented Hamiltonian configuration.
 
 # Arguments
-- `c::AugmentedHamiltonianPointConfig`: The augmented Hamiltonian configuration.
+- `c::AugmentedHamiltonianEndPointConfig`: The augmented Hamiltonian configuration.
 
 # Returns
 - The initial costate vector.
 
-See also: [`CTFlows.Configs.AugmentedHamiltonianPointConfig`](@ref).
+See also: [`CTFlows.Configs.AugmentedHamiltonianEndPointConfig`](@ref).
 """
-function initial_costate(c::AugmentedHamiltonianPointConfig)
+function initial_costate(c::AugmentedHamiltonianEndPointConfig)
     return c.p0
 end
 
@@ -256,13 +256,13 @@ Return the initial variable costate for augmented Hamiltonian configurations.
 Extracts the initial variable costate field from the augmented Hamiltonian configuration.
 
 # Arguments
-- `c::AugmentedHamiltonianPointConfig`: The augmented Hamiltonian configuration.
+- `c::AugmentedHamiltonianEndPointConfig`: The augmented Hamiltonian configuration.
 
 # Returns
 - The initial variable costate vector.
 
-See also: [`CTFlows.Configs.AugmentedHamiltonianPointConfig`](@ref).
+See also: [`CTFlows.Configs.AugmentedHamiltonianEndPointConfig`](@ref).
 """
-function initial_variable_costate(c::AugmentedHamiltonianPointConfig)
+function initial_variable_costate(c::AugmentedHamiltonianEndPointConfig)
     return c.pv0
 end

--- a/src/Configs/implementations.jl
+++ b/src/Configs/implementations.jl
@@ -11,14 +11,14 @@ For point configurations, extracts the initial and final times from the
 `t0` and `tf` fields.
 
 # Arguments
-- `c::AbstractPointConfig`: The point configuration.
+- `c::AbstractEndPointConfig`: The point configuration.
 
 # Returns
 - `Tuple{Real, Real}`: Time span as (t0, tf).
 
-See also: [`CTFlows.Configs.AbstractPointConfig`](@ref), [`CTFlows.Configs.tspan`](@ref).
+See also: [`CTFlows.Configs.AbstractEndPointConfig`](@ref), [`CTFlows.Configs.tspan`](@ref).
 """
-function tspan(c::AbstractPointConfig)::Tuple{Real, Real}
+function tspan(c::AbstractEndPointConfig)::Tuple{Real, Real}
     return (c.t0, c.tf)
 end
 
@@ -49,14 +49,14 @@ Return the initial time for point configurations.
 For point configurations, returns the stored `t0` field directly.
 
 # Arguments
-- `c::AbstractPointConfig`: The point configuration.
+- `c::AbstractEndPointConfig`: The point configuration.
 
 # Returns
 - `Real`: Initial time t0.
 
-See also: [`CTFlows.Configs.AbstractPointConfig`](@ref), [`CTFlows.Configs.initial_time`](@ref).
+See also: [`CTFlows.Configs.AbstractEndPointConfig`](@ref), [`CTFlows.Configs.initial_time`](@ref).
 """
-function initial_time(c::AbstractPointConfig)::Real
+function initial_time(c::AbstractEndPointConfig)::Real
     return c.t0
 end
 
@@ -87,14 +87,14 @@ Return the final time for point configurations.
 For point configurations, returns the stored `tf` field directly.
 
 # Arguments
-- `c::AbstractPointConfig`: The point configuration.
+- `c::AbstractEndPointConfig`: The point configuration.
 
 # Returns
 - `Real`: Final time tf.
 
-See also: [`CTFlows.Configs.AbstractPointConfig`](@ref), [`CTFlows.Configs.final_time`](@ref).
+See also: [`CTFlows.Configs.AbstractEndPointConfig`](@ref), [`CTFlows.Configs.final_time`](@ref).
 """
-function final_time(c::AbstractPointConfig)::Real
+function final_time(c::AbstractEndPointConfig)::Real
     return c.tf
 end
 
@@ -217,7 +217,7 @@ function initial_costate(c::AbstractStateConfig)
         "initial_costate is only defined for Hamiltonian configs";
         context = "initial_costate - requires Hamiltonian config",
         reason = "config type $(typeof(c)) does not have a costate field",
-        suggestion = "use HamiltonianPointConfig or HamiltonianTrajectoryConfig instead",
+        suggestion = "use HamiltonianEndPointConfig or HamiltonianTrajectoryConfig instead",
     ))
 end
 

--- a/src/Configs/show.jl
+++ b/src/Configs/show.jl
@@ -5,10 +5,10 @@
 """
 $(TYPEDSIGNATURES)
 
-Display the `StatePointConfig` in tree-style format.
+Display the `StateEndPointConfig` in tree-style format.
 """
-function Base.show(io::IO, c::StatePointConfig)
-    println(io, "StatePointConfig")
+function Base.show(io::IO, c::StateEndPointConfig)
+    println(io, "StateEndPointConfig")
     println(io, "  t0: ", c.t0)
     println(io, "  x0: ", c.x0)
     print(io, "  tf: ", c.tf)
@@ -17,9 +17,9 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the `StatePointConfig` in REPL format.
+Display the `StateEndPointConfig` in REPL format.
 """
-function Base.show(io::IO, ::MIME"text/plain", c::StatePointConfig)
+function Base.show(io::IO, ::MIME"text/plain", c::StateEndPointConfig)
     show(io, c)
 end
 
@@ -46,10 +46,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the `HamiltonianPointConfig` in tree-style format.
+Display the `HamiltonianEndPointConfig` in tree-style format.
 """
-function Base.show(io::IO, c::HamiltonianPointConfig)
-    println(io, "HamiltonianPointConfig")
+function Base.show(io::IO, c::HamiltonianEndPointConfig)
+    println(io, "HamiltonianEndPointConfig")
     println(io, "  t0: ", c.t0)
     println(io, "  x0: ", c.x0)
     println(io, "  p0: ", c.p0)
@@ -59,9 +59,9 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the `HamiltonianPointConfig` in REPL format.
+Display the `HamiltonianEndPointConfig` in REPL format.
 """
-function Base.show(io::IO, ::MIME"text/plain", c::HamiltonianPointConfig)
+function Base.show(io::IO, ::MIME"text/plain", c::HamiltonianEndPointConfig)
     show(io, c)
 end
 
@@ -89,10 +89,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the `AugmentedHamiltonianPointConfig` in tree-style format.
+Display the `AugmentedHamiltonianEndPointConfig` in tree-style format.
 """
-function Base.show(io::IO, c::AugmentedHamiltonianPointConfig)
-    println(io, "AugmentedHamiltonianPointConfig")
+function Base.show(io::IO, c::AugmentedHamiltonianEndPointConfig)
+    println(io, "AugmentedHamiltonianEndPointConfig")
     println(io, "  t0: ", c.t0)
     println(io, "  x0: ", c.x0)
     println(io, "  p0: ", c.p0)
@@ -103,8 +103,8 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the `AugmentedHamiltonianPointConfig` in REPL format.
+Display the `AugmentedHamiltonianEndPointConfig` in REPL format.
 """
-function Base.show(io::IO, ::MIME"text/plain", c::AugmentedHamiltonianPointConfig)
+function Base.show(io::IO, ::MIME"text/plain", c::AugmentedHamiltonianEndPointConfig)
     show(io, c)
 end

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -3,7 +3,7 @@ $(TYPEDSIGNATURES)
 
 Convenience call for `StateFlow` with point configuration.
 
-Builds a `StatePointConfig` internally and calls the flow with it.
+Builds a `StateEndPointConfig` internally and calls the flow with it.
 
 # Arguments
 - `f::StateFlow`: The state flow to integrate.
@@ -25,7 +25,7 @@ julia> flow = StateFlow(system, integrator)
 julia> sol = flow(0.0, [1.0, 0.0], 1.0)
 \`\`\`
 
-See also: [`CTFlows.Configs.StatePointConfig`](@ref), [`CTFlows.Flows.call`](@ref).
+See also: [`CTFlows.Configs.StateEndPointConfig`](@ref), [`CTFlows.Flows.call`](@ref).
 """
 function (f::AbstractStateFlow)(
     t0::Real,
@@ -34,7 +34,7 @@ function (f::AbstractStateFlow)(
     variable=Common.__variable(),
     unsafe=Common.__unsafe(),
 )
-    return _invoke_flow(f, Configs.StatePointConfig(t0, x0, tf); variable=variable, unsafe=unsafe)
+    return _invoke_flow(f, Configs.StateEndPointConfig(t0, x0, tf); variable=variable, unsafe=unsafe)
 end
 
 """
@@ -42,7 +42,7 @@ $(TYPEDSIGNATURES)
 
 Convenience call for `HamiltonianFlow` with point configuration.
 
-Builds a `HamiltonianPointConfig` internally and calls the flow with it.
+Builds a `HamiltonianEndPointConfig` internally and calls the flow with it.
 
 # Arguments
 - `f::HamiltonianFlow`: The Hamiltonian flow to integrate.
@@ -65,7 +65,7 @@ julia> flow = HamiltonianFlow(system, integrator)
 julia> sol = flow(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 \`\`\`
 
-See also: [`CTFlows.Configs.HamiltonianPointConfig`](@ref), [`CTFlows.Flows.call`](@ref).
+See also: [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref), [`CTFlows.Flows.call`](@ref).
 """
 function (f::AbstractHamiltonianFlow)(
     t0::Real,
@@ -76,7 +76,7 @@ function (f::AbstractHamiltonianFlow)(
     unsafe=Common.__unsafe(),
     variable_costate::Bool=Common.__variable_costate(),
 )
-    config = Configs.HamiltonianPointConfig(t0, x0, p0, tf)
+    config = Configs.HamiltonianEndPointConfig(t0, x0, p0, tf)
     variable_costate && return _invoke_flow_variable_costate(f, config; variable=variable, unsafe=unsafe)
     return _invoke_flow(f, config; variable=variable, unsafe=unsafe)
 end
@@ -177,7 +177,7 @@ This function dispatches to one of four specialized implementations based on:
 
 # Arguments
 - `flow::CTFlows.Flows.AbstractFlow`: The flow to solve.
-- `config::CTFlows.Configs.AbstractConfig`: The integration configuration (e.g., `StatePointConfig`, `StateTrajectoryConfig`).
+- `config::CTFlows.Configs.AbstractConfig`: The integration configuration (e.g., `StateEndPointConfig`, `StateTrajectoryConfig`).
 - `variable`: The variable parameter value (required for NonFixed systems, must be omitted for Fixed systems).
 - `unsafe`: If `true`, bypass ODE solver retcode checking; if `false`, throw `SolverFailure` on integration failure.
 
@@ -405,7 +405,7 @@ function _invoke_flow_variable_costate(
     ::Type{Traits.NoVariableCostate},
     ::Type{VT},
     flow::AbstractHamiltonianFlow,
-    config::Configs.HamiltonianPointConfig; variable, unsafe
+    config::Configs.HamiltonianEndPointConfig; variable, unsafe
 ) where {VT}
     throw(Exceptions.PreconditionError(
         "variable_costate=true is not supported on this flow";
@@ -420,33 +420,33 @@ $(TYPEDSIGNATURES)
 
 Variable costate call for flows that support it.
 
-Constructs an `AugmentedHamiltonianPointConfig` with zero initial variable costate
+Constructs an `AugmentedHamiltonianEndPointConfig` with zero initial variable costate
 and calls the flow with it.
 
 # Arguments
 - `::Type{Traits.SupportsVariableCostate}`: The capability trait.
 - `flow::AbstractHamiltonianFlow`: The Hamiltonian flow.
-- `config::Configs.HamiltonianPointConfig`: The base Hamiltonian point configuration.
+- `config::Configs.HamiltonianEndPointConfig`: The base Hamiltonian point configuration.
 - `variable`: The variable parameter value.
 - `unsafe`: If `true`, bypass ODE solver retcode checking.
 
 # Returns
 - `Tuple{AbstractVector, AbstractVector, AbstractVector}`: The augmented solution `(xf, pf, pvf)`.
 
-See also: [`CTFlows.Traits.SupportsVariableCostate`](@ref), [`CTFlows.Configs.AugmentedHamiltonianPointConfig`](@ref).
+See also: [`CTFlows.Traits.SupportsVariableCostate`](@ref), [`CTFlows.Configs.AugmentedHamiltonianEndPointConfig`](@ref).
 """
 function _invoke_flow_variable_costate(
     ::Type{Traits.SupportsVariableCostate},
     ::Type{VT},
     flow::AbstractHamiltonianFlow,
-    config::Configs.HamiltonianPointConfig; variable, unsafe
+    config::Configs.HamiltonianEndPointConfig; variable, unsafe
 ) where {VT}
     t0  = Configs.initial_time(config) 
     x0  = Configs.initial_state(config)
     p0  = Configs.initial_costate(config)
     pv0 = Common.make_coerce(variable)(zeros(eltype(x0), length(variable)))
     tf  = Configs.final_time(config)
-    config_aug = Configs.AugmentedHamiltonianPointConfig(t0, x0, p0, pv0, tf)
+    config_aug = Configs.AugmentedHamiltonianEndPointConfig(t0, x0, p0, pv0, tf)
     return _invoke_flow(flow, config_aug; variable=variable, unsafe=unsafe)
 end
 
@@ -467,7 +467,7 @@ function _invoke_flow_variable_costate(
     ::Type{Traits.SupportsVariableCostate},
     ::Type{Common.NotProvided},
     flow::AbstractHamiltonianFlow,
-    config::Configs.HamiltonianPointConfig; variable, unsafe
+    config::Configs.HamiltonianEndPointConfig; variable, unsafe
 )
     throw(Exceptions.PreconditionError(
         "variable must be provided when variable_costate=true";

--- a/src/Integrators/sciml.jl
+++ b/src/Integrators/sciml.jl
@@ -59,7 +59,7 @@ To activate the extension, load any of:
 
 # Fields
 - `options::CTSolvers.Strategies.StrategyOptions`: Validated option bundle.
-- `options_point::Dict{Symbol, Any}`: Pre-computed options for StatePointConfig.
+- `options_point::Dict{Symbol, Any}`: Pre-computed options for StateEndPointConfig.
 - `options_trajectory::Dict{Symbol, Any}`: Pre-computed options for StateTrajectoryConfig.
 """
 struct SciML{O<:CTSolvers.Strategies.StrategyOptions, OP<:Dict{Symbol, Any}, OT<:Dict{Symbol, Any}} <: AbstractSciMLIntegrator

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -8,7 +8,7 @@ $(TYPEDSIGNATURES)
 Extract the initial state from a state configuration.
 
 # Arguments
-- `config::Configs.AbstractStateConfig`: The state configuration (StatePointConfig or StateTrajectoryConfig).
+- `config::Configs.AbstractStateConfig`: The state configuration (StateEndPointConfig or StateTrajectoryConfig).
 
 # Returns
 - Initial state vector.
@@ -25,7 +25,7 @@ $(TYPEDSIGNATURES)
 Extract the initial state and costate from a Hamiltonian configuration.
 
 # Arguments
-- `config::Configs.AbstractHamiltonianConfig`: The Hamiltonian configuration (HamiltonianPointConfig or HamiltonianTrajectoryConfig).
+- `config::Configs.AbstractHamiltonianConfig`: The Hamiltonian configuration (HamiltonianEndPointConfig or HamiltonianTrajectoryConfig).
 
 # Returns
 - Tuple of (initial_state, initial_costate).
@@ -45,7 +45,7 @@ Iterates through all phases sequentially, applying jumps at switching times.
 
 # Arguments
 - `mpf`: The multi-phase flow to evaluate.
-- `config::Configs.AbstractPointConfig`: The point configuration with time span and initial conditions.
+- `config::Configs.AbstractEndPointConfig`: The point configuration with time span and initial conditions.
 - `variable`: The variable parameter value (for NonFixed systems).
 - `unsafe`: If true, bypass ODE solver retcode checking.
 
@@ -54,7 +54,7 @@ Iterates through all phases sequentially, applying jumps at switching times.
 
 See also: [`CTFlows.MultiPhase._evaluate_phase`](@ref), [`CTFlows.MultiPhase._apply_jump`](@ref).
 """
-function _evaluate_multiphase(mpf, config::Configs.AbstractPointConfig; variable, unsafe)
+function _evaluate_multiphase(mpf, config::Configs.AbstractEndPointConfig; variable, unsafe)
     t0, tf = Configs.tspan(config)
     current_state = _extract_initial_state(config)
     current_t = t0
@@ -138,7 +138,7 @@ Evaluate a single phase for a state flow with point configuration.
 - `t0`: Start time.
 - `tf`: End time.
 - `x`: Initial state.
-- `::Configs.AbstractPointConfig`: Point configuration type tag.
+- `::Configs.AbstractEndPointConfig`: Point configuration type tag.
 - `variable`: The variable parameter value (for NonFixed systems).
 - `unsafe`: If true, bypass ODE solver retcode checking.
 
@@ -147,7 +147,7 @@ Evaluate a single phase for a state flow with point configuration.
 
 See also: [`CTFlows.Flows.StateFlow`](@ref).
 """
-function _evaluate_phase(flow::Flows.StateFlow, t0, tf, x, ::Configs.AbstractPointConfig; variable, unsafe)
+function _evaluate_phase(flow::Flows.StateFlow, t0, tf, x, ::Configs.AbstractEndPointConfig; variable, unsafe)
     return flow(t0, x, tf; variable=variable, unsafe=unsafe)
 end
 
@@ -184,7 +184,7 @@ Evaluate a single phase for a Hamiltonian flow with point configuration.
 - `t0`: Start time.
 - `tf`: End time.
 - `state_tuple`: Tuple of (initial_state, initial_costate).
-- `::Configs.AbstractPointConfig`: Point configuration type tag.
+- `::Configs.AbstractEndPointConfig`: Point configuration type tag.
 - `variable`: The variable parameter value (for NonFixed systems).
 - `unsafe`: If true, bypass ODE solver retcode checking.
 
@@ -193,7 +193,7 @@ Evaluate a single phase for a Hamiltonian flow with point configuration.
 
 See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
-function _evaluate_phase(flow::Flows.HamiltonianFlow, t0, tf, state_tuple, ::Configs.AbstractPointConfig; variable, unsafe)
+function _evaluate_phase(flow::Flows.HamiltonianFlow, t0, tf, state_tuple, ::Configs.AbstractEndPointConfig; variable, unsafe)
     x, p = state_tuple
     return flow(t0, x, p, tf; variable=variable, unsafe=unsafe)
 end
@@ -452,7 +452,7 @@ $(TYPEDSIGNATURES)
 
 Convenience call for `MultiPhaseStateFlow` with point configuration.
 
-Builds a `StatePointConfig` internally and evaluates the multi-phase flow.
+Builds a `StateEndPointConfig` internally and evaluates the multi-phase flow.
 
 # Arguments
 - `mpf::MultiPhaseStateFlow`: The multi-phase state flow to evaluate.
@@ -473,7 +473,7 @@ mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf(0.0, [1.0, 0.0], 3.0)
 \`\`\`
 
-See also: [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref).
+See also: [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref).
 """
 function (mpf::MultiPhaseFlow{TD, VD, Traits.StateDynamics})(
     t0::Real,
@@ -482,7 +482,7 @@ function (mpf::MultiPhaseFlow{TD, VD, Traits.StateDynamics})(
     variable=Common.__variable(),
     unsafe=Common.__unsafe(),
 ) where {TD, VD}
-    config = Configs.StatePointConfig(t0, x0, tf)
+    config = Configs.StateEndPointConfig(t0, x0, tf)
     return _evaluate_multiphase(mpf, config; variable=variable, unsafe=unsafe)
 end
 
@@ -529,7 +529,7 @@ $(TYPEDSIGNATURES)
 
 Convenience call for `MultiPhaseHamiltonianFlow` with point configuration.
 
-Builds a `HamiltonianPointConfig` internally and evaluates the multi-phase flow.
+Builds a `HamiltonianEndPointConfig` internally and evaluates the multi-phase flow.
 
 # Arguments
 - `mpf::MultiPhaseHamiltonianFlow`: The multi-phase Hamiltonian flow to evaluate.
@@ -551,7 +551,7 @@ mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf(0.0, [1.0, 0.0], [0.5, 0.3], 3.0)
 \`\`\`
 
-See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.Configs.HamiltonianPointConfig`](@ref).
+See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref).
 """
 function (mpf::MultiPhaseFlow{TD, VD, Traits.HamiltonianDynamics})(
     t0::Real,
@@ -561,7 +561,7 @@ function (mpf::MultiPhaseFlow{TD, VD, Traits.HamiltonianDynamics})(
     variable=Common.__variable(),
     unsafe=Common.__unsafe(),
 ) where {TD, VD}
-    config = Configs.HamiltonianPointConfig(t0, x0, p0, tf)
+    config = Configs.HamiltonianEndPointConfig(t0, x0, p0, tf)
     return _evaluate_multiphase(mpf, config; variable=variable, unsafe=unsafe)
 end
 

--- a/src/Solutions/building.jl
+++ b/src/Solutions/building.jl
@@ -13,7 +13,7 @@ introduced by scalar-promotion at ODE problem construction time.
 This uses compile-time dispatch on the initial state type to avoid runtime type tests.
 
 # Arguments
-- `::Type{Traits.PointTrait}`: The point mode trait type.
+- `::Type{Traits.EndPointMode}`: The point mode trait type.
 - `::Type{Traits.StateDynamics}`: The state content trait type.
 - `initial_state::Number`: The scalar initial state.
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
@@ -21,10 +21,10 @@ This uses compile-time dispatch on the initial state type to avoid runtime type 
 # Returns
 - `Number`: The unwrapped scalar final state.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.StateDynamics`](@ref).
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.StateDynamics`](@ref).
 """
 function build_solution(
-    ::Type{Traits.PointTrait},
+    ::Type{Traits.EndPointMode},
     ::Type{Traits.StateDynamics},
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult, 
@@ -39,7 +39,7 @@ Default implementation for trajectory configs — wrap the integration result
 in a `VectorFieldSolution` for future extensibility.
 
 # Arguments
-- `::Type{Traits.TrajectoryTrait}`: The trajectory mode trait type.
+- `::Type{Traits.TrajectoryMode}`: The trajectory mode trait type.
 - `::Type{Traits.StateDynamics}`: The state content trait type.
 - `initial_state`: The initial state.
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
@@ -47,10 +47,10 @@ in a `VectorFieldSolution` for future extensibility.
 # Returns
 - `VectorFieldSolution`: The wrapped integration result.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.VectorFieldSolution`](@ref), [`CTFlows.Traits.TrajectoryTrait`](), [`CTFlows.Traits.StateDynamics`]().
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.VectorFieldSolution`](@ref), [`CTFlows.Traits.TrajectoryMode`](), [`CTFlows.Traits.StateDynamics`]().
 """
 function build_solution(
-    ::Type{Traits.TrajectoryTrait},
+    ::Type{Traits.TrajectoryMode},
     ::Type{Traits.StateDynamics},
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult, 
@@ -79,7 +79,7 @@ For Hamiltonian systems, `n_p = n_x` always, so the augmented state is `[x; p; p
 - `Tuple{AbstractVector, AbstractVector, AbstractVector}`: Tuple `(x, p, pv)`.
 
 # Notes
-- Internal helper used by `build_solution` for `AugmentedHamiltonianPointConfig`.
+- Internal helper used by `build_solution` for `AugmentedHamiltonianEndPointConfig`.
 - Assumes `n_p = n_x` invariant for Hamiltonian systems.
 """
 function _aug_split_solution(u, x0, pv0)
@@ -104,7 +104,7 @@ Returns the final state and costate as a tuple `(xf, pf)`, dispatching on the
 type of the initial state to handle scalar, vector, and matrix cases.
 
 # Arguments
-- `::Type{Traits.PointTrait}`: The point mode trait type.
+- `::Type{Traits.EndPointMode}`: The point mode trait type.
 - `::Type{Traits.HamiltonianDynamics}`: The Hamiltonian content trait type.
 - `initial_state`: The initial state (scalar, vector, or matrix).
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
@@ -115,10 +115,10 @@ type of the initial state to handle scalar, vector, and matrix cases.
   - `Tuple{AbstractVector, AbstractVector}` for vector inputs
   - `Tuple{AbstractMatrix, AbstractMatrix}` for matrix inputs
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.HamiltonianDynamics`]().
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.HamiltonianDynamics`]().
 """
 function build_solution(
-    ::Type{Traits.PointTrait},
+    ::Type{Traits.EndPointMode},
     ::Type{Traits.HamiltonianDynamics},
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult,
@@ -137,7 +137,7 @@ Build a solution for Hamiltonian trajectory configs.
 Wraps the integration result in a `HamiltonianVectorFieldSolution` for future extensibility.
 
 # Arguments
-- `::Type{Traits.TrajectoryTrait}`: The trajectory mode trait type.
+- `::Type{Traits.TrajectoryMode}`: The trajectory mode trait type.
 - `::Type{Traits.HamiltonianDynamics}`: The Hamiltonian content trait type.
 - `initial_state`: The initial state.
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
@@ -145,10 +145,10 @@ Wraps the integration result in a `HamiltonianVectorFieldSolution` for future ex
 # Returns
 - `HamiltonianVectorFieldSolution`: The wrapped integration result.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Traits.TrajectoryTrait`](), [`CTFlows.Traits.HamiltonianDynamics`]().
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Solutions.HamiltonianVectorFieldSolution`](@ref), [`CTFlows.Traits.TrajectoryMode`](), [`CTFlows.Traits.HamiltonianDynamics`]().
 """
 function build_solution(
-    ::Type{Traits.TrajectoryTrait},
+    ::Type{Traits.TrajectoryMode},
     ::Type{Traits.HamiltonianDynamics},
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult,
@@ -171,7 +171,7 @@ For Hamiltonian systems, `n_p = n_x` always, so the augmented state `[x; p; pv]`
 splits using only the state dimension `n = length(initial_state)`.
 
 # Arguments
-- `::Type{Traits.PointTrait}`: The point mode trait type.
+- `::Type{Traits.EndPointMode}`: The point mode trait type.
 - `::Type{Traits.AugmentedHamiltonianDynamics}`: The augmented Hamiltonian content trait type.
 - `initial_state`: The initial state (used to determine state dimension `n`).
 - `result::Integrators.AbstractIntegrationResult`: The integration result.
@@ -183,10 +183,10 @@ splits using only the state dimension `n = length(initial_state)`.
 - Uses `_aug_split_solution` helper to split the augmented final state.
 - Assumes `n_p = n_x` invariant for Hamiltonian systems.
 
-See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.AugmentedHamiltonianDynamics`]().
+See also: [`CTFlows.Integrators.AbstractIntegrationResult`](@ref), [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.AugmentedHamiltonianDynamics`]().
 """
 function build_solution(
-    ::Type{Traits.PointTrait},
+    ::Type{Traits.EndPointMode},
     ::Type{Traits.AugmentedHamiltonianDynamics},
     config::Configs.AbstractConfig,
     result::Integrators.AbstractIntegrationResult,

--- a/src/Traits/Traits.jl
+++ b/src/Traits/Traits.jl
@@ -7,7 +7,7 @@ This module provides the trait system used throughout CTFlows for compile-time
 dispatch on:
 - Time dependence: [`Autonomous`](@extref), [`NonAutonomous`](@extref)
 - Variable dependence: [`Fixed`](@ref), [`NonFixed`](@ref)
-- Integration mode: [`PointTrait`](@ref), [`TrajectoryTrait`](@ref)
+- Integration mode: [`EndPointMode`](@ref), [`TrajectoryMode`](@ref)
 - Dynamics type: [`StateDynamics`](@ref), [`HamiltonianDynamics`](@ref), [`AugmentedHamiltonianDynamics`](@ref)
 - Mutability: [`InPlace`](@ref), [`OutOfPlace`](@ref)
 - Automatic differentiation: [`WithAD`](@ref), [`WithoutAD`](@ref)
@@ -55,7 +55,7 @@ export AbstractModeTrait, AbstractDynamicsTrait
 export AbstractMutabilityTrait
 export AbstractADTrait
 export AbstractVariableCostateCapability
-export PointTrait, TrajectoryTrait
+export EndPointMode, TrajectoryMode
 export StateDynamics, HamiltonianDynamics, AugmentedHamiltonianDynamics
 export InPlace, OutOfPlace
 export WithAD, WithoutAD

--- a/src/Traits/abstract.jl
+++ b/src/Traits/abstract.jl
@@ -12,7 +12,7 @@ mode, content type, mutability).
 
 Traits are used as type parameters in abstract configuration types to enable
 compile-time dispatch without runtime type checks. For example, `AbstractConfig`
-uses `PointTrait` vs `TrajectoryTrait` to distinguish integration modes, and
+uses `EndPointMode` vs `TrajectoryMode` to distinguish integration modes, and
 `StateDynamics` vs `HamiltonianDynamics` to distinguish dynamics types.
 
 All concrete trait types are empty structs with no fields, making them zero-cost
@@ -29,20 +29,20 @@ Concrete trait subtypes should:
 \`\`\`julia-repl
 julia> using CTFlows.Traits
 
-julia> PointTrait <: Traits.AbstractTrait
+julia> EndPointMode <: Traits.AbstractTrait
 true
 
-julia> PointTrait <: Traits.AbstractModeTrait
+julia> EndPointMode <: Traits.AbstractModeTrait
 true
 
 julia> # Used as type parameters in configs:
-julia> StatePointConfig <: CTFlows.Configs.AbstractConfig{<:Any, PointTrait, StateDynamics}
+julia> StateEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, EndPointMode, StateDynamics}
 true
 \`\`\`
 
 # Notes
 - Traits are distinct from tags: tags mark extension implementations (e.g., `SciMLTag`),
-  while traits encode configuration semantics (e.g., `PointTrait`)
+  while traits encode configuration semantics (e.g., `EndPointMode`)
 - All trait types have zero runtime overhead (empty structs)
 - The trait pattern enables static dispatch on configuration properties
 

--- a/src/Traits/dynamics.jl
+++ b/src/Traits/dynamics.jl
@@ -18,7 +18,7 @@ julia> HamiltonianDynamics <: Traits.AbstractDynamicsTrait
 true
 
 julia> # Used in configuration type parameters:
-julia> StatePointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, StateDynamics}
+julia> StateEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, StateDynamics}
 true
 \`\`\`
 
@@ -50,7 +50,7 @@ julia> st isa Traits.AbstractDynamicsTrait
 true
 
 julia> # Used in state-only configurations:
-julia> StatePointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, StateDynamics}
+julia> StateEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, StateDynamics}
 true
 \`\`\`
 
@@ -59,7 +59,7 @@ true
 - The `initial_costate` accessor throws a `PreconditionError` for state configurations
 - This mode is suitable for standard ODE integration without adjoint variables
 
-See also: [`CTFlows.Traits.HamiltonianDynamics`](@ref), [`CTFlows.Traits.AbstractDynamicsTrait`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref).
+See also: [`CTFlows.Traits.HamiltonianDynamics`](@ref), [`CTFlows.Traits.AbstractDynamicsTrait`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref).
 """
 struct StateDynamics <: AbstractDynamicsTrait end
 
@@ -82,7 +82,7 @@ julia> ham isa Traits.AbstractDynamicsTrait
 true
 
 julia> # Used in Hamiltonian configurations:
-julia> HamiltonianPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, HamiltonianDynamics}
+julia> HamiltonianEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, <:Traits.AbstractModeTrait, HamiltonianDynamics}
 true
 \`\`\`
 
@@ -91,7 +91,7 @@ true
 - The `initial_condition` accessor returns `vcat(x0, p0)` for Hamiltonian configurations
 - This mode is suitable for optimal control problems with Pontryagin's maximum principle
 
-See also: [`CTFlows.Traits.StateDynamics`](@ref), [`CTFlows.Traits.AbstractDynamicsTrait`](@ref), [`CTFlows.Configs.HamiltonianPointConfig`](@ref).
+See also: [`CTFlows.Traits.StateDynamics`](@ref), [`CTFlows.Traits.AbstractDynamicsTrait`](@ref), [`CTFlows.Configs.HamiltonianEndPointConfig`](@ref).
 """
 struct HamiltonianDynamics <: AbstractDynamicsTrait end
 

--- a/src/Traits/mode.jl
+++ b/src/Traits/mode.jl
@@ -11,14 +11,14 @@ integration (full time evolution).
 \`\`\`julia-repl
 julia> using CTFlows.Traits
 
-julia> PointTrait <: Traits.AbstractModeTrait
+julia> EndPointMode <: Traits.AbstractModeTrait
 true
 
-julia> TrajectoryTrait <: Traits.AbstractModeTrait
+julia> TrajectoryMode <: Traits.AbstractModeTrait
 true
 
 julia> # Used in configuration type parameters:
-julia> StatePointConfig <: CTFlows.Configs.AbstractConfig{<:Any, PointTrait, <:Traits.AbstractDynamicsTrait}
+julia> StateEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, EndPointMode, <:Traits.AbstractDynamicsTrait}
 true
 \`\`\`
 
@@ -27,7 +27,7 @@ true
 - Point mode indicates integration from a single initial condition to a specific final time
 - Trajectory mode indicates integration over a continuous time interval
 
-See also: [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.TrajectoryTrait`](@ref), [`CTFlows.Configs.AbstractConfig`](@ref).
+See also: [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.TrajectoryMode`](@ref), [`CTFlows.Configs.AbstractConfig`](@ref).
 """
 abstract type AbstractModeTrait <: AbstractTrait end
 
@@ -43,14 +43,14 @@ which computes the solution at a specific final time from a single initial condi
 \`\`\`julia-repl
 julia> using CTFlows.Traits
 
-julia> pt = PointTrait()
-PointTrait()
+julia> pt = EndPointMode()
+EndPointMode()
 
 julia> pt isa Traits.AbstractModeTrait
 true
 
 julia> # Used in point-to-point configurations:
-julia> StatePointConfig <: CTFlows.Configs.AbstractConfig{<:Any, PointTrait, <:Traits.AbstractDynamicsTrait}
+julia> StateEndPointConfig <: CTFlows.Configs.AbstractConfig{<:Any, EndPointMode, <:Traits.AbstractDynamicsTrait}
 true
 \`\`\`
 
@@ -59,9 +59,9 @@ true
 - This mode is suitable for boundary value problems and shooting methods
 - The `tspan` accessor returns `(c.t0, c.tf)` for point configurations
 
-See also: [`CTFlows.Traits.TrajectoryTrait`](@ref), [`CTFlows.Traits.AbstractModeTrait`](@ref), [`CTFlows.Configs.StatePointConfig`](@ref).
+See also: [`CTFlows.Traits.TrajectoryMode`](@ref), [`CTFlows.Traits.AbstractModeTrait`](@ref), [`CTFlows.Configs.StateEndPointConfig`](@ref).
 """
-struct PointTrait <: AbstractModeTrait end
+struct EndPointMode <: AbstractModeTrait end
 
 """
 $(TYPEDEF)
@@ -75,14 +75,14 @@ which computes the full solution trajectory over a continuous time interval.
 \`\`\`julia-repl
 julia> using CTFlows.Traits
 
-julia> traj = TrajectoryTrait()
-TrajectoryTrait()
+julia> traj = TrajectoryMode()
+TrajectoryMode()
 
 julia> traj isa Traits.AbstractModeTrait
 true
 
 julia> # Used in trajectory configurations:
-julia> StateTrajectoryConfig <: CTFlows.Configs.AbstractConfig{<:Any, TrajectoryTrait, <:Traits.AbstractDynamicsTrait}
+julia> StateTrajectoryConfig <: CTFlows.Configs.AbstractConfig{<:Any, TrajectoryMode, <:Traits.AbstractDynamicsTrait}
 true
 \`\`\`
 
@@ -91,6 +91,6 @@ true
 - This mode is suitable for generating full time evolution and visualization
 - The `tspan` accessor returns `c.tspan` directly for trajectory configurations
 
-See also: [`CTFlows.Traits.PointTrait`](@ref), [`CTFlows.Traits.AbstractModeTrait`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
+See also: [`CTFlows.Traits.EndPointMode`](@ref), [`CTFlows.Traits.AbstractModeTrait`](@ref), [`CTFlows.Configs.StateTrajectoryConfig`](@ref).
 """
-struct TrajectoryTrait <: AbstractModeTrait end
+struct TrajectoryMode <: AbstractModeTrait end

--- a/test/suite/configs/test_abstract_configs.jl
+++ b/test/suite/configs/test_abstract_configs.jl
@@ -14,7 +14,7 @@ const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING :
 """
 Fake config type for testing the AbstractConfig contract.
 """
-struct FakeConfig{X0} <: Configs.AbstractConfigWithMaC{X0, Traits.PointTrait, Traits.StateDynamics}
+struct FakeConfig{X0} <: Configs.AbstractConfigWithMaC{X0, Traits.EndPointMode, Traits.StateDynamics}
     x0::X0
 end
 
@@ -47,8 +47,8 @@ function test_abstract_configs()
             end
 
             Test.@testset "Type Aliases" begin
-                Test.@testset "AbstractPointConfig is exported" begin
-                    Test.@test isdefined(Configs, :AbstractPointConfig)
+                Test.@testset "AbstractEndPointConfig is exported" begin
+                    Test.@test isdefined(Configs, :AbstractEndPointConfig)
                 end
 
                 Test.@testset "AbstractTrajectoryConfig is exported" begin
@@ -69,14 +69,14 @@ function test_abstract_configs()
             end
 
             Test.@testset "Trait Alias Hierarchy" begin
-                Test.@testset "StatePointConfig subtypes" begin
-                    Test.@test Configs.StatePointConfig <: Configs.AbstractPointConfig
-                    Test.@test Configs.StatePointConfig <: Configs.AbstractStateConfig
+                Test.@testset "StateEndPointConfig subtypes" begin
+                    Test.@test Configs.StateEndPointConfig <: Configs.AbstractEndPointConfig
+                    Test.@test Configs.StateEndPointConfig <: Configs.AbstractStateConfig
                 end
 
-                Test.@testset "HamiltonianPointConfig subtypes" begin
-                    Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractPointConfig
-                    Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractHamiltonianConfig
+                Test.@testset "HamiltonianEndPointConfig subtypes" begin
+                    Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractEndPointConfig
+                    Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractHamiltonianConfig
                 end
 
                 Test.@testset "StateTrajectoryConfig subtypes" begin
@@ -90,9 +90,9 @@ function test_abstract_configs()
                 end
 
                 Test.@testset "Negative checks" begin
-                    Test.@test !(Configs.StatePointConfig <: Configs.AbstractHamiltonianConfig)
-                    Test.@test !(Configs.HamiltonianPointConfig <: Configs.AbstractStateConfig)
-                    Test.@test !(Configs.StatePointConfig <: Configs.AbstractTrajectoryConfig)
+                    Test.@test !(Configs.StateEndPointConfig <: Configs.AbstractHamiltonianConfig)
+                    Test.@test !(Configs.HamiltonianEndPointConfig <: Configs.AbstractStateConfig)
+                    Test.@test !(Configs.StateEndPointConfig <: Configs.AbstractTrajectoryConfig)
                 end
             end
         end
@@ -103,35 +103,35 @@ function test_abstract_configs()
 
         Test.@testset "UNIT TESTS - Trait Accessors" begin
             Test.@testset "mode_trait" begin
-                Test.@testset "mode_trait for StatePointConfig" begin
-                    config = Configs.StatePointConfig(0.0, [1.0], 1.0)
-                    Test.@test Configs.mode_trait(config) === Traits.PointTrait
+                Test.@testset "mode_trait for StateEndPointConfig" begin
+                    config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
+                    Test.@test Configs.mode_trait(config) === Traits.EndPointMode
                 end
 
                 Test.@testset "mode_trait for StateTrajectoryConfig" begin
                     config = Configs.StateTrajectoryConfig((0.0, 1.0), [1.0])
-                    Test.@test Configs.mode_trait(config) === Traits.TrajectoryTrait
+                    Test.@test Configs.mode_trait(config) === Traits.TrajectoryMode
                 end
 
-                Test.@testset "mode_trait for HamiltonianPointConfig" begin
-                    config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
-                    Test.@test Configs.mode_trait(config) === Traits.PointTrait
+                Test.@testset "mode_trait for HamiltonianEndPointConfig" begin
+                    config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
+                    Test.@test Configs.mode_trait(config) === Traits.EndPointMode
                 end
 
                 Test.@testset "mode_trait for HamiltonianTrajectoryConfig" begin
                     config = Configs.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0], [0.5])
-                    Test.@test Configs.mode_trait(config) === Traits.TrajectoryTrait
+                    Test.@test Configs.mode_trait(config) === Traits.TrajectoryMode
                 end
             end
 
             Test.@testset "dynamics_trait" begin
-                Test.@testset "dynamics_trait for StatePointConfig" begin
-                    config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                Test.@testset "dynamics_trait for StateEndPointConfig" begin
+                    config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                     Test.@test Configs.dynamics_trait(config) === Traits.StateDynamics
                 end
 
-                Test.@testset "dynamics_trait for HamiltonianPointConfig" begin
-                    config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+                Test.@testset "dynamics_trait for HamiltonianEndPointConfig" begin
+                    config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
                     Test.@test Configs.dynamics_trait(config) === Traits.HamiltonianDynamics
                 end
             end

--- a/test/suite/configs/test_concrete_configs.jl
+++ b/test/suite/configs/test_concrete_configs.jl
@@ -15,9 +15,9 @@ function test_concrete_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - Concrete Type Construction" begin
-            Test.@testset "StatePointConfig construction" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
-                Test.@test config isa Configs.StatePointConfig
+            Test.@testset "StateEndPointConfig construction" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
+                Test.@test config isa Configs.StateEndPointConfig
                 Test.@test config.t0 === 0.0
                 Test.@test config.x0 == [1.0, 0.0]
                 Test.@test config.tf === 1.0
@@ -30,9 +30,9 @@ function test_concrete_configs()
                 Test.@test config.x0 == [1.0, 0.0]
             end
 
-            Test.@testset "HamiltonianPointConfig construction" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
-                Test.@test config isa Configs.HamiltonianPointConfig
+            Test.@testset "HamiltonianEndPointConfig construction" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                Test.@test config isa Configs.HamiltonianEndPointConfig
                 Test.@test config.t0 === 0.0
                 Test.@test config.x0 == [1.0, 0.0]
                 Test.@test config.p0 == [0.5, 0.3]
@@ -47,9 +47,9 @@ function test_concrete_configs()
                 Test.@test config.p0 == [0.5, 0.3]
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig construction" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
-                Test.@test config isa Configs.AugmentedHamiltonianPointConfig
+            Test.@testset "AugmentedHamiltonianEndPointConfig construction" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+                Test.@test config isa Configs.AugmentedHamiltonianEndPointConfig
                 Test.@test config.t0 === 0.0
                 Test.@test config.x0 == [1.0, 0.0]
                 Test.@test config.p0 == [0.5, 0.3]
@@ -63,14 +63,14 @@ function test_concrete_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - Concrete Type Subtype Relationships" begin
-            Test.@testset "StatePointConfig subtypes" begin
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+            Test.@testset "StateEndPointConfig subtypes" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 Test.@test config isa Configs.AbstractConfig
-                Test.@test config isa Configs.AbstractPointConfig
+                Test.@test config isa Configs.AbstractEndPointConfig
                 Test.@test config isa Configs.AbstractStateConfig
-                Test.@test Configs.StatePointConfig <: Configs.AbstractConfig
-                Test.@test Configs.StatePointConfig <: Configs.AbstractPointConfig
-                Test.@test Configs.StatePointConfig <: Configs.AbstractStateConfig
+                Test.@test Configs.StateEndPointConfig <: Configs.AbstractConfig
+                Test.@test Configs.StateEndPointConfig <: Configs.AbstractEndPointConfig
+                Test.@test Configs.StateEndPointConfig <: Configs.AbstractStateConfig
             end
 
             Test.@testset "StateTrajectoryConfig subtypes" begin
@@ -83,14 +83,14 @@ function test_concrete_configs()
                 Test.@test Configs.StateTrajectoryConfig <: Configs.AbstractStateConfig
             end
 
-            Test.@testset "HamiltonianPointConfig subtypes" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+            Test.@testset "HamiltonianEndPointConfig subtypes" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
                 Test.@test config isa Configs.AbstractConfig
-                Test.@test config isa Configs.AbstractPointConfig
+                Test.@test config isa Configs.AbstractEndPointConfig
                 Test.@test config isa Configs.AbstractHamiltonianConfig
-                Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractConfig
-                Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractPointConfig
-                Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractHamiltonianConfig
+                Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractConfig
+                Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractEndPointConfig
+                Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractHamiltonianConfig
             end
 
             Test.@testset "HamiltonianTrajectoryConfig subtypes" begin
@@ -103,43 +103,43 @@ function test_concrete_configs()
                 Test.@test Configs.HamiltonianTrajectoryConfig <: Configs.AbstractHamiltonianConfig
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig subtypes" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig subtypes" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
                 Test.@test config isa Configs.AbstractAugmentedHamiltonianConfig
-                Test.@test config isa Configs.AbstractPointConfig
-                Test.@test Configs.AugmentedHamiltonianPointConfig <: Configs.AbstractAugmentedHamiltonianConfig
-                Test.@test Configs.AugmentedHamiltonianPointConfig <: Configs.AbstractPointConfig
+                Test.@test config isa Configs.AbstractEndPointConfig
+                Test.@test Configs.AugmentedHamiltonianEndPointConfig <: Configs.AbstractAugmentedHamiltonianConfig
+                Test.@test Configs.AugmentedHamiltonianEndPointConfig <: Configs.AbstractEndPointConfig
             end
         end
 
         # ====================================================================
-        # UNIT TESTS - AugmentedHamiltonianPointConfig Specific Methods
+        # UNIT TESTS - AugmentedHamiltonianEndPointConfig Specific Methods
         # ====================================================================
 
-        Test.@testset "UNIT TESTS - AugmentedHamiltonianPointConfig Specific Methods" begin
-            Test.@testset "AugmentedHamiltonianPointConfig initial_condition" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+        Test.@testset "UNIT TESTS - AugmentedHamiltonianEndPointConfig Specific Methods" begin
+            Test.@testset "AugmentedHamiltonianEndPointConfig initial_condition" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 ic = Configs.initial_condition(config)
                 Test.@test ic == [1.0, 0.0, 0.5, 0.3, 0.0, 0.0]
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig initial_state" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig initial_state" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 Test.@test Configs.initial_state(config) == [1.0, 0.0]
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig initial_costate" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig initial_costate" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 Test.@test Configs.initial_costate(config) == [0.5, 0.3]
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig initial_variable_costate" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig initial_variable_costate" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 Test.@test Configs.initial_variable_costate(config) == [0.0, 0.0]
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig tspan" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig tspan" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 Test.@test Configs.tspan(config) == (0.0, 1.0)
             end
         end
@@ -149,8 +149,8 @@ function test_concrete_configs()
         # ====================================================================
 
         Test.@testset "TYPE STABILITY TESTS" begin
-            Test.@testset "Type Stability: AugmentedHamiltonianPointConfig getters" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+            Test.@testset "Type Stability: AugmentedHamiltonianEndPointConfig getters" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
                 Test.@test_nowarn Test.@inferred(Configs.initial_condition(config)) == [1.0, 0.0, 0.5, 0.3, 0.0, 0.0]
                 Test.@test_nowarn Test.@inferred(Configs.initial_state(config)) == [1.0, 0.0]
                 Test.@test_nowarn Test.@inferred(Configs.initial_costate(config)) == [0.5, 0.3]

--- a/test/suite/configs/test_configs_module.jl
+++ b/test/suite/configs/test_configs_module.jl
@@ -34,7 +34,7 @@ const CurrentModule = TestConfigsModule
 const EXPORTED_ABSTRACT_TYPES = (
     :AbstractConfig,
     :AbstractConfigWithMaC,
-    :AbstractPointConfig,
+    :AbstractEndPointConfig,
     :AbstractTrajectoryConfig,
     :AbstractStateConfig,
     :AbstractHamiltonianConfig,
@@ -42,11 +42,11 @@ const EXPORTED_ABSTRACT_TYPES = (
 )
 
 const EXPORTED_CONCRETE_TYPES = (
-    :StatePointConfig,
+    :StateEndPointConfig,
     :StateTrajectoryConfig,
-    :HamiltonianPointConfig,
+    :HamiltonianEndPointConfig,
     :HamiltonianTrajectoryConfig,
-    :AugmentedHamiltonianPointConfig,
+    :AugmentedHamiltonianEndPointConfig,
 )
 
 const EXPORTED_FUNCTIONS = (
@@ -147,7 +147,7 @@ function test_configs_module()
             Test.@testset "Abstract types are abstract" begin
                 Test.@test isabstracttype(Configs.AbstractConfig)
                 Test.@test isabstracttype(Configs.AbstractConfigWithMaC)
-                Test.@test isabstracttype(Configs.AbstractPointConfig)
+                Test.@test isabstracttype(Configs.AbstractEndPointConfig)
                 Test.@test isabstracttype(Configs.AbstractTrajectoryConfig)
                 Test.@test isabstracttype(Configs.AbstractStateConfig)
                 Test.@test isabstracttype(Configs.AbstractHamiltonianConfig)
@@ -155,16 +155,16 @@ function test_configs_module()
             end
 
             Test.@testset "Concrete types inherit from abstract types" begin
-                Test.@test Configs.StatePointConfig <: Configs.AbstractPointConfig
-                Test.@test Configs.StatePointConfig <: Configs.AbstractStateConfig
+                Test.@test Configs.StateEndPointConfig <: Configs.AbstractEndPointConfig
+                Test.@test Configs.StateEndPointConfig <: Configs.AbstractStateConfig
                 Test.@test Configs.StateTrajectoryConfig <: Configs.AbstractTrajectoryConfig
                 Test.@test Configs.StateTrajectoryConfig <: Configs.AbstractStateConfig
-                Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractPointConfig
-                Test.@test Configs.HamiltonianPointConfig <: Configs.AbstractHamiltonianConfig
+                Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractEndPointConfig
+                Test.@test Configs.HamiltonianEndPointConfig <: Configs.AbstractHamiltonianConfig
                 Test.@test Configs.HamiltonianTrajectoryConfig <: Configs.AbstractTrajectoryConfig
                 Test.@test Configs.HamiltonianTrajectoryConfig <: Configs.AbstractHamiltonianConfig
-                Test.@test Configs.AugmentedHamiltonianPointConfig <: Configs.AbstractPointConfig
-                Test.@test Configs.AugmentedHamiltonianPointConfig <: Configs.AbstractAugmentedHamiltonianConfig
+                Test.@test Configs.AugmentedHamiltonianEndPointConfig <: Configs.AbstractEndPointConfig
+                Test.@test Configs.AugmentedHamiltonianEndPointConfig <: Configs.AbstractAugmentedHamiltonianConfig
             end
         end
     end

--- a/test/suite/configs/test_implementations_configs.jl
+++ b/test/suite/configs/test_implementations_configs.jl
@@ -16,8 +16,8 @@ function test_implementations_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - tspan Implementations" begin
-            Test.@testset "AbstractPointConfig tspan returns tuple" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "AbstractEndPointConfig tspan returns tuple" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 ts = Configs.tspan(config)
                 Test.@test ts isa Tuple{Real, Real}
                 Test.@test ts == (0.0, 1.0)
@@ -36,8 +36,8 @@ function test_implementations_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - initial_time Implementations" begin
-            Test.@testset "AbstractPointConfig initial_time returns t0" begin
-                config = Configs.StatePointConfig(0.5, [1.0], 1.0)
+            Test.@testset "AbstractEndPointConfig initial_time returns t0" begin
+                config = Configs.StateEndPointConfig(0.5, [1.0], 1.0)
                 Test.@test Configs.initial_time(config) == 0.5
             end
 
@@ -52,8 +52,8 @@ function test_implementations_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - final_time Implementations" begin
-            Test.@testset "AbstractPointConfig final_time returns tf" begin
-                config = Configs.StatePointConfig(0.0, [1.0], 2.5)
+            Test.@testset "AbstractEndPointConfig final_time returns tf" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0], 2.5)
                 Test.@test Configs.final_time(config) == 2.5
             end
 
@@ -69,21 +69,21 @@ function test_implementations_configs()
 
         Test.@testset "UNIT TESTS - initial_condition Implementations" begin
             Test.@testset "AbstractStateConfig with scalar X0 wraps in vector" begin
-                config = Configs.StatePointConfig(0.0, 1.0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, 1.0, 1.0)
                 ic = Configs.initial_condition(config)
                 Test.@test ic isa AbstractVector
                 Test.@test ic == [1.0]
             end
 
             Test.@testset "AbstractStateConfig with vector X0 returns vector" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 ic = Configs.initial_condition(config)
                 Test.@test ic isa AbstractVector
                 Test.@test ic == [1.0, 0.0]
             end
 
             Test.@testset "AbstractHamiltonianConfig returns vcat(x0, p0)" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
                 ic = Configs.initial_condition(config)
                 Test.@test ic == [1.0, 0.0, 0.5, 0.3]
             end
@@ -95,12 +95,12 @@ function test_implementations_configs()
 
         Test.@testset "UNIT TESTS - initial_state Implementation" begin
             Test.@testset "initial_state returns x0 field" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 Test.@test Configs.initial_state(config) == [1.0, 0.0]
             end
 
-            Test.@testset "initial_state for HamiltonianPointConfig" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+            Test.@testset "initial_state for HamiltonianEndPointConfig" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
                 Test.@test Configs.initial_state(config) == [1.0, 0.0]
             end
 
@@ -121,12 +121,12 @@ function test_implementations_configs()
 
         Test.@testset "ERROR TESTS - initial_costate Implementations" begin
             Test.@testset "initial_costate throws PreconditionError for state configs" begin
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 Test.@test_throws Exceptions.PreconditionError Configs.initial_costate(config)
             end
 
             Test.@testset "PreconditionError message quality" begin
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 e = try
                     Configs.initial_costate(config)
                 catch err
@@ -138,7 +138,7 @@ function test_implementations_configs()
             end
 
             Test.@testset "initial_costate returns p0 for Hamiltonian configs" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
                 Test.@test Configs.initial_costate(config) == [0.5, 0.3]
             end
 

--- a/test/suite/configs/test_show_configs.jl
+++ b/test/suite/configs/test_show_configs.jl
@@ -14,23 +14,23 @@ function test_show_configs()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - Display Methods" begin
-            Test.@testset "StatePointConfig show methods" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "StateEndPointConfig show methods" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 io = IOBuffer()
                 show(io, config)
                 output = String(take!(io))
-                Test.@test occursin("StatePointConfig", output)
+                Test.@test occursin("StateEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("tf:", output)
             end
 
-            Test.@testset "StatePointConfig text/plain show method" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "StateEndPointConfig text/plain show method" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 io = IOBuffer()
                 show(io, MIME("text/plain"), config)
                 output = String(take!(io))
-                Test.@test occursin("StatePointConfig", output)
+                Test.@test occursin("StateEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("tf:", output)
@@ -56,24 +56,24 @@ function test_show_configs()
                 Test.@test occursin("x0:", output)
             end
 
-            Test.@testset "HamiltonianPointConfig show methods" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+            Test.@testset "HamiltonianEndPointConfig show methods" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
                 io = IOBuffer()
                 show(io, config)
                 output = String(take!(io))
-                Test.@test occursin("HamiltonianPointConfig", output)
+                Test.@test occursin("HamiltonianEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("p0:", output)
                 Test.@test occursin("tf:", output)
             end
 
-            Test.@testset "HamiltonianPointConfig text/plain show method" begin
-                config = Configs.HamiltonianPointConfig(0.0, [1.0], [0.5], 1.0)
+            Test.@testset "HamiltonianEndPointConfig text/plain show method" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
                 io = IOBuffer()
                 show(io, MIME("text/plain"), config)
                 output = String(take!(io))
-                Test.@test occursin("HamiltonianPointConfig", output)
+                Test.@test occursin("HamiltonianEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("p0:", output)
@@ -102,12 +102,12 @@ function test_show_configs()
                 Test.@test occursin("p0:", output)
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig show methods" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig show methods" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
                 io = IOBuffer()
                 show(io, config)
                 output = String(take!(io))
-                Test.@test occursin("AugmentedHamiltonianPointConfig", output)
+                Test.@test occursin("AugmentedHamiltonianEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("p0:", output)
@@ -115,12 +115,12 @@ function test_show_configs()
                 Test.@test occursin("tf:", output)
             end
 
-            Test.@testset "AugmentedHamiltonianPointConfig text/plain show method" begin
-                config = Configs.AugmentedHamiltonianPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
+            Test.@testset "AugmentedHamiltonianEndPointConfig text/plain show method" begin
+                config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0], [0.5], [0.0], 1.0)
                 io = IOBuffer()
                 show(io, MIME("text/plain"), config)
                 output = String(take!(io))
-                Test.@test occursin("AugmentedHamiltonianPointConfig", output)
+                Test.@test occursin("AugmentedHamiltonianEndPointConfig", output)
                 Test.@test occursin("t0:", output)
                 Test.@test occursin("x0:", output)
                 Test.@test occursin("p0:", output)

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system.jl
@@ -70,10 +70,10 @@ function test_flow_callables_sciml_hamiltonian_system()
     Test.@testset "Flow Callables SciML HamiltonianSystem Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # INTEGRATION TESTS - HamiltonianSystem → HamiltonianFlow HamiltonianPointConfig
+        # INTEGRATION TESTS - HamiltonianSystem → HamiltonianFlow HamiltonianEndPointConfig
         # ====================================================================
 
-        Test.@testset "HamiltonianFlow HamiltonianPointConfig" begin
+        Test.@testset "HamiltonianFlow HamiltonianEndPointConfig" begin
             Test.@testset "scalar x0, p0" begin
                 hflow = Flows.build_flow(HSYS, INTEG)
                 xf, pf = hflow(0.0, 1.0, 0.0, π/2)

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system_di.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system_di.jl
@@ -44,7 +44,7 @@ const ATOL       = 1e-5
 function test_flow_callables_sciml_hamiltonian_system_di()
     Test.@testset "Flow Callables SciML HamiltonianSystem DI Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
-        Test.@testset "HamiltonianFlow HamiltonianPointConfig" begin
+        Test.@testset "HamiltonianFlow HamiltonianEndPointConfig" begin
             Test.@testset "scalar x0, p0" begin
                 hflow = Flows.build_flow(HSYS, INTEG)
                 xf, pf = hflow(0.0, 1.0, 0.0, π/2)

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_vector_field.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_vector_field.jl
@@ -40,10 +40,10 @@ function test_flow_callables_sciml_hamiltonian_vector_field()
     Test.@testset "Flow Callables SciML HamiltonianVectorField Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # INTEGRATION TESTS - HamiltonianFlow HamiltonianPointConfig
+        # INTEGRATION TESTS - HamiltonianFlow HamiltonianEndPointConfig
         # ====================================================================
 
-        Test.@testset "HamiltonianFlow HamiltonianPointConfig" begin
+        Test.@testset "HamiltonianFlow HamiltonianEndPointConfig" begin
             Test.@testset "scalar x0, p0" begin
                 hflow = Flows.build_flow(HSYS, INTEG)
                 xf, pf = hflow(0.0, 1.0, 0.0, π/2)

--- a/test/suite/extensions/test_flow_callables_sciml_vector_field.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_vector_field.jl
@@ -36,10 +36,10 @@ function test_flow_callables_sciml_vector_field()
     Test.@testset "Flow Callables SciML VectorField Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # INTEGRATION TESTS - StateFlow StatePointConfig
+        # INTEGRATION TESTS - StateFlow StateEndPointConfig
         # ====================================================================
 
-        Test.@testset "StateFlow StatePointConfig" begin
+        Test.@testset "StateFlow StateEndPointConfig" begin
             flow = Flows.build_flow(SYS_DECAY, INTEG)
 
             Test.@testset "scalar Real x0" begin

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -206,7 +206,7 @@ function test_sciml_extension()
                     Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
 
-                config = Configs.StatePointConfig(0.0, [1.0, 2.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 2.0], 1.0)
                 integ = Integrators.SciML()
 
                 # Build ODE problem
@@ -223,7 +223,7 @@ function test_sciml_extension()
                     Data.VectorField((x, v) -> x .+ v; is_autonomous=true, is_variable=true)
                 )
 
-                config = Configs.StatePointConfig(0.0, [1.0, 2.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 2.0], 1.0)
                 integ = Integrators.SciML()
 
                 # Build ODE problem with variable
@@ -245,7 +245,7 @@ function test_sciml_extension()
                 Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
             )
 
-            config = Configs.StatePointConfig(0.0, [1.0, 2.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 2.0], 1.0)
             integ = Integrators.SciML(maxiters=1000, reltol=1e-6)
 
             # Build ODE problem
@@ -266,7 +266,7 @@ function test_sciml_extension()
                 # Create a simple ODE problem that will fail with maxiters=1
                 prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
                 integ = Integrators.SciML(maxiters=1)
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 opts = Integrators.build_options(integ, config)
 
                 # Test that solve_problem throws SolverFailure when unsafe=false
@@ -288,7 +288,7 @@ function test_sciml_extension()
                 # Create a simple ODE problem that will fail with maxiters=1
                 prob = ODEProblem((du, u, p, t) -> du .= u, [1.0], (0.0, 1.0))
                 integ = Integrators.SciML(maxiters=1)
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 opts = Integrators.build_options(integ, config)
 
                 # With unsafe=true, should not throw even with bad retcode
@@ -329,12 +329,12 @@ function test_sciml_extension()
         # ====================================================================
 
         Test.@testset "Full Workflow" begin
-            Test.@testset "StatePointConfig workflow" begin
+            Test.@testset "StateEndPointConfig workflow" begin
                 sys = Systems.VectorFieldSystem(
                     Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
 
-                config = Configs.StatePointConfig(0.0, 1.0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, 1.0, 1.0)
                 integ = Integrators.SciML(maxiters=1000, reltol=1e-6)
 
                 # Build problem
@@ -388,7 +388,7 @@ function test_sciml_extension()
                 vf  = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 u0  = [1.0, 2.0]
-                config = Configs.StatePointConfig(0.0, u0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -400,7 +400,7 @@ function test_sciml_extension()
                 vf  = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 u0  = SA[1.0, 2.0]
-                config = Configs.StatePointConfig(0.0, u0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -412,7 +412,7 @@ function test_sciml_extension()
                 vf  = Data.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 u0  = [1.0, 2.0]
-                config = Configs.StatePointConfig(0.0, u0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, u0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -424,7 +424,7 @@ function test_sciml_extension()
                 vf  = Data.VectorField((du, x) -> (du .= -x); is_autonomous=true, is_variable=false)
                 sys = Systems.VectorFieldSystem(vf)
                 u0  = SA[1.0, 2.0]
-                config = Configs.StatePointConfig(0.0, u0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, u0, 1.0)
                 prob = Test.@test_logs (:warn, r"InPlace VectorField") Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -446,7 +446,7 @@ function test_sciml_extension()
                 sys = Systems.HamiltonianVectorFieldSystem(hvf)
                 x0  = 1.0
                 p0  = 0.5
-                config = Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -460,7 +460,7 @@ function test_sciml_extension()
                 sys = Systems.HamiltonianVectorFieldSystem(hvf)
                 x0  = SA[1.0]
                 p0  = SA[0.5]
-                config = Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -474,7 +474,7 @@ function test_sciml_extension()
                 sys = Systems.HamiltonianVectorFieldSystem(hvf)
                 x0  = 1.0
                 p0  = 0.5
-                config = Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -488,7 +488,7 @@ function test_sciml_extension()
                 sys = Systems.HamiltonianVectorFieldSystem(hvf)
                 x0  = SA[1.0]
                 p0  = SA[0.5]
-                config = Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0)
                 prob = Test.@test_logs (:warn, r"InPlace HamiltonianVectorField") Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
                 result = Integrators.solve_problem(integ, prob, opts)
@@ -504,10 +504,10 @@ function test_sciml_extension()
 
         Test.@testset "Config-Dependent Options" begin
             integ = Integrators.SciML()
-            config_point = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config_point = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
             config_traj = Configs.StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
 
-            Test.@testset "auto defaults resolve correctly for StatePointConfig" begin
+            Test.@testset "auto defaults resolve correctly for StateEndPointConfig" begin
                 opts = Integrators.build_options(integ, config_point)
                 Test.@test opts[:dense] === false
                 Test.@test opts[:save_everystep] === false
@@ -547,7 +547,7 @@ function test_sciml_extension()
                 sys = Systems.VectorFieldSystem(
                     Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
                 )
-                config = Configs.StatePointConfig(0.0, [1.0], 0.5)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 0.5)
                 integ = Integrators.SciML(reltol=1e-8)
                 prob = Integrators.build_problem(integ, sys, config; variable=nothing)
                 opts = Integrators.build_options(integ, config)
@@ -563,14 +563,14 @@ function test_sciml_extension()
                 integ = Integrators.SciML(reltol=1e-8)
                 
                 # First segment: [0, 0.5]
-                config1 = Configs.StatePointConfig(0.0, [1.0], 0.5)
+                config1 = Configs.StateEndPointConfig(0.0, [1.0], 0.5)
                 prob1 = Integrators.build_problem(integ, sys, config1; variable=nothing)
                 opts1 = Integrators.build_options(integ, config1)
                 result1 = Integrators.solve_problem(integ, prob1, opts1)
                 
                 # Second segment: [0.5, 1.0]
                 xf1 = Integrators.final_state(result1)
-                config2 = Configs.StatePointConfig(0.5, xf1, 1.0)
+                config2 = Configs.StateEndPointConfig(0.5, xf1, 1.0)
                 prob2 = Integrators.build_problem(integ, sys, config2; variable=nothing)
                 opts2 = Integrators.build_options(integ, config2)
                 result2 = Integrators.solve_problem(integ, prob2, opts2)

--- a/test/suite/extensions/test_scimlbase_function_system.jl
+++ b/test/suite/extensions/test_scimlbase_function_system.jl
@@ -135,7 +135,7 @@ function test_scimlbase_function_system()
                 f = ODEFunction((du, u, p, t) -> du .= -u)
                 sys = CTFlowsSciMLFlows.SciMLFunctionSystem(f)
                 integ = Integrators.SciML()
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=2.0)
                 Test.@test prob isa SciMLBase.ODEProblem
                 Test.@test prob.p isa Common.ODEParameters
@@ -146,7 +146,7 @@ function test_scimlbase_function_system()
                 f = ODEFunction((du, u, p, t) -> du .= -p .* u)
                 sys = CTFlowsSciMLFlows.SciMLFunctionSystem(f)
                 integ = Integrators.SciML()
-                config = Configs.StatePointConfig(0.0, [1.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
                 prob = Integrators.build_problem(integ, sys, config; variable=3.5)
                 Test.@test prob.p isa Common.ODEParameters
                 Test.@test prob.p.variable == 3.5

--- a/test/suite/flows/test_abstract_flow.jl
+++ b/test/suite/flows/test_abstract_flow.jl
@@ -137,7 +137,7 @@ function test_abstract_flow()
             end
 
             Test.@testset "callable with config" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 result = flow(config)
                 Test.@test result === :fake_config_trajectory
             end

--- a/test/suite/flows/test_calling_flows.jl
+++ b/test/suite/flows/test_calling_flows.jl
@@ -107,7 +107,7 @@ function Integrators.solve_problem(integ::FakeIntegratorForCalling, prob, option
 end
 
 function Solutions.build_solution(
-    ::Type{Traits.PointTrait},
+    ::Type{Traits.EndPointMode},
     ::Type{Traits.StateDynamics},
     config::Configs.AbstractConfig,
     result::FakeIntegrationResultForCalling,
@@ -116,7 +116,7 @@ function Solutions.build_solution(
 end
 
 function Solutions.build_solution(
-    ::Type{Traits.TrajectoryTrait},
+    ::Type{Traits.TrajectoryMode},
     ::Type{Traits.StateDynamics},
     config::Configs.AbstractConfig,
     result::FakeIntegrationResultForCalling,
@@ -125,7 +125,7 @@ function Solutions.build_solution(
 end
 
 function Solutions.build_solution(
-    ::Type{Traits.PointTrait},
+    ::Type{Traits.EndPointMode},
     ::Type{Traits.HamiltonianDynamics},
     config::Configs.AbstractConfig,
     result::FakeIntegrationResultForCalling,
@@ -134,7 +134,7 @@ function Solutions.build_solution(
 end
 
 function Solutions.build_solution(
-    ::Type{Traits.TrajectoryTrait},
+    ::Type{Traits.TrajectoryMode},
     ::Type{Traits.HamiltonianDynamics},
     config::Configs.AbstractConfig,
     result::FakeIntegrationResultForCalling,
@@ -179,7 +179,7 @@ function test_calling_flows()
                 sys = FakeSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 
                 # Execute
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
@@ -189,7 +189,7 @@ function test_calling_flows()
                 Test.@test integ.build_options_called === true
                 Test.@test integ.solve_problem_called === true
                 
-                # Verify result - for StatePointConfig it unwraps the vector
+                # Verify result - for StateEndPointConfig it unwraps the vector
                 Test.@test result == :fake_flow_solution
             end
 
@@ -197,7 +197,7 @@ function test_calling_flows()
                 sys = FakeSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 
                 # Call with variable (should now raise PreconditionError for Fixed flow)
                 Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(flow, config; variable=0.5, unsafe=false)
@@ -221,7 +221,7 @@ function test_calling_flows()
                 sys = FakeSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
                 # Call with unsafe=true
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=true)
@@ -232,11 +232,11 @@ function test_calling_flows()
                 Test.@test result == :fake_flow_solution
             end
 
-            Test.@testset "call with HamiltonianPointConfig" begin
+            Test.@testset "call with HamiltonianEndPointConfig" begin
                 sys = FakeHamiltonianSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
 
@@ -270,7 +270,7 @@ function test_calling_flows()
                 sys = FakeHamiltonianSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
 
@@ -286,7 +286,7 @@ function test_calling_flows()
                 sys = FakeHamiltonianSystemWithAD(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
 
@@ -300,7 +300,7 @@ function test_calling_flows()
                 sys = FakeSystemForCalling(2)
                 integ = FakeIntegratorForCalling()
                 flow = FakeFlowForCalling(sys, integ)
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
                 result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
 
@@ -320,7 +320,7 @@ function test_calling_flows()
             sys = FakeSystemForCalling(2)
             integ = FakeIntegratorForCalling()
             flow = FakeFlowForCalling(sys, integ)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
 
@@ -334,7 +334,7 @@ function test_calling_flows()
             sys = FakeSystemForCalling(2)
             integ = FakeIntegratorForCalling()
             flow = FakeFlowForCalling(sys, integ)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(flow, config; variable=0.5, unsafe=false)
         end
@@ -343,7 +343,7 @@ function test_calling_flows()
             sys = FakeSystemNonFixed(2)
             integ = FakeIntegratorForCalling()
             flow = FakeFlowForCalling(sys, integ)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             result = Flows._invoke_flow(flow, config; variable=0.5, unsafe=false)
 
@@ -357,7 +357,7 @@ function test_calling_flows()
             sys = FakeSystemNonFixed(2)
             integ = FakeIntegratorForCalling()
             flow = FakeFlowForCalling(sys, integ)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
         end

--- a/test/suite/flows/test_flow.jl
+++ b/test/suite/flows/test_flow.jl
@@ -59,7 +59,7 @@ function Flows.integrator(flow::FakeFlow)
 end
 
 # Config-based callable - both Fixed and NonFixed require variable, unsafe
-function (flow::FakeFlow)(config::Configs.StatePointConfig; variable, unsafe)
+function (flow::FakeFlow)(config::Configs.StateEndPointConfig; variable, unsafe)
     return flow.integ.result
 end
 
@@ -184,14 +184,14 @@ function test_flow()
             integ = FakeIntegrator(:solution)
             flow = FakeFlow{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics, FixedSystem, typeof(integ)}(sys, integ)
 
-            Test.@testset "call with StatePointConfig" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "call with StateEndPointConfig" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 result = flow(config; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
-            Test.@testset "call with StatePointConfig and variable (ignored for Fixed)" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "call with StateEndPointConfig and variable (ignored for Fixed)" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 result = flow(config; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end
@@ -231,14 +231,14 @@ function test_flow()
             integ = FakeIntegrator(:solution)
             flow = FakeFlow{Traits.Autonomous, Traits.NonFixed, Traits.StateDynamics, NonFixedSystem, typeof(integ)}(sys, integ)
 
-            Test.@testset "call with StatePointConfig" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "call with StateEndPointConfig" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 result = flow(config; variable=nothing, unsafe=false)
                 Test.@test result === :solution
             end
 
-            Test.@testset "call with StatePointConfig and variable" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            Test.@testset "call with StateEndPointConfig and variable" begin
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 result = flow(config; variable=0.5, unsafe=false)
                 Test.@test result === :solution
             end

--- a/test/suite/flows/test_flow_callables.jl
+++ b/test/suite/flows/test_flow_callables.jl
@@ -53,19 +53,19 @@ function Integrators.solve_problem(integ::FakeIntegFC, prob, options::Dict{Symbo
     return FakeResultFC()
 end
 
-function Solutions.build_solution(::Type{Traits.PointTrait}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
+function Solutions.build_solution(::Type{Traits.EndPointMode}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
     return :state_point_sol
 end
 
-function Solutions.build_solution(::Type{Traits.TrajectoryTrait}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
+function Solutions.build_solution(::Type{Traits.TrajectoryMode}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
     return :state_traj_sol
 end
 
-function Solutions.build_solution(::Type{Traits.PointTrait}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
+function Solutions.build_solution(::Type{Traits.EndPointMode}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
     return :ham_point_sol
 end
 
-function Solutions.build_solution(::Type{Traits.TrajectoryTrait}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
+function Solutions.build_solution(::Type{Traits.TrajectoryMode}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::FakeResultFC)
     return :ham_traj_sol
 end
 
@@ -77,10 +77,10 @@ function test_flow_callables()
     Test.@testset "Flow Callables Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # UNIT TESTS - StateFlow (t0, x0, tf) -> StatePointConfig
+        # UNIT TESTS - StateFlow (t0, x0, tf) -> StateEndPointConfig
         # ====================================================================
 
-        Test.@testset "StateFlow (t0, x0, tf) -> StatePointConfig" begin
+        Test.@testset "StateFlow (t0, x0, tf) -> StateEndPointConfig" begin
             integ = FakeIntegFC(nothing)
             sys = FakeStateSystemFC(2)
             flow = Flows.StateFlow(sys, integ)
@@ -88,7 +88,7 @@ function test_flow_callables()
             Test.@testset "scalar x0" begin
                 x0 = 1.0
                 result = flow(0.0, x0, 1.0)
-                Test.@test integ.last_config isa Configs.StatePointConfig
+                Test.@test integ.last_config isa Configs.StateEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -98,7 +98,7 @@ function test_flow_callables()
             Test.@testset "vector x0" begin
                 x0 = [1.0, 0.0]
                 result = flow(0.0, x0, 1.0)
-                Test.@test integ.last_config isa Configs.StatePointConfig
+                Test.@test integ.last_config isa Configs.StateEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -108,7 +108,7 @@ function test_flow_callables()
             Test.@testset "SVector x0" begin
                 x0 = SA[1.0, 0.0]
                 result = flow(0.0, x0, 1.0)
-                Test.@test integ.last_config isa Configs.StatePointConfig
+                Test.@test integ.last_config isa Configs.StateEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -118,7 +118,7 @@ function test_flow_callables()
             Test.@testset "matrix x0" begin
                 x0 = [1.0 2.0; 3.0 4.0]
                 result = flow(0.0, x0, 1.0)
-                Test.@test integ.last_config isa Configs.StatePointConfig
+                Test.@test integ.last_config isa Configs.StateEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -164,10 +164,10 @@ function test_flow_callables()
         end
 
         # ====================================================================
-        # UNIT TESTS - HamiltonianFlow (t0, x0, p0, tf) -> HamiltonianPointConfig
+        # UNIT TESTS - HamiltonianFlow (t0, x0, p0, tf) -> HamiltonianEndPointConfig
         # ====================================================================
 
-        Test.@testset "HamiltonianFlow (t0, x0, p0, tf) -> HamiltonianPointConfig" begin
+        Test.@testset "HamiltonianFlow (t0, x0, p0, tf) -> HamiltonianEndPointConfig" begin
             integ = FakeIntegFC(nothing)
             sys = FakeHamSysFC(2)
             flow = Flows.HamiltonianFlow(sys, integ)
@@ -176,7 +176,7 @@ function test_flow_callables()
                 x0 = 1.0
                 p0 = 0.0
                 result = flow(0.0, x0, p0, 1.0)
-                Test.@test integ.last_config isa Configs.HamiltonianPointConfig
+                Test.@test integ.last_config isa Configs.HamiltonianEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -188,7 +188,7 @@ function test_flow_callables()
                 x0 = [1.0, 0.0]
                 p0 = [0.0, 1.0]
                 result = flow(0.0, x0, p0, 1.0)
-                Test.@test integ.last_config isa Configs.HamiltonianPointConfig
+                Test.@test integ.last_config isa Configs.HamiltonianEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0
@@ -200,7 +200,7 @@ function test_flow_callables()
                 x0 = SA[1.0, 0.0]
                 p0 = SA[0.0, 1.0]
                 result = flow(0.0, x0, p0, 1.0)
-                Test.@test integ.last_config isa Configs.HamiltonianPointConfig
+                Test.@test integ.last_config isa Configs.HamiltonianEndPointConfig
                 Test.@test integ.last_config.t0 == 0.0
                 Test.@test integ.last_config.tf == 1.0
                 Test.@test integ.last_config.x0 === x0

--- a/test/suite/flows/test_variable_costate_flows.jl
+++ b/test/suite/flows/test_variable_costate_flows.jl
@@ -124,7 +124,7 @@ function test_variable_costate_flows()
             x0 = [1.0, 2.0]  # n = 2
             p0 = [3.0, 4.0]
             pv0 = [5.0, 6.0, 7.0, 8.0]
-            config = Configs.AugmentedHamiltonianPointConfig(0, x0, p0, pv0, 1)
+            config = Configs.AugmentedHamiltonianEndPointConfig(0, x0, p0, pv0, 1)
             result = FakeIntegrationResult(u_final)
 
             xf, pf, pvf = Solutions.build_solution(

--- a/test/suite/integrators/test_abstract_integrator.jl
+++ b/test/suite/integrators/test_abstract_integrator.jl
@@ -100,7 +100,7 @@ function test_abstract_integrator()
         Test.@testset "Contract Implementation" begin
             integ = FakeIntegrator()
             sys = FakeSystem(2)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             Test.@testset "Problem building signature" begin
                 result = Integrators.build_problem(integ, sys, config; variable=nothing, cache=nothing)
@@ -113,7 +113,7 @@ function test_abstract_integrator()
             end
 
             Test.@testset "build_options signature" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 opts = Integrators.build_options(integ, config)
                 Test.@test opts isa Dict{Symbol,Any}
             end
@@ -126,7 +126,7 @@ function test_abstract_integrator()
         Test.@testset "NotImplemented Errors" begin
             integ = MinimalIntegrator()
             sys = FakeSystem(2)
-            config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+            config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
             Test.@testset "Problem building throws NotImplemented" begin
                 Test.@test_throws Exceptions.NotImplemented Integrators.build_problem(integ, sys, config; variable=nothing, cache=nothing)
@@ -137,7 +137,7 @@ function test_abstract_integrator()
             end
 
             Test.@testset "build_options throws NotImplemented" begin
-                config = Configs.StatePointConfig(0.0, [1.0, 0.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 Test.@test_throws Exceptions.NotImplemented Integrators.build_options(integ, config)
             end
 

--- a/test/suite/multiphase/test_calling_multiphase.jl
+++ b/test/suite/multiphase/test_calling_multiphase.jl
@@ -77,7 +77,7 @@ Strategies.options(integ::MockIntegrator) = Options.StrategyOptions()
 # Mock Integrator Interface Implementation
 # ==============================================================================
 
-function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractSystem, config::Configs.StatePointConfig; variable)
+function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractSystem, config::Configs.StateEndPointConfig; variable)
     x0 = Configs.initial_state(config)
     tspan = Configs.tspan(config)
     return MockODEProblem(x0, tspan)
@@ -89,7 +89,7 @@ function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractS
     return MockODEProblem(x0, tspan)
 end
 
-function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractSystem, config::Configs.HamiltonianPointConfig; variable)
+function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractSystem, config::Configs.HamiltonianEndPointConfig; variable)
     x0, p0 = Configs.initial_state(config), Configs.initial_costate(config)
     tspan = Configs.tspan(config)
     return MockODEProblem(vcat(x0, p0), tspan)
@@ -101,7 +101,7 @@ function Integrators.build_problem(integ::MockIntegrator, sys::Systems.AbstractS
     return MockODEProblem(vcat(x0, p0), tspan)
 end
 
-function Integrators.build_options(integ::MockIntegrator, config::Configs.StatePointConfig)
+function Integrators.build_options(integ::MockIntegrator, config::Configs.StateEndPointConfig)
     return Dict{Symbol, Any}()
 end
 
@@ -109,7 +109,7 @@ function Integrators.build_options(integ::MockIntegrator, config::Configs.StateT
     return Dict{Symbol, Any}()
 end
 
-function Integrators.build_options(integ::MockIntegrator, config::Configs.HamiltonianPointConfig)
+function Integrators.build_options(integ::MockIntegrator, config::Configs.HamiltonianEndPointConfig)
     return Dict{Symbol, Any}()
 end
 
@@ -148,17 +148,17 @@ function Integrators.evaluate_at(result::MockIntegrationResult, t::Real)
     end
 end
 
-function Solutions.build_solution(::Type{Traits.PointTrait}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
-    # For StatePointConfig, return the final state directly (as expected by _evaluate_phase)
+function Solutions.build_solution(::Type{Traits.EndPointMode}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
+    # For StateEndPointConfig, return the final state directly (as expected by _evaluate_phase)
     return result.u
 end
 
-function Solutions.build_solution(::Type{Traits.TrajectoryTrait}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
+function Solutions.build_solution(::Type{Traits.TrajectoryMode}, ::Type{Traits.StateDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
     # For StateTrajectoryConfig with StateFlow, return the full result
     return result
 end
 
-function Solutions.build_solution(::Type{Traits.PointTrait}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
+function Solutions.build_solution(::Type{Traits.EndPointMode}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
     # For HamiltonianFlow, return a tuple (x, p) matching _ham_split_solution behavior
     x_len = length(result.u) ÷ 2
     x_part = result.u[1:x_len]
@@ -166,7 +166,7 @@ function Solutions.build_solution(::Type{Traits.PointTrait}, ::Type{Traits.Hamil
     return (x_part, p_part)
 end
 
-function Solutions.build_solution(::Type{Traits.TrajectoryTrait}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
+function Solutions.build_solution(::Type{Traits.TrajectoryMode}, ::Type{Traits.HamiltonianDynamics}, config::Configs.AbstractConfig, result::MockIntegrationResult)
     # For HamiltonianTrajectoryConfig, return the full result
     return result
 end
@@ -198,8 +198,8 @@ function test_calling_multiphase()
             x0 = [1.0, 2.0]
             p0 = [0.5, 0.3]
 
-            Test.@testset "StatePointConfig" begin
-                config = Configs.StatePointConfig(0.0, x0, 1.0)
+            Test.@testset "StateEndPointConfig" begin
+                config = Configs.StateEndPointConfig(0.0, x0, 1.0)
                 result = MultiPhase._extract_initial_state(config)
                 Test.@test result === x0
             end
@@ -210,8 +210,8 @@ function test_calling_multiphase()
                 Test.@test result === x0
             end
 
-            Test.@testset "HamiltonianPointConfig" begin
-                config = Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0)
+            Test.@testset "HamiltonianEndPointConfig" begin
+                config = Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0)
                 result = MultiPhase._extract_initial_state(config)
                 Test.@test result === (x0, p0)
             end
@@ -348,14 +348,14 @@ function test_calling_multiphase()
             x = [1.0, 2.0]
             p = [0.5, 0.3]
 
-            Test.@testset "StateFlow with StatePointConfig" begin
+            Test.@testset "StateFlow with StateEndPointConfig" begin
                 sys = FakeStateSystem([1.0, 2.0])
                 integ = MockIntegrator(2.0)  # Multiplier of 2
                 flow = Flows.StateFlow(sys, integ)
                 t0 = 0.0
                 tf = 1.0
 
-                result = MultiPhase._evaluate_phase(flow, t0, tf, x, Configs.StatePointConfig(t0, x, tf); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_phase(flow, t0, tf, x, Configs.StateEndPointConfig(t0, x, tf); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 Test.@test result == x * 2
             end
@@ -371,14 +371,14 @@ function test_calling_multiphase()
                 Test.@test result.u == x * 2
             end
 
-            Test.@testset "HamiltonianFlow with StatePointConfig" begin
+            Test.@testset "HamiltonianFlow with StateEndPointConfig" begin
                 hsys = FakeHamiltonianSystem([1.0, 2.0])
                 integ = MockIntegrator(2.0)
                 flow = Flows.HamiltonianFlow(hsys, integ)
                 t0 = 0.0
                 tf = 1.0
 
-                result = MultiPhase._evaluate_phase(flow, t0, tf, (x, p), Configs.HamiltonianPointConfig(t0, x, p, tf); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_phase(flow, t0, tf, (x, p), Configs.HamiltonianEndPointConfig(t0, x, p, tf); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 Test.@test result[1] == x * 2
                 Test.@test result[2] == p * 2
@@ -396,7 +396,7 @@ function test_calling_multiphase()
             end
         end
 
-        Test.@testset "_evaluate_multiphase with StatePointConfig" begin
+        Test.@testset "_evaluate_multiphase with StateEndPointConfig" begin
             x0 = [1.0, 2.0]
             p0 = [0.5, 0.3]
 
@@ -407,7 +407,7 @@ function test_calling_multiphase()
                 flow2 = Flows.StateFlow(sys, integ)
                 mpf = flow1 * (0.5, flow2)
 
-                result = MultiPhase._evaluate_multiphase(mpf, Configs.StatePointConfig(0.0, x0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_multiphase(mpf, Configs.StateEndPointConfig(0.0, x0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 # Each phase multiplies by 2, so final is x0 * 2 * 2 = x0 * 4
                 Test.@test result == x0 * 4
@@ -421,7 +421,7 @@ function test_calling_multiphase()
                 jump = [0.1, 0.2]
                 mpf = flow1 * (0.5, jump, flow2)
 
-                result = MultiPhase._evaluate_multiphase(mpf, Configs.StatePointConfig(0.0, x0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_multiphase(mpf, Configs.StateEndPointConfig(0.0, x0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 # Phase 1: x0 * 2, then jump applied, then phase 2: (x0 * 2 + jump) * 2
                 expected = (x0 * 2 + jump) * 2
@@ -435,7 +435,7 @@ function test_calling_multiphase()
                 hflow2 = Flows.HamiltonianFlow(hsys, integ)
                 hmpf = hflow1 * (0.5, hflow2)
 
-                result = MultiPhase._evaluate_multiphase(hmpf, Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_multiphase(hmpf, Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 # Each phase multiplies by 2, _format_final_output returns vcat(x, p)
                 Test.@test result == vcat(x0 * 4, p0 * 4)
@@ -449,7 +449,7 @@ function test_calling_multiphase()
                 jump_p = [0.01, 0.02]
                 hmpf = hflow1 * (0.5, jump_p, hflow2)
 
-                result = MultiPhase._evaluate_multiphase(hmpf, Configs.HamiltonianPointConfig(0.0, x0, p0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
+                result = MultiPhase._evaluate_multiphase(hmpf, Configs.HamiltonianEndPointConfig(0.0, x0, p0, 1.0); variable=Common.__variable(), unsafe=Common.__unsafe())
                 
                 # Phase 1: x0*2, p0*2, then jump_p applied to p, then phase 2: x*2, (p+jump_p)*2
                 # _format_final_output returns vcat(x, p)

--- a/test/suite/solutions/test_building_solutions.jl
+++ b/test/suite/solutions/test_building_solutions.jl
@@ -32,28 +32,28 @@ function test_building_solutions()
     Test.@testset "Building Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # UNIT TESTS - build_solution for StatePointConfig
+        # UNIT TESTS - build_solution for StateEndPointConfig
         # ====================================================================
 
-        Test.@testset "build_solution - StatePointConfig" begin
+        Test.@testset "build_solution - StateEndPointConfig" begin
             Test.@testset "vector initial condition returns final state" begin
                 sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[1.0, 2.0], [0.5, 1.0]])
-                config = Configs.StatePointConfig(0.0, [1.0, 2.0], 1.0)
+                config = Configs.StateEndPointConfig(0.0, [1.0, 2.0], 1.0)
                 
                 output = Solutions.build_solution(Configs.mode_trait(config), Configs.dynamics_trait(config), config, result)
                 Test.@test output == [0.5, 1.0]
-                Test.@test typeof(config) <: Configs.StatePointConfig{Float64, <:AbstractVector, Float64}
+                Test.@test typeof(config) <: Configs.StateEndPointConfig{Float64, <:AbstractVector, Float64}
             end
 
             Test.@testset "scalar initial condition unwraps length-1 vector" begin
                 sys = Systems.VectorFieldSystem(Data.VectorField(x -> -x; is_autonomous=true, is_variable=false))
                 result = FakeIntegrationResult([[3.0], [1.5]])
-                config = Configs.StatePointConfig(0.0, 3.0, 1.0)
+                config = Configs.StateEndPointConfig(0.0, 3.0, 1.0)
                 
                 output = Solutions.build_solution(Configs.mode_trait(config), Configs.dynamics_trait(config), config, result)
                 Test.@test output == 1.5
-                Test.@test typeof(config) == Configs.StatePointConfig{Float64, Float64, Float64}
+                Test.@test typeof(config) == Configs.StateEndPointConfig{Float64, Float64, Float64}
             end
         end
 
@@ -82,20 +82,20 @@ function test_building_solutions()
         end
 
         # ====================================================================
-        # UNIT TESTS - build_solution for HamiltonianPointConfig
+        # UNIT TESTS - build_solution for HamiltonianEndPointConfig
         # ====================================================================
 
-        Test.@testset "build_solution - HamiltonianPointConfig" begin
+        Test.@testset "build_solution - HamiltonianEndPointConfig" begin
             Test.@testset "scalar initial condition returns tuple of scalars" begin
                 sys = Systems.HamiltonianVectorFieldSystem(
                     Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
                 )
                 result = FakeIntegrationResult([[1.0, 0.5], [0.5, 0.25]])
-                config = Configs.HamiltonianPointConfig(0.0, 1.0, 0.5, 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, 1.0, 0.5, 1.0)
                 
                 output = Solutions.build_solution(Configs.mode_trait(config), Configs.dynamics_trait(config), config, result)
                 Test.@test output == (0.5, 0.25)
-                Test.@test typeof(config) == Configs.HamiltonianPointConfig{Float64, Float64, Float64, Float64}
+                Test.@test typeof(config) == Configs.HamiltonianEndPointConfig{Float64, Float64, Float64, Float64}
             end
 
             Test.@testset "vector initial condition returns tuple of vectors" begin
@@ -103,11 +103,11 @@ function test_building_solutions()
                     Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
                 )
                 result = FakeIntegrationResult([[1.0, 2.0, 0.5, 0.3], [0.5, 1.0, 0.25, 0.15]])
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 2.0], [0.5, 0.3], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 2.0], [0.5, 0.3], 1.0)
                 
                 output = Solutions.build_solution(Configs.mode_trait(config), Configs.dynamics_trait(config), config, result)
                 Test.@test output == ([0.5, 1.0], [0.25, 0.15])
-                Test.@test typeof(config) <: Configs.HamiltonianPointConfig{Float64, <:AbstractVector, <:AbstractVector, Float64}
+                Test.@test typeof(config) <: Configs.HamiltonianEndPointConfig{Float64, <:AbstractVector, <:AbstractVector, Float64}
             end
 
             Test.@testset "vector initial condition uses correct dimension split" begin
@@ -117,7 +117,7 @@ function test_building_solutions()
                 )
                 # Final state has 6 elements: 3 state + 3 costate
                 result = FakeIntegrationResult([[1.0, 2.0, 3.0, 0.5, 0.6, 0.7], [0.5, 1.0, 1.5, 0.25, 0.3, 0.35]])
-                config = Configs.HamiltonianPointConfig(0.0, [1.0, 2.0, 3.0], [0.5, 0.6, 0.7], 1.0)
+                config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 2.0, 3.0], [0.5, 0.6, 0.7], 1.0)
                 
                 output = Solutions.build_solution(Configs.mode_trait(config), Configs.dynamics_trait(config), config, result)
                 # Should split into first 3 (state) and last 3 (costate)

--- a/test/suite/traits/test_mode.jl
+++ b/test/suite/traits/test_mode.jl
@@ -34,41 +34,41 @@ function test_mode()
         # ====================================================================
 
         Test.@testset "UNIT TESTS - Concrete Trait Types" begin
-            Test.@testset "PointTrait" begin
-                Test.@testset "PointTrait is exported" begin
-                    Test.@test isdefined(Traits, :PointTrait)
+            Test.@testset "EndPointMode" begin
+                Test.@testset "EndPointMode is exported" begin
+                    Test.@test isdefined(Traits, :EndPointMode)
                 end
 
-                Test.@testset "PointTrait is concrete" begin
-                    Test.@test !isabstracttype(Traits.PointTrait)
+                Test.@testset "EndPointMode is concrete" begin
+                    Test.@test !isabstracttype(Traits.EndPointMode)
                 end
 
-                Test.@testset "PointTrait instantiates" begin
-                    pt = Traits.PointTrait()
-                    Test.@test pt isa Traits.PointTrait
+                Test.@testset "EndPointMode instantiates" begin
+                    pt = Traits.EndPointMode()
+                    Test.@test pt isa Traits.EndPointMode
                 end
 
-                Test.@testset "PointTrait subtypes AbstractModeTrait" begin
-                    Test.@test Traits.PointTrait <: Traits.AbstractModeTrait
+                Test.@testset "EndPointMode subtypes AbstractModeTrait" begin
+                    Test.@test Traits.EndPointMode <: Traits.AbstractModeTrait
                 end
             end
 
-            Test.@testset "TrajectoryTrait" begin
-                Test.@testset "TrajectoryTrait is exported" begin
-                    Test.@test isdefined(Traits, :TrajectoryTrait)
+            Test.@testset "TrajectoryMode" begin
+                Test.@testset "TrajectoryMode is exported" begin
+                    Test.@test isdefined(Traits, :TrajectoryMode)
                 end
 
-                Test.@testset "TrajectoryTrait is concrete" begin
-                    Test.@test !isabstracttype(Traits.TrajectoryTrait)
+                Test.@testset "TrajectoryMode is concrete" begin
+                    Test.@test !isabstracttype(Traits.TrajectoryMode)
                 end
 
-                Test.@testset "TrajectoryTrait instantiates" begin
-                    traj = Traits.TrajectoryTrait()
-                    Test.@test traj isa Traits.TrajectoryTrait
+                Test.@testset "TrajectoryMode instantiates" begin
+                    traj = Traits.TrajectoryMode()
+                    Test.@test traj isa Traits.TrajectoryMode
                 end
 
-                Test.@testset "TrajectoryTrait subtypes AbstractModeTrait" begin
-                    Test.@test Traits.TrajectoryTrait <: Traits.AbstractModeTrait
+                Test.@testset "TrajectoryMode subtypes AbstractModeTrait" begin
+                    Test.@test Traits.TrajectoryMode <: Traits.AbstractModeTrait
                 end
             end
         end
@@ -79,8 +79,8 @@ function test_mode()
 
         Test.@testset "UNIT TESTS - Type Hierarchy" begin
             Test.@testset "All mode traits subtype AbstractTrait" begin
-                Test.@test Traits.PointTrait <: Traits.AbstractTrait
-                Test.@test Traits.TrajectoryTrait <: Traits.AbstractTrait
+                Test.@test Traits.EndPointMode <: Traits.AbstractTrait
+                Test.@test Traits.TrajectoryMode <: Traits.AbstractTrait
             end
         end
 
@@ -90,7 +90,7 @@ function test_mode()
 
         Test.@testset "Exports Verification" begin
             Test.@testset "Exported mode trait types" begin
-                for sym in (:AbstractModeTrait, :PointTrait, :TrajectoryTrait)
+                for sym in (:AbstractModeTrait, :EndPointMode, :TrajectoryMode)
                     Test.@test isdefined(Traits, sym)
                 end
             end

--- a/test/suite/traits/test_traits_module.jl
+++ b/test/suite/traits/test_traits_module.jl
@@ -46,8 +46,8 @@ const EXPORTED_ABSTRACT_TYPES = (
 )
 
 const EXPORTED_CONCRETE_TYPES = (
-    :PointTrait,
-    :TrajectoryTrait,
+    :EndPointMode,
+    :TrajectoryMode,
     :StateDynamics,
     :HamiltonianDynamics,
     :AugmentedHamiltonianDynamics,
@@ -185,8 +185,8 @@ function test_traits_module()
             end
 
             Test.@testset "Concrete types inherit from abstract types" begin
-                Test.@test Traits.PointTrait <: Traits.AbstractModeTrait
-                Test.@test Traits.TrajectoryTrait <: Traits.AbstractModeTrait
+                Test.@test Traits.EndPointMode <: Traits.AbstractModeTrait
+                Test.@test Traits.TrajectoryMode <: Traits.AbstractModeTrait
                 Test.@test Traits.StateDynamics <: Traits.AbstractDynamicsTrait
                 Test.@test Traits.HamiltonianDynamics <: Traits.AbstractDynamicsTrait
                 Test.@test Traits.AugmentedHamiltonianDynamics <: Traits.AbstractDynamicsTrait


### PR DESCRIPTION
## Summary

Pure rename — no logic changes.

### Traits (`src/Traits/`)

| Old name | New name |
|---|---|
| `PointTrait` | `EndPointMode` |
| `TrajectoryTrait` | `TrajectoryMode` |

### Config structs (`src/Configs/`)

| Old name | New name |
|---|---|
| `StatePointConfig` | `StateEndPointConfig` |
| `HamiltonianPointConfig` | `HamiltonianEndPointConfig` |
| `AugmentedHamiltonianPointConfig` | `AugmentedHamiltonianEndPointConfig` |

`StateTrajectoryConfig`, `HamiltonianTrajectoryConfig`, and `AugmentedHamiltonianTrajectoryConfig` are **unchanged** (the `Trajectory` suffix was already expressive enough).

### Propagation

All references updated consistently across:
- `src/` (Traits, Configs, Flows, Integrators, MultiPhase, Solutions, Common)
- `ext/` (SciMLFlows, SciMLIntegrator)
- `test/suite/` (all affected test files)
- `docs/` (index and integrating pages)
- `reports/` (working notes)

### Motivation

The old names (`PointTrait`, `TrajectoryTrait`) were ambiguous — "point" conflicted with geometric usage. The new names (`EndPointMode`, `TrajectoryMode`) make the semantic clearer: **endpoint** integration (single final state) vs **trajectory** integration (full time evolution).
