### PR TITLE
Build a flow from a control-free OCP (Flow(ocp::CTModels.Models.Model))

### DIFF
--- a/DUMMY.txt
+++ b/DUMMY.txt
@@ -1,0 +1,1 @@
+Dummy file for testing the branch creation and PR workflow.

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,7 @@ extend-ignore-re = [
     "_anf",
     "GODD",
     "_godd",
+    "_ANF",
 ]
 
 [files]

--- a/ext/CTFlowsSciMLIntegrator/build_and_solve.jl
+++ b/ext/CTFlowsSciMLIntegrator/build_and_solve.jl
@@ -227,11 +227,13 @@ function Integrators.build_problem(
     config::Configs.AbstractAugmentedHamiltonianConfig;
     variable,
 )
+    x0  = Configs.initial_state(config)
+    p0  = Configs.initial_costate(config)
     u0  = Configs.initial_condition(config)          # vcat(x0, p0, pv0)
     λ   = Common.ODEParameters(variable)
-    n_x = length(Configs.initial_state(config))
+    n_x = length(x0)
     n_v = length(Configs.initial_variable_costate(config))
-    f!  = Systems.build_rhs_augmented(system, n_x, n_v)
+    f!  = Systems.build_rhs_augmented(system, n_x, n_v, x0, p0)
     return ODEProblem(f!, u0, Configs.tspan(config), λ)
 end
 

--- a/reports/dev/closures_audit.md
+++ b/reports/dev/closures_audit.md
@@ -68,7 +68,7 @@ listés ci-dessous. Voir `reports/dev/closures_refactor_action_plan.md` pour le 
 
 | Site | Phase | Functor introduit | Statut |
 |---|---|---|---|
-| `src/DifferentialGeometry/lift.jl` | B/2 | `LiftedHamiltonian{F,TD,VD}` | ✅ Terminé |
+| `src/DifferentialGeometry/lift.jl` | B/2 | `LiftedHamiltonianFunction{F,TD,VD}` | ✅ Terminé |
 | `src/Solutions/hamiltonian_vector_field_solution.jl` | B/2 | `StateProjection{S}`, `CostateProjection{S}` | ✅ Terminé |
 | `ext/CTFlowsDifferentiationInterface.jl` (`h_x/h_p/h_v`) | C/3 | `WithActiveArg(h, Val(1/2/3))` | ✅ Terminé |
 | `src/DifferentialGeometry/poisson.jl` | D/4 | `PoissonBracket{TH,TG,B,TD,VD}` | ✅ Terminé |
@@ -111,7 +111,7 @@ _Lift(f, ::Type{Traits.NonAutonomous}, ::Type{Traits.NonFixed}) = (t, x, p, v) -
 | 4 | `f` | `(t, x, p, v)` |
 
 La closure retournée est wrappée dans un `Data.Hamiltonian` par l'appelant.
-Cible naturelle : un functor `LiftedHamiltonian{F, TD, VD}`.
+Cible naturelle : un functor `LiftedHamiltonianFunction{F, TD, VD}`.
 
 ---
 

--- a/reports/dev/closures_refactor_action_plan.md
+++ b/reports/dev/closures_refactor_action_plan.md
@@ -50,7 +50,7 @@ Checkpoint: `test/suite/differentiation` via MCP — vert avant de continuer.
 
 ### Phase B — Sites sans AD (risque nul)
 Steps:
-1. `src/DifferentialGeometry/lift.jl` : `LiftedHamiltonian{TF,TD,VD} <: Function` + 4 call
+1. `src/DifferentialGeometry/lift.jl` : `LiftedHamiltonianFunction{TF,TD,VD} <: Function` + 4 call
    methods ; `_Lift` renvoie le functor (annexe A.4).
 2. `src/Solutions/hamiltonian_vector_field_solution.jl` : `StateProjection`/`CostateProjection`
    (`<: Function`) ; `state`/`costate` renvoient les functors (annexe A.5).

--- a/reports/dev/closures_refactor_plan.md
+++ b/reports/dev/closures_refactor_plan.md
@@ -160,7 +160,7 @@ Le dispatch scalaire/vecteur de `_ad_result` (déjà présent) est conservé : i
 « dérivée de Lie scalaire » de « crochet de Lie vectoriel ».
 
 ### `src/DifferentialGeometry/lift.jl`
-`_Lift` (4) → `LiftedHamiltonian{F,TD,VD}` à 4 call methods. Pur algébrique (`H = p'·f(x)`),
+`_Lift` (4) → `LiftedHamiltonianFunction{F,TD,VD}` à 4 call methods. Pur algébrique (`H = p'·f(x)`),
 aucune AD, aucune closure interne.
 
 ### `src/Solutions/hamiltonian_vector_field_solution.jl`
@@ -338,19 +338,19 @@ end
 ## A.4 `src/DifferentialGeometry/lift.jl` (sans AD, le plus simple)
 
 ```julia
-struct LiftedHamiltonian{TF,TD,VD} <: Function   # <: Function : voir difficulté #7
+struct LiftedHamiltonianFunction{TF,TD,VD} <: Function   # <: Function : voir difficulté #7
     f::TF
 end
-LiftedHamiltonian(f, ::Type{TD}, ::Type{VD}) where {TD,VD} =
-    LiftedHamiltonian{typeof(f),TD,VD}(f)
+LiftedHamiltonianFunction(f, ::Type{TD}, ::Type{VD}) where {TD,VD} =
+    LiftedHamiltonianFunction{typeof(f),TD,VD}(f)
 
-(L::LiftedHamiltonian{TF,Traits.Autonomous,   Traits.Fixed})(x, p)       where {TF} = p' * L.f(x)
-(L::LiftedHamiltonian{TF,Traits.Autonomous,   Traits.NonFixed})(x, p, v) where {TF} = p' * L.f(x, v)
-(L::LiftedHamiltonian{TF,Traits.NonAutonomous,Traits.Fixed})(t, x, p)    where {TF} = p' * L.f(t, x)
-(L::LiftedHamiltonian{TF,Traits.NonAutonomous,Traits.NonFixed})(t, x, p, v) where {TF} = p' * L.f(t, x, v)
+(L::LiftedHamiltonianFunction{TF,Traits.Autonomous,   Traits.Fixed})(x, p)       where {TF} = p' * L.f(x)
+(L::LiftedHamiltonianFunction{TF,Traits.Autonomous,   Traits.NonFixed})(x, p, v) where {TF} = p' * L.f(x, v)
+(L::LiftedHamiltonianFunction{TF,Traits.NonAutonomous,Traits.Fixed})(t, x, p)    where {TF} = p' * L.f(t, x)
+(L::LiftedHamiltonianFunction{TF,Traits.NonAutonomous,Traits.NonFixed})(t, x, p, v) where {TF} = p' * L.f(t, x, v)
 
 # remplace les 4 _Lift :
-_Lift(f, ::Type{TD}, ::Type{VD}) where {TD,VD} = LiftedHamiltonian(f, TD, VD)
+_Lift(f, ::Type{TD}, ::Type{VD}) where {TD,VD} = LiftedHamiltonianFunction(f, TD, VD)
 ```
 
 `Lift(X::Data.AbstractVectorField)` continue d'appeler `Data.Hamiltonian(_Lift(...), TD, VD)` :
@@ -551,7 +551,7 @@ Le dispatch scalaire/vecteur passe de `_ad_result(::Number/::AbstractVector)` à
    Un callable struct ordinaire n'est **pas** `<:Function` ⇒ échec à la construction
    **et** non-match des call methods. **Résolution** (déjà appliquée dans les snippets
    ci-dessus) : déclarer les functors stockés dans `Data.*` comme `<: Function`
-   (`struct PoissonBracket{…} <: Function`, idem `LiftedHamiltonian`, `TimeDeriv*`). C'est
+   (`struct PoissonBracket{…} <: Function`, idem `LiftedHamiltonianFunction`, `TimeDeriv*`). C'est
    légal en Julia et **reproduit exactement** la relation de type des closures remplacées
    (toute closure est `<:Function`) — donc aucune autre signature `::Function` ailleurs
    n'est cassée. **Ne PAS** relâcher la contrainte des structs `Data.*` (plus invasif et

--- a/reports/dev/test_audit_phases1_4.md
+++ b/reports/dev/test_audit_phases1_4.md
@@ -60,17 +60,17 @@ La condition dans `@generated` est `1 ≤ Slot ≤ total`. Seul `Slot > total` e
 
 ---
 
-## Phase 2 — `LiftedHamiltonian`
+## Phase 2 — `LiftedHamiltonianFunction`
 
 **Fichier** : `test/suite/differential_geometry/test_lift_dg.jl`
 
-### T2.1 — Type concret `LiftedHamiltonian`
+### T2.1 — Type concret `LiftedHamiltonianFunction`
 ```julia
-Test.@testset "Lift() - retourne un LiftedHamiltonian" begin
+Test.@testset "Lift() - retourne un LiftedHamiltonianFunction" begin
     F(x) = [x[2], -x[1]]
     H = DifferentialGeometry.Lift(F)
-    Test.@test H isa DifferentialGeometry.LiftedHamiltonian
-    Test.@test H isa DifferentialGeometry.LiftedHamiltonian{typeof(F), Traits.Autonomous, Traits.Fixed}
+    Test.@test H isa DifferentialGeometry.LiftedHamiltonianFunction
+    Test.@test H isa DifferentialGeometry.LiftedHamiltonianFunction{typeof(F), Traits.Autonomous, Traits.Fixed}
 end
 ```
 Le test existant vérifie `H isa Function` (trop large). Le type concret paramétré est
@@ -85,7 +85,7 @@ Test.@testset "Lift() - @inferred" begin
     Test.@test_nowarn Test.@inferred H(x0, p0)
 end
 ```
-`LiftedHamiltonian` est sur le chemin chaud de `PoissonBracket`. L'inférence doit être
+`LiftedHamiltonianFunction` est sur le chemin chaud de `PoissonBracket`. L'inférence doit être
 totale pour éviter les boîtes dynamiques dans l'intégrateur.
 
 ### T2.3 — Champ `.f` préservé (pas de closure intermédiaire)
@@ -100,14 +100,14 @@ Détecte une régression où `Lift` envelopperait `F` dans une closure avant de 
 
 ### T2.4 — Functor stocké dans `Data.Hamiltonian` (path VectorField)
 ```julia
-Test.@testset "Lift() - VectorField: functor interne est LiftedHamiltonian" begin
+Test.@testset "Lift() - VectorField: functor interne est LiftedHamiltonianFunction" begin
     X = Data.VectorField(x -> [x[2], -x[1]]; is_autonomous=true, is_variable=false)
     H = DifferentialGeometry.Lift(X)
-    Test.@test H.f isa DifferentialGeometry.LiftedHamiltonian
+    Test.@test H.f isa DifferentialGeometry.LiftedHamiltonianFunction
 end
 ```
 Quand `Lift` reçoit un `VectorField`, il construit un `Data.Hamiltonian` dont le champ
-`.f` est un `LiftedHamiltonian`. Aucun test ne vérifie ça actuellement.
+`.f` est un `LiftedHamiltonianFunction`. Aucun test ne vérifie ça actuellement.
 
 ---
 
@@ -336,10 +336,10 @@ end
 | T1.2 | 1     | `test_arg_placement.jl`                     | `@inferred` slot 1 et slot 3                      |
 | T1.3 | 1     | `test_arg_placement.jl`                     | Champs `got`/`expected` de l'erreur               |
 | T1.4 | 1     | `test_arg_placement.jl`                     | Slot 0 lève bien `IncorrectArgument`              |
-| T2.1 | 2     | `test_lift_dg.jl`                           | `isa LiftedHamiltonian{F,TD,VD}`                  |
+| T2.1 | 2     | `test_lift_dg.jl`                           | `isa LiftedHamiltonianFunction{F,TD,VD}`                  |
 | T2.2 | 2     | `test_lift_dg.jl`                           | `@inferred` sur l'appel                           |
 | T2.3 | 2     | `test_lift_dg.jl`                           | `.f === F` (pas de closure intermédiaire)         |
-| T2.4 | 2     | `test_lift_dg.jl`                           | `.f isa LiftedHamiltonian` (path VectorField)     |
+| T2.4 | 2     | `test_lift_dg.jl`                           | `.f isa LiftedHamiltonianFunction` (path VectorField)     |
 | T3.1 | 3     | `test_differentiation_interface_extension.jl` | `cache.h_x/h_p isa WithActiveArg` (Fixed)       |
 | T3.2 | 3     | `test_differentiation_interface_extension.jl` | `cache.h_v isa WithActiveArg` (NonFixed)         |
 | T3.3 | 3     | `test_differentiation_interface_extension.jl` | Slot paramétrique correct dans le type           |

--- a/reports/refactor-build-problem/rhs_getter_unification.md
+++ b/reports/refactor-build-problem/rhs_getter_unification.md
@@ -1,0 +1,262 @@
+# Refactor : unification des getters RHS et simplification de `build_problem`
+
+## Contexte
+
+Ce document décrit un problème d'architecture identifié lors de l'ajout d'`OptimalControlFlowSystem`
+(PR `Flow(ocp::CTModels.Models.Model)`). L'ajout de ce nouveau système a mis en évidence une
+duplication de protocoles dans la couche Systems / SciML extension.
+
+---
+
+## Problème actuel : deux familles de getters RHS
+
+### Famille 1 — `rhs` / `rhs_oop` (sur `AbstractSystem`)
+
+Définis dans `src/Systems/abstract_system.jl:263–326` comme contrat de `AbstractSystem`.
+Implémentés **uniquement** par `VectorFieldSystem` (`src/Systems/vector_field_system.jl`).
+
+```julia
+rhs(sys::VectorFieldSystem)     → sys.rhs      # simple accesseur de champ
+rhs_oop(sys::VectorFieldSystem) → sys.rhs_oop  # idem
+```
+
+Les functors sont construits **au moment de la construction du système** (eager), stockés
+dans les champs typés `rhs::RHS` et `rhs_oop::OOPROHS` du struct.
+
+### Famille 2 — `build_rhs` / `build_oop_rhs` (sur `AbstractHamiltonianSystem`)
+
+Définis dans `src/Systems/abstract_system.jl:341–373` comme contrat de `AbstractHamiltonianSystem`.
+Implémentés par `HamiltonianSystem`, `HamiltonianVectorFieldSystem`, et désormais
+`OptimalControlFlowSystem`.
+
+```julia
+build_rhs(sys::HamiltonianSystem, x0, p0, _, _)          → HamIpRHS(...)   # lazy
+build_oop_rhs(sys::HamiltonianSystem, x0, p0, _, _)      → HamOoPRHS(...)  # lazy
+build_rhs(sys::HVFSystem, x0, p0)                        → IPHVFOoPRHS(...) # lazy
+build_rhs(sys::OptimalControlFlowSystem, _, _, _, _)     → sys.rhs_ip      # eager (accesseur)
+build_oop_rhs(sys::OptimalControlFlowSystem, _, _, _, _) → sys.rhs_oop     # eager (accesseur)
+```
+
+### Le symptôme dans `build_and_solve.jl`
+
+La dualité des familles force des overloads spécialisés dans l'extension SciML
+(`ext/CTFlowsSciMLIntegrator/build_and_solve.jl`). Actuellement il y a **5 overloads** de
+`Integrators.build_problem` :
+
+| Overload | system type | config type |
+|---|---|---|
+| 1 | `AbstractSystem` | `AbstractConfig` |
+| 2 | `HamiltonianVectorFieldSystem` | `AbstractHamiltonianConfig` |
+| 3 | `HamiltonianSystem` | `AbstractHamiltonianConfig` |
+| 4 | `HamiltonianSystem` | `AbstractAugmentedHamiltonianConfig` |
+| 5 | `OptimalControlFlowSystem` | `AbstractHamiltonianConfig` |
+| 6 | `OptimalControlFlowSystem` | `AbstractAugmentedHamiltonianConfig` |
+
+Chaque nouvel type de système oblige à écrire **deux** nouveaux overloads (non-augmenté +
+augmenté). Le corps de chaque overload est quasiment identique : extraire `x0, p0, t0,
+variable` de la config, appeler le getter, créer l'`ODEProblem`.
+
+### Cause racine
+
+La famille 2 (`build_rhs`) a été conçue pour transmettre `x0`/`p0` au getter parce que
+`HamiltonianSystem` en a besoin : il construit les fonctions de coercition
+`cx = Common.make_coerce(x0)` et `cp = Common.make_coerce(p0)` qui encodent le type concret
+du tableau initial (Vector, SVector, matrice...). Ces informations ne sont pas disponibles à
+la construction du système, seulement au moment de l'intégration.
+
+```julia
+function build_rhs(sys::HamiltonianSystem, x0, p0, _, _)
+    N  = _state_dim(x0)          # ← besoin de x0
+    cx = Common.make_coerce(x0)  # ← besoin de x0
+    cp = Common.make_coerce(p0)  # ← besoin de p0
+    return HamIpRHS(sys.h, sys.backend, N, cx, cp)
+end
+```
+
+Pour `HamiltonianVectorFieldSystem`, le même besoin existe (`x0`/`p0` pour les coercitions).
+
+En revanche, `OptimalControlFlowSystem` et `VectorFieldSystem` n'ont pas ce besoin : toute
+l'information est disponible à la construction. `OptimalControlFlowSystem` ignore les quatre
+arguments `_, _, _, _` de `build_rhs`.
+
+### La dette créée par `OptimalControlFlowSystem`
+
+L'ajout d'`OptimalControlFlowSystem` a rendu la tension visible : on a un système eager
+(functors pré-construits) qui doit quand même satisfaire l'interface `build_rhs(sys, x0, p0,
+_, _)` pour que `build_problem` l'appelle. On paie le coût des 4 arguments inutiles et d'un
+overload `build_problem` supplémentaire juste pour satisfaire la convention.
+
+---
+
+## Proposition : famille unifiée `get_ip_rhs` / `get_oop_rhs` / `get_ip_rhs_augmented`
+
+### Principe
+
+Passer la **config** entière au getter, et laisser chaque système extraire ce dont il a
+besoin. Les systèmes eager ignorent la config. Les systèmes lazy la lisent.
+
+```
+get_ip_rhs(sys, config)           → AbstractIPRHS   (non-augmenté, in-place)
+get_oop_rhs(sys, config)          → AbstractOoPRHS  (non-augmenté, out-of-place)
+get_ip_rhs_augmented(sys, config) → AbstractIPRHS   (augmenté, toujours in-place)
+```
+
+### Implémentations par système
+
+```julia
+# VectorFieldSystem — eager, ignore la config
+get_ip_rhs(sys::VectorFieldSystem, _)  = sys.rhs
+get_oop_rhs(sys::VectorFieldSystem, _) = sys.rhs_oop
+
+# OptimalControlFlowSystem — eager, ignore la config
+get_ip_rhs(sys::OptimalControlFlowSystem, _)           = sys.rhs_ip
+get_oop_rhs(sys::OptimalControlFlowSystem, _)          = sys.rhs_oop
+get_ip_rhs_augmented(sys::OptimalControlFlowSystem, _) = sys.rhs_aug
+
+# HamiltonianSystem — lazy, lit x0/p0 depuis la config
+function get_ip_rhs(sys::HamiltonianSystem, config::AbstractHamiltonianConfig)
+    x0 = Configs.initial_state(config)
+    p0 = Configs.initial_costate(config)
+    return HamIpRHS(sys.h, sys.backend, _state_dim(x0),
+                    Common.make_coerce(x0), Common.make_coerce(p0))
+end
+function get_oop_rhs(sys::HamiltonianSystem, config::AbstractHamiltonianConfig)
+    x0 = Configs.initial_state(config)
+    p0 = Configs.initial_costate(config)
+    return HamOoPRHS(sys.h, sys.backend, _state_dim(x0),
+                     Common.make_coerce(x0), Common.make_coerce(p0))
+end
+function get_ip_rhs_augmented(sys::HamiltonianSystem, config::AbstractAugmentedHamiltonianConfig)
+    n_x = length(Configs.initial_state(config))
+    n_v = length(Configs.initial_variable_costate(config))
+    return HamIpAugRHS(sys.h, sys.backend, n_x, n_v)
+end
+
+# HamiltonianVectorFieldSystem — lazy, lit x0/p0 depuis la config
+function get_ip_rhs(sys::HamiltonianVectorFieldSystem{...,OutOfPlace}, config)
+    x0, p0 = Configs.initial_state(config), Configs.initial_costate(config)
+    return IPHVFOoPRHS(sys.hvf, _state_dim(x0),
+                       Common.make_coerce(x0), Common.make_coerce(p0))
+end
+# ... variants InPlace, augmented, etc.
+```
+
+### `build_problem` simplifié
+
+Le trait `Traits.dynamics_trait(sys)` (`StateDynamics` vs `HamiltonianDynamics`) et la
+hiérarchie de config (`AbstractConfig` < `AbstractHamiltonianConfig` <
+`AbstractAugmentedHamiltonianConfig`) permettent un check de compatibilité en entrée,
+analogue à `_check_outofplace` dans `src/DifferentialGeometry/ad_types.jl` :
+
+```julia
+_check_dyn_config(::Type{Traits.StateDynamics},       ::AbstractConfig)                     = nothing
+_check_dyn_config(::Type{Traits.HamiltonianDynamics}, ::AbstractHamiltonianConfig)          = nothing
+_check_dyn_config(::Type{Traits.HamiltonianDynamics}, ::AbstractAugmentedHamiltonianConfig) = nothing
+_check_dyn_config(D, C) = throw(PreconditionError("incompatible system dynamics ($D) and config ($C)"))
+```
+
+Puis les **deux seuls overloads** nécessaires dans `build_and_solve.jl` :
+
+```julia
+# Cas non-augmenté — couvre State + Hamiltonian
+function Integrators.build_problem(
+    integ::SciML, system::AbstractSystem, config::AbstractConfig; variable,
+)
+    _check_dyn_config(Traits.dynamics_trait(system), config)
+    u0 = Configs.initial_condition(config)
+    λ  = Common.ODEParameters(variable)
+    if ismutable(u0)
+        f! = Systems.get_ip_rhs(system, config)
+        return ODEProblem(f!, u0, Configs.tspan(config), λ)
+    else
+        f = Systems.get_oop_rhs(system, config)
+        return ODEProblem(f, u0, Configs.tspan(config), λ)
+    end
+end
+
+# Cas augmenté — toujours in-place (pv0 = zeros(...) est mutable par construction)
+function Integrators.build_problem(
+    integ::SciML, system::AbstractSystem, config::AbstractAugmentedHamiltonianConfig; variable,
+)
+    _check_dyn_config(Traits.dynamics_trait(system), config)
+    u0 = Configs.initial_condition(config)
+    λ  = Common.ODEParameters(variable)
+    f! = Systems.get_ip_rhs_augmented(system, config)
+    return ODEProblem(f!, u0, Configs.tspan(config), λ)
+end
+```
+
+6 overloads → 2. Chaque nouveau type de système n'ajoute plus rien dans l'extension SciML.
+
+### Contrat abstract (dans `abstract_system.jl`)
+
+```julia
+# Stubs NotImplemented sur AbstractSystem / AbstractHamiltonianSystem
+function get_ip_rhs(system::AbstractSystem, config)
+    throw(NotImplemented(...))
+end
+function get_oop_rhs(system::AbstractSystem, config)
+    throw(NotImplemented(...))
+end
+function get_ip_rhs_augmented(system::AbstractHamiltonianSystem, config)
+    throw(NotImplemented(...))
+end
+```
+
+### Sort des anciennes méthodes
+
+| Méthode actuelle | Remplacée par | Note |
+|---|---|---|
+| `rhs(sys)` | `get_ip_rhs(sys, _)` | config ignorée pour les systèmes eager |
+| `rhs_oop(sys)` | `get_oop_rhs(sys, _)` | idem |
+| `build_rhs(sys, x0, p0, t0, v)` | `get_ip_rhs(sys, config)` | config porte x0, p0 |
+| `build_oop_rhs(sys, x0, p0, t0, v)` | `get_oop_rhs(sys, config)` | idem |
+| `build_rhs_augmented(sys, n_x, n_v, ...)` | `get_ip_rhs_augmented(sys, config)` | n_x, n_v extraits de config |
+
+Les anciens noms peuvent être gardés comme wrappers dépréciés le temps de la migration,
+ou supprimés d'un coup si aucun code externe ne les appelle directement.
+
+---
+
+## Impact sur les docstrings manquantes
+
+`build_rhs_augmented` sur `HamiltonianVectorFieldSystem` a actuellement un `# TODO: docstring`
+(`hamiltonian_vector_field_system.jl:252`). Ce refactor est l'occasion de tout documenter
+d'un coup avec le nouveau nom.
+
+---
+
+## Ce que ce refactor ne touche pas
+
+- La logique des functors eux-mêmes (`HamIpRHS`, `OCPFlowIpRHS`, etc.) — inchangés.
+- La hiérarchie `AbstractSystem` / `AbstractHamiltonianSystem` — inchangée.
+- La hiérarchie des configs — inchangée.
+- L'extension SciML StaticArrays — suit automatiquement via la même interface.
+
+---
+
+## Résumé des gains
+
+| Avant | Après |
+|---|---|
+| 2 familles de getters (`rhs`/`build_rhs`) | 1 famille (`get_ip_rhs`/`get_oop_rhs`/`get_ip_rhs_augmented`) |
+| 6 overloads `build_problem` dans l'extension | 2 |
+| Nouveau système → 2 overloads `build_problem` | Nouveau système → 0 overload `build_problem` |
+| Arguments émiettés `x0, p0, t0, variable` | Config transmise entière |
+| `OptimalControlFlowSystem` ignore 4 args `_` | Même chose, mais sémantique claire |
+
+---
+
+## Priorité et séquençage suggéré
+
+Ce refactor est indépendant des fonctionnalités en cours. Il peut s'appliquer une fois que
+l'API `Flow(ocp)` est stabilisée et les tests écrits. Suggéré comme PR autonome après la
+finalisation du PR `Flow(ocp)`.
+
+**Fichiers impactés :**
+- `src/Systems/abstract_system.jl` (contrat)
+- `src/Systems/vector_field_system.jl`
+- `src/Systems/hamiltonian_system.jl`
+- `src/Systems/hamiltonian_vector_field_system.jl`
+- `src/Systems/optimal_control_flow_system.jl`
+- `ext/CTFlowsSciMLIntegrator/build_and_solve.jl`

--- a/reports/save/closures_synthesis.md
+++ b/reports/save/closures_synthesis.md
@@ -557,7 +557,7 @@ avant de convertir les closures internes passées à `gradient`/`derivative`.
 | `IPVFOoPRHS{F,TD,VD}` | `_build_rhs_vf_oop` | 1, 2, 3 |
 | `OoPVFIpRHS{F,TD,VD,BUF}` | `_build_oop_rhs_vf_ip` | 1, 6 |
 | `IPHVFIpRHS{F,TD,VD,CX,CP}` | closure de `build_rhs` (HVF) | 7, 3 |
-| `LiftedHamiltonian{TF,TD,VD}` | 4 closures `_Lift` | 2, 8 |
+| `LiftedHamiltonianFunction{TF,TD,VD}` | 4 closures `_Lift` | 2, 8 |
 | `StateProjection{S}` | `t -> sol(t)[1]` | 1 |
 | `WithActiveArg{F,Slot}` | `h_x/h_p/h_v`, closures `y -> H(y,p)` | 4 |
 | `PoissonBracket{TH,TG,TB,TD,VD}` | 4 closures `_Poisson` + 16 closures internes | 2, 4, 8 |

--- a/src/DifferentialGeometry/DifferentialGeometry.jl
+++ b/src/DifferentialGeometry/DifferentialGeometry.jl
@@ -53,7 +53,7 @@ include("lie_macro.jl")
 
 export ad
 export Lift
-export LiftedHamiltonian
+export LiftedHamiltonianFunction
 export Poisson
 export ∂ₜ
 export @Lie

--- a/src/DifferentialGeometry/lift.jl
+++ b/src/DifferentialGeometry/lift.jl
@@ -10,21 +10,21 @@ call method is resolved at compile time — no allocation per call.
 Inherits from `Function` so that it satisfies the `F<:Function` constraint of
 `Data.Hamiltonian` and passes existing `isa Function` checks.
 """
-struct LiftedHamiltonian{F, TD, VD} <: Function
+struct LiftedHamiltonianFunction{F, TD, VD} <: Function
     f::F
 end
 
-(h::LiftedHamiltonian{F, Traits.Autonomous,    Traits.Fixed})(x, p)       where {F} = p' * h.f(x)
-(h::LiftedHamiltonian{F, Traits.Autonomous,    Traits.NonFixed})(x, p, v) where {F} = p' * h.f(x, v)
-(h::LiftedHamiltonian{F, Traits.NonAutonomous, Traits.Fixed})(t, x, p)    where {F} = p' * h.f(t, x)
-(h::LiftedHamiltonian{F, Traits.NonAutonomous, Traits.NonFixed})(t, x, p, v) where {F} = p' * h.f(t, x, v)
+(h::LiftedHamiltonianFunction{F, Traits.Autonomous,    Traits.Fixed})(x, p)       where {F} = p' * h.f(x)
+(h::LiftedHamiltonianFunction{F, Traits.Autonomous,    Traits.NonFixed})(x, p, v) where {F} = p' * h.f(x, v)
+(h::LiftedHamiltonianFunction{F, Traits.NonAutonomous, Traits.Fixed})(t, x, p)    where {F} = p' * h.f(t, x)
+(h::LiftedHamiltonianFunction{F, Traits.NonAutonomous, Traits.NonFixed})(t, x, p, v) where {F} = p' * h.f(t, x, v)
 
 """
 $(TYPEDSIGNATURES)
 
 Lift a function to a Hamiltonian via the canonical symplectic structure.
 
-Returns a [`LiftedHamiltonian`](@ref) representing `H(x, p) = p' * f(x)`. This is an
+Returns a [`LiftedHamiltonianFunction`](@ref) representing `H(x, p) = p' * f(x)`. This is an
 algebraic operation that does not use automatic differentiation.
 
 # Arguments
@@ -33,7 +33,7 @@ algebraic operation that does not use automatic differentiation.
 - `is_variable::Bool`: Whether the function depends on a variable parameter (default: from global config).
 
 # Returns
-- A [`LiftedHamiltonian`](@ref) with signature depending on TD/VD:
+- A [`LiftedHamiltonianFunction`](@ref) with signature depending on TD/VD:
   - Autonomous/Fixed: `(x, p) -> p' * f(x)`
   - NonAutonomous/Fixed: `(t, x, p) -> p' * f(t, x)`
   - Autonomous/NonFixed: `(x, p, v) -> p' * f(x, v)`
@@ -66,7 +66,7 @@ $(TYPEDSIGNATURES)
 
 Lift a function to a Hamiltonian with explicit type parameters.
 
-Returns a [`LiftedHamiltonian`](@ref) representing `H(x, p) = p' * f(x)`. This typed entry
+Returns a [`LiftedHamiltonianFunction`](@ref) representing `H(x, p) = p' * f(x)`. This typed entry
 point is used by the [`@Lie`](@ref) macro for compile-time dispatch.
 
 # Arguments
@@ -75,7 +75,7 @@ point is used by the [`@Lie`](@ref) macro for compile-time dispatch.
 - `::Type{VD}`: Variable dependence type ([`CTFlows.Traits.Fixed`](@ref) or [`CTFlows.Traits.NonFixed`](@ref)).
 
 # Returns
-- A [`LiftedHamiltonian{typeof(f), TD, VD}`](@ref).
+- A [`LiftedHamiltonianFunction{typeof(f), TD, VD}`](@ref).
 
 # Example
 ```julia
@@ -91,7 +91,7 @@ H([1.0, 2.0], [0.5, 1.0])  # Returns -1.5
 See also: [`CTFlows.DifferentialGeometry.Lift(f::Function)`](@ref), [`CTFlows.DifferentialGeometry.@Lie`](@ref)
 """
 function Lift(f::Function, ::Type{TD}, ::Type{VD}) where {TD, VD}
-    return LiftedHamiltonian{typeof(f), TD, VD}(f)
+    return LiftedHamiltonianFunction{typeof(f), TD, VD}(f)
 end
 
 """
@@ -127,7 +127,7 @@ See also: [`CTFlows.DifferentialGeometry.Lift(f::Function)`](@ref), [`CTFlows.Di
 """
 function Lift(X::Data.AbstractVectorField{TD, VD}) where {TD, VD}
     _check_not_hvf(X)   # guard from ad_types.jl
-    lh = LiftedHamiltonian{typeof(X), TD, VD}(X)
+    lh = LiftedHamiltonianFunction{typeof(X), TD, VD}(X)
     return Data.Hamiltonian(lh, TD, VD)   # typed constructor (no MD param)
 end
 
@@ -143,31 +143,31 @@ _lh_call_sig(::Type{Traits.NonAutonomous}, ::Type{Traits.NonFixed}) = "h(t, x, p
 """
 $(TYPEDSIGNATURES)
 
-Display a compact representation of a `LiftedHamiltonian` showing its traits and call signature.
+Display a compact representation of a `LiftedHamiltonianFunction` showing its traits and call signature.
 
 # Arguments
 - `io::IO`: The IO stream.
-- `h::LiftedHamiltonian`: The lifted Hamiltonian object.
+- `h::LiftedHamiltonianFunction`: The lifted Hamiltonian object.
 
 # Example
 ```julia-repl
 julia> H = Lift(x -> [x[2], -x[1]])
-LiftedHamiltonian: autonomous, fixed (no variable)
+LiftedHamiltonianFunction: autonomous, fixed (no variable)
   call: h(x, p) = p' * f(x)
 ```
 """
-function Base.show(io::IO, ::LiftedHamiltonian{F, TD, VD}) where {F, TD, VD}
-    println(io, "LiftedHamiltonian: $(Data._td_label(TD)), $(Data._vd_label(VD))")
+function Base.show(io::IO, ::LiftedHamiltonianFunction{F, TD, VD}) where {F, TD, VD}
+    println(io, "LiftedHamiltonianFunction: $(Data._td_label(TD)), $(Data._vd_label(VD))")
     print(io, "  call: ", _lh_call_sig(TD, VD))
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Display a `LiftedHamiltonian` in the REPL with the same format as `Base.show(io, h)`.
+Display a `LiftedHamiltonianFunction` in the REPL with the same format as `Base.show(io, h)`.
 
-See also: [`CTFlows.DifferentialGeometry.LiftedHamiltonian`](@ref).
+See also: [`CTFlows.DifferentialGeometry.LiftedHamiltonianFunction`](@ref).
 """
-function Base.show(io::IO, ::MIME"text/plain", h::LiftedHamiltonian{F, TD, VD}) where {F, TD, VD}
+function Base.show(io::IO, ::MIME"text/plain", h::LiftedHamiltonianFunction{F, TD, VD}) where {F, TD, VD}
     show(io, h)
 end

--- a/src/Flows/Flows.jl
+++ b/src/Flows/Flows.jl
@@ -37,6 +37,8 @@ include(joinpath(@__DIR__, "abstract_flow.jl"))
 include(joinpath(@__DIR__, "flow.jl"))
 include(joinpath(@__DIR__, "registry.jl"))
 include(joinpath(@__DIR__, "flow_routing.jl"))
+include(joinpath(@__DIR__, "ocp_model_traits.jl"))
+include(joinpath(@__DIR__, "optimal_control_flow.jl"))
 include(joinpath(@__DIR__, "building.jl"))
 include(joinpath(@__DIR__, "calling.jl"))
 
@@ -45,6 +47,7 @@ include(joinpath(@__DIR__, "calling.jl"))
 # ==============================================================================
 
 export AbstractFlow, AbstractStateFlow, AbstractHamiltonianFlow, Flow, StateFlow, HamiltonianFlow
+export OptimalControlFlow
 export system, integrator
 export build_flow
 export hamiltonian_vector_field

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -117,3 +117,43 @@ function Flow(h::Data.AbstractHamiltonian; kwargs...)
     return build_flow(sys, components.integrator)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+High-level constructor for an `OptimalControlFlow` from a control-free OCP.
+
+Builds a Hamiltonian flow directly from a `CTModels.Models.Model` with control
+dimension 0, exploiting the OCP structure: state equation ẋ = f(t,x,∅,v) is
+computed exactly (no AD), and only ṗ = −∂H/∂x uses automatic differentiation.
+
+# Arguments
+- `ocp::CTModels.Models.Model`: The optimal control problem model.
+- `kwargs...`: Keyword options passed to the backend and integrator strategies
+  (same as `Flow(h::Data.AbstractHamiltonian; kwargs...)`).
+
+# Returns
+- `OptimalControlFlow`: Wraps an inner `HamiltonianFlow` and exposes:
+  - Point eval: `f(t0, x0, p0, tf; variable, variable_costate, unsafe)`
+  - Trajectory: `f((t0,tf), x0, p0; variable)` → `CTModels.Solution`
+
+See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), [`CTFlows.Flows.Flow`](@ref).
+"""
+function Flow(ocp::CTModels.Models.Model; kwargs...)
+    routed     = _route_flow_options(kwargs)
+    components = _build_flow_components(routed)
+    h          = _ocp_hamiltonian(ocp)
+    sys        = Systems.build_system(h, components.backend)
+    inner      = build_flow(sys, components.integrator)
+    return OptimalControlFlow(inner, ocp)
+end
+
+function Flow(::CTModels.Models.Model, ::Any, args...; kwargs...)
+    throw(Exceptions.PreconditionError(
+        "Flow(ocp, …) with extra positional arguments is not supported for control-free OCPs";
+        reason     = "this OCP is control-free (EmptyControlModel); passing a control law, " *
+                     "state constraint or multiplier is not handled by this path",
+        suggestion = "call Flow(ocp; kwargs…) — the control-free flow takes no control argument",
+        context    = "Flow(ocp::CTModels.Models.Model) — control-free guard",
+    ))
+end
+

--- a/src/Flows/ocp_model_traits.jl
+++ b/src/Flows/ocp_model_traits.jl
@@ -1,0 +1,40 @@
+# =============================================================================
+# Trait contracts for CTModels.Models.Model
+#
+# TEMPORARY — will move to CTModels once the contracts are stable.
+#
+# Implements has_time_dependence_trait / time_dependence and
+# has_variable_dependence_trait / variable_dependence for CTModels.Models.Model,
+# enabling Flow(ocp) to read TD/VD at the type level without boolean inspection.
+# =============================================================================
+
+import CTModels
+
+# -----------------------------------------------------------------------------
+# Time dependence
+#
+# CTModels.Model{TD, ...} carries TD ∈ {Components.Autonomous, Components.NonAutonomous}
+# as a type parameter.  CTFlows.Traits.is_autonomous compares via:
+#   time_dependence(obj) === Models.Autonomous
+# so returning the TD type itself satisfies the contract.
+# -----------------------------------------------------------------------------
+
+Traits.has_time_dependence_trait(::CTModels.Models.Model) = true
+
+Traits.time_dependence(::CTModels.Models.Model{TD}) where {TD} = TD
+
+# -----------------------------------------------------------------------------
+# Variable dependence
+#
+# Position 5 of CTModels.Model is VariableModelType.
+# CTModels.Components.EmptyVariableModel ⟹ no optimisation variable ⟹ Traits.Fixed
+# Any other VariableModelType                                        ⟹ Traits.NonFixed
+#
+# CTFlows.Traits.Fixed / NonFixed are types; the contract compares via ===, so
+# return the type (not an instance).
+# -----------------------------------------------------------------------------
+
+Traits.has_variable_dependence_trait(::CTModels.Models.Model) = true
+
+Traits.variable_dependence(ocp::CTModels.Models.Model) =
+    CTModels.Models.is_nonvariable(ocp) ? Traits.Fixed : Traits.NonFixed

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -1,0 +1,178 @@
+# =============================================================================
+# OCPHamiltonianFunctionFunction, OptimalControlFlow, and solution builder
+# =============================================================================
+
+import CTModels
+
+# =============================================================================
+# OCPHamiltonianFunction — OCP Hamiltonian H(t,x,p,v) = p·f(t,x,∅,v) + sp0·ℓ(t,x,∅,v)
+#
+# TD/VD are compile-time parameters so dispatch selects the right natural-arity
+# method without runtime branches.  A single _ocp_H core does the work; scalar
+# inputs (x or p as Number when n_x=1) are rewrapped to 1-vectors so the always-
+# in-place CTModels dynamics receives the array it expects.
+#
+# sp0 = s·p⁰ where p⁰=-1: sp0=-1 for :min, sp0=+1 for :max.
+# =============================================================================
+
+struct OCPHamiltonianFunction{TD, VD, DF, LF} <: Function
+    dynamics!::DF
+    lagrange::LF
+    sp0::Float64
+    n::Int
+end
+
+# Aliases to keep method signatures concise
+const _CTM_Auton    = CTModels.Components.Autonomous
+const _CTM_NonAuton = CTModels.Components.NonAutonomous
+
+# Rewrap a scalar to a 1-vector; leave arrays unchanged.
+_asvec(z::Number)         = [z]
+_asvec(z::AbstractVector) = z
+
+function _ocp_H(h::OCPHamiltonianFunction, t, x, p, v)
+    xv = _asvec(x)
+    pv_arg = _asvec(p)
+    if v === nothing
+        T  = promote_type(eltype(xv), eltype(pv_arg))
+        u  = Vector{T}(undef, 0)
+        r  = Vector{T}(undef, h.n)
+        h.dynamics!(r, t, xv, u, u)
+        val = sum(pv_arg .* r)
+        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, u, u))
+    else
+        vv = _asvec(v)
+        T  = promote_type(eltype(xv), eltype(pv_arg), eltype(vv))
+        u  = Vector{T}(undef, 0)
+        r  = Vector{T}(undef, h.n)
+        h.dynamics!(r, t, xv, u, vv)
+        val = sum(pv_arg .* r)
+        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, u, vv))
+    end
+    return val
+end
+
+(h::OCPHamiltonianFunction{_CTM_Auton,    Traits.Fixed,    DF, LF})(x, p)       where {DF, LF} = _ocp_H(h, 0.0, x, p, nothing)
+(h::OCPHamiltonianFunction{_CTM_NonAuton, Traits.Fixed,    DF, LF})(t, x, p)    where {DF, LF} = _ocp_H(h, t,   x, p, nothing)
+(h::OCPHamiltonianFunction{_CTM_Auton,    Traits.NonFixed, DF, LF})(x, p, v)    where {DF, LF} = _ocp_H(h, 0.0, x, p, v)
+(h::OCPHamiltonianFunction{_CTM_NonAuton, Traits.NonFixed, DF, LF})(t, x, p, v) where {DF, LF} = _ocp_H(h, t,   x, p, v)
+
+# =============================================================================
+# _ocp_hamiltonian — builds an OCPHamiltonianFunction wrapped in Data.Hamiltonian
+# =============================================================================
+
+function _ocp_hamiltonian(ocp)
+    n    = CTModels.Models.state_dimension(ocp)
+    dyn! = CTModels.Models.dynamics(ocp)
+    sp0  = CTModels.Components.criterion(ocp) === :min ? -1.0 : 1.0   # s*p⁰, p⁰=-1
+    lag  = CTModels.Components.has_lagrange_cost(ocp) ?
+               CTModels.Components.lagrange(ocp) : nothing
+    TD   = Traits.time_dependence(ocp)       # Traits.Autonomous or NonAutonomous
+    VD   = Traits.variable_dependence(ocp)   # Traits.Fixed or Traits.NonFixed
+    h_raw = OCPHamiltonianFunction{TD, VD, typeof(dyn!), typeof(lag)}(dyn!, lag, sp0, n)
+    return Data.Hamiltonian(h_raw, TD, VD)   # typed ctor → uniform (t,x,p,v) interface for AD
+end
+
+# =============================================================================
+# OptimalControlFlow — thin AbstractFlow wrapper that carries the ocp reference
+#
+# The inner HamiltonianFlow handles all point-eval + variable_costate logic.
+# This wrapper exists solely so the trajectory call can build a CTModels.Solution.
+# =============================================================================
+
+struct OptimalControlFlow{
+    TD <: Traits.TimeDependence,
+    VD <: Traits.VariableDependence,
+    IF,
+    M,
+} <: AbstractFlow{TD, VD, Traits.HamiltonianDynamics}
+    flow::IF    # inner HamiltonianFlow
+    ocp::M
+end
+
+function OptimalControlFlow(
+    flow::Flow{TD, VD, Traits.HamiltonianDynamics},
+    ocp,
+) where {TD, VD}
+    return OptimalControlFlow{TD, VD, typeof(flow), typeof(ocp)}(flow, ocp)
+end
+
+system(F::OptimalControlFlow)     = system(F.flow)
+integrator(F::OptimalControlFlow) = integrator(F.flow)
+
+# ── point eval — pure delegation ────────────────────────────────────────────
+
+function (F::OptimalControlFlow)(
+    t0::Real, x0, p0, tf::Real;
+    variable          = Common.NotProvided(),
+    variable_costate::Bool = false,
+    unsafe::Bool           = false,
+)
+    return F.flow(t0, x0, p0, tf; variable, variable_costate, unsafe)
+end
+
+# ── trajectory call — builds a CTModels.Solution ────────────────────────────
+
+function (F::OptimalControlFlow)(
+    tspan::Tuple{<:Real, <:Real}, x0, p0;
+    variable = Common.NotProvided(),
+    unsafe::Bool = false,
+)
+    sol = F.flow(tspan, x0, p0; variable, unsafe)   # HamiltonianVectorFieldSolution
+    return _build_ocp_solution(F.ocp, sol, variable, integrator(F.flow))
+end
+
+# =============================================================================
+# Solution helpers
+# =============================================================================
+
+_variable_vector(::Common.NotProvided)  = Float64[]
+_variable_vector(v::Number)             = [Float64(v)]
+_variable_vector(v::AbstractVector)     = Float64.(v)
+
+function _ocp_objective(ocp, x, v, t0, tf, integ)
+    obj = 0.0
+    if CTModels.Components.has_mayer_cost(ocp)
+        may = CTModels.Components.mayer(ocp)
+        obj += may(x(t0), x(tf), v)
+    end
+    if CTModels.Components.has_lagrange_cost(ocp)
+        lag      = CTModels.Components.lagrange(ocp)
+        u_empty  = Float64[]
+        # Integrate ℓ̇(t) = lag(t, x(t), ∅, v) from t0 to tf.
+        # Use a 1-element Vector so SciML always has a mutable in-place buffer.
+        running  = Data.VectorField(
+            (t, ℓ_vec) -> [lag(t, x(t), u_empty, v)];
+            is_autonomous = false, is_variable = false,
+        )
+        cost_flow = build_flow(Systems.build_system(running), integ)
+        ℓ_tf      = cost_flow(t0, [0.0], tf)   # returns [ℓ(tf)]
+        obj      += ℓ_tf[1]
+    end
+    return obj
+end
+
+function _build_ocp_solution(
+    ocp,
+    sol::Solutions.HamiltonianVectorFieldSolution,
+    variable,
+    integ,
+)
+    T      = collect(Float64, Solutions.time_grid(sol))
+    x      = Solutions.state(sol)    # callable StateProjection: t -> x(t)
+    p      = Solutions.costate(sol)  # callable CostateProjection: t -> p(t)
+    t0, tf = first(T), last(T)
+    v      = _variable_vector(variable)
+    u      = _ -> Float64[]          # empty control for control-free OCP
+    obj    = _ocp_objective(ocp, x, v, t0, tf, integ)
+    return CTModels.Solutions.build_solution(
+        ocp, T, x, u, v, p;
+        objective             = obj,
+        iterations            = -1,
+        constraints_violation = -1.0,
+        message               = "Solution computed by CTFlows OCP flow",
+        status                = :nostatusmessage,
+        successful            = true,
+        control_interpolation = :linear,
+    )
+end

--- a/src/Systems/hamiltonian_rhs_functors.jl
+++ b/src/Systems/hamiltonian_rhs_functors.jl
@@ -266,19 +266,21 @@ The state vector is augmented as `[x; p; v]` where `v` is the variable costate.
 
 See also: [`CTFlows.Systems.HamIpRHS`](@ref), [`CTFlows.Systems.HamOoPRHS`](@ref).
 """
-struct HamIpAugRHS{F,TD,VD,B} <: AbstractIPHamRHS
+struct HamIpAugRHS{F,TD,VD,B,CX,CP} <: AbstractIPHamRHS
     h::Data.Hamiltonian{F,TD,VD}
     backend::B
     n_x::Int
     n_v::Int
+    cx::CX
+    cp::CP
 end
 
-function (f::HamIpAugRHS{F,TD,VD,B})(du, u, λ, t) where {F,TD,VD,B}
+function (f::HamIpAugRHS{F,TD,VD,B,CX,CP})(du, u, λ, t) where {F,TD,VD,B,CX,CP}
     v = Common.variable(λ)
     _check_aug_batch_compat(u, v)
     x, p, _ = _aug_split(u, f.n_x, f.n_v)
-    ∂x, ∂p = Differentiation.hamiltonian_gradient(f.backend, f.h, t, x, p, v)
-    ∂pv = Differentiation.variable_gradient(f.backend, f.h, t, x, p, v)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(f.backend, f.h, t, f.cx(x), f.cp(p), v)
+    ∂pv = Differentiation.variable_gradient(f.backend, f.h, t, f.cx(x), f.cp(p), v)
     _aug_assign!(du, ∂p, -∂x, -∂pv, f.n_x, f.n_v)
     return nothing
 end

--- a/src/Systems/hamiltonian_system.jl
+++ b/src/Systems/hamiltonian_system.jl
@@ -201,9 +201,11 @@ variable costate.
 
 See also: [`CTFlows.Systems.HamIpAugRHS`](@ref), [`CTFlows.Systems.build_rhs`](@ref).
 """
-function build_rhs_augmented(sys::HamiltonianSystem, n_x::Int, n_v::Int, _, _, _, _)
+function build_rhs_augmented(sys::HamiltonianSystem, n_x::Int, n_v::Int, x0, p0, _, _)
     h, backend = sys.h, sys.backend
-    return HamIpAugRHS(h, backend, n_x, n_v)
+    cx = Common.make_coerce(x0)
+    cp = Common.make_coerce(p0)
+    return HamIpAugRHS(h, backend, n_x, n_v, cx, cp)
 end
 
 # =============================================================================

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -138,19 +138,19 @@ The augmented state vector has the form `[x; p; pv]` where:
 - `n_v::Int`: Variable dimension.
 
 # Returns
-- `Tuple`: `(x, p, pv)` where each component is a view or scalar.
+- `Tuple`: `(x, p, pv)` where each component is a `@view` slice.
 
 # Notes
-- For scalar state (`n_x == 1`), returns scalars instead of views.
+- Always returns views (never scalars), consistent with `_ham_split`.
 - For matrix inputs, returns column views.
 - Used internally by [`CTFlows.Systems.HamIpAugRHS`](@ref).
 
 See also: [`CTFlows.Systems._aug_assign!`](@ref), [`CTFlows.Systems.HamIpAugRHS`](@ref).
 """
 function _aug_split(u::AbstractVector, n_x::Int, n_v::Int)
-    x   = n_x == 1 ? u[1]    : @view(u[1:n_x])
-    p   = n_x == 1 ? u[n_x+1] : @view(u[n_x+1:2*n_x])
-    pv  = @view(u[end-n_v+1:end])
+    x  = @view(u[1:n_x])
+    p  = @view(u[n_x+1:2*n_x])
+    pv = @view(u[end-n_v+1:end])
     return (x, p, pv)
 end
 _aug_split(u::AbstractMatrix, n_x::Int, n_v::Int) =
@@ -252,17 +252,17 @@ end
 # TODO: docstring
 function build_rhs_augmented(
     sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.OutOfPlace},
-    n_x::Int, n_v::Int,
+    n_x::Int, n_v::Int, x0, p0,
 ) where {F, TD, VD}
-    return IPHVFOoPAugRHS(sys.hvf, n_x, n_v)
+    return IPHVFOoPAugRHS(sys.hvf, n_x, n_v, Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 # TODO: docstring
 function build_rhs_augmented(
     sys::HamiltonianVectorFieldSystem{F, TD, VD, Traits.InPlace},
-    n_x::Int, n_v::Int,
+    n_x::Int, n_v::Int, x0, p0,
 ) where {F, TD, VD}
-    return IPHVFIpAugRHS(sys.hvf, n_x, n_v)
+    return IPHVFIpAugRHS(sys.hvf, n_x, n_v, Common.make_coerce(x0), Common.make_coerce(p0))
 end
 
 # =============================================================================

--- a/src/Systems/hvf_rhs_functors.jl
+++ b/src/Systems/hvf_rhs_functors.jl
@@ -211,16 +211,18 @@ for the augmented system (state + costate + variable costate).
 # Call signature
 `(f::IPHVFOoPAugRHS)(du, u, λ, t) -> nothing`
 """
-struct IPHVFOoPAugRHS{F,TD,VD} <: AbstractIPHVFRHS
+struct IPHVFOoPAugRHS{F,TD,VD,CX,CP} <: AbstractIPHVFRHS
     hvf::Data.HamiltonianVectorField{F,TD,VD,Traits.OutOfPlace}
     n_x::Int
     n_v::Int
+    cx::CX
+    cp::CP
 end
 
-function (f::IPHVFOoPAugRHS{F,TD,VD})(du, u, λ, t) where {F,TD,VD}
+function (f::IPHVFOoPAugRHS{F,TD,VD,CX,CP})(du, u, λ, t) where {F,TD,VD,CX,CP}
     v = Common.variable(λ)
     x, p, _ = _aug_split(u, f.n_x, f.n_v)
-    dx, dp, dpv = f.hvf(t, x, p, v; variable_costate=true)
+    dx, dp, dpv = f.hvf(t, f.cx(x), f.cp(p), v; variable_costate=true)
     _aug_assign!(du, dx, dp, dpv, f.n_x, f.n_v)
     return nothing
 end
@@ -241,18 +243,20 @@ for the augmented system (state + costate + variable costate).
 # Call signature
 `(f::IPHVFIpAugRHS)(du, u, λ, t) -> nothing`
 """
-struct IPHVFIpAugRHS{F,TD,VD} <: AbstractIPHVFRHS
+struct IPHVFIpAugRHS{F,TD,VD,CX,CP} <: AbstractIPHVFRHS
     hvf::Data.HamiltonianVectorField{F,TD,VD,Traits.InPlace}
     n_x::Int
     n_v::Int
+    cx::CX
+    cp::CP
 end
 
-function (f::IPHVFIpAugRHS{F,TD,VD})(du, u, λ, t) where {F,TD,VD}
+function (f::IPHVFIpAugRHS{F,TD,VD,CX,CP})(du, u, λ, t) where {F,TD,VD,CX,CP}
     v = Common.variable(λ)
     x, p, _ = _aug_split(u,  f.n_x, f.n_v)
     dx, dp, _ = _aug_split(du, f.n_x, f.n_v)
     dpv = similar(u[end-f.n_v+1:end])
-    f.hvf(dx, dp, t, x, p, v; dpv=dpv, variable_costate=true)
+    f.hvf(dx, dp, t, f.cx(x), f.cp(p), v; dpv=dpv, variable_costate=true)
     du[end-f.n_v+1:end] .= dpv
     return nothing
 end

--- a/test/suite/differential_geometry/test_lift_dg.jl
+++ b/test/suite/differential_geometry/test_lift_dg.jl
@@ -27,11 +27,11 @@ function test_lift_dg()
         Test.@test H_na(2.0, x0, p0) ≈ 8.0 atol=1e-10
     end
 
-    Test.@testset "Lift() - concrete type LiftedHamiltonian" verbose=VERBOSE showtiming=SHOWTIMING begin
+    Test.@testset "Lift() - concrete type LiftedHamiltonianFunction" verbose=VERBOSE showtiming=SHOWTIMING begin
         F(x) = [x[2], -x[1]]
         H = DifferentialGeometry.Lift(F)
-        Test.@test H isa DifferentialGeometry.LiftedHamiltonian
-        Test.@test H isa DifferentialGeometry.LiftedHamiltonian{typeof(F), Traits.Autonomous, Traits.Fixed}
+        Test.@test H isa DifferentialGeometry.LiftedHamiltonianFunction
+        Test.@test H isa DifferentialGeometry.LiftedHamiltonianFunction{typeof(F), Traits.Autonomous, Traits.Fixed}
     end
 
     Test.@testset "Lift() - @inferred type-stability" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -63,8 +63,8 @@ function test_lift_dg()
         Test.@test H isa Data.Hamiltonian
         Test.@test H isa Data.AbstractHamiltonian{Traits.Autonomous, Traits.Fixed}
 
-        # Check that internal functor is LiftedHamiltonian
-        Test.@test H.f isa DifferentialGeometry.LiftedHamiltonian
+        # Check that internal functor is LiftedHamiltonianFunction
+        Test.@test H.f isa DifferentialGeometry.LiftedHamiltonianFunction
 
         # Check correctness
         x0 = [1.0, 2.0]; p0 = [3.0, 4.0]

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -1,0 +1,374 @@
+"""
+End-to-end integration and error tests for Flow(ocp::CTModels.Models.Model).
+
+Requires SciML + DI extensions (loaded via `using OrdinaryDiffEqTsit5` etc.).
+
+Analytical references (ẋ = λx, λ=2, autonomous, fixed):
+  x(t) = x0·e^{λ(t-t0)},   p(t) = p0·e^{-λ(t-t0)}
+  pv(tf) = -p0·x0·(tf-t0)   (Lagrange-free variable costate, 1D)
+  Lagrange ℓ=x²:  objective = x0²·(e^{2λT}-1)/(2λ)
+  Mayer   m=xf:   objective = x0·e^{λT}
+  Bolza        :   both summed
+
+Non-autonomous reference (ẋ=t·x, autonomous=false, fixed):
+  x(t) = x0·exp((t²-t0²)/2)
+"""
+
+module TestOptimalControlFlow
+
+import Test
+import CTModels
+import CTBase.Exceptions: Exceptions
+import CTFlows: CTFlows
+import CTFlows.Flows: Flows
+import CTFlows.Systems: Systems
+import CTFlows.Integrators: Integrators
+import CTFlows.Differentiation: Differentiation
+import CTFlows.Data: Data
+import CTFlows.Traits: Traits
+
+using SciMLBase: SciMLBase
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
+using ADTypes: ADTypes
+using DifferentiationInterface: DifferentiationInterface as DI
+
+const CTFlowsSciMLIntegrator = Base.get_extension(CTFlows, :CTFlowsSciMLIntegrator)
+const CTFlowsDifferentiationInterface = Base.get_extension(CTFlows, :CTFlowsDifferentiationInterface)
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+const ATOL = 1e-4
+
+# =============================================================================
+# Shared constants
+# =============================================================================
+
+const λ_TEST = 2.0
+const INTEG  = Integrators.SciML(; alg=Tsit5())
+const DI_BACKEND = Differentiation.DifferentiationInterface(; ad_backend=ADTypes.AutoForwardDiff())
+
+# =============================================================================
+# OCP fixtures (module top-level)
+# =============================================================================
+
+function _build_ocp_auton_fixed_mayer()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_fixed_lagrange()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(_, x, _, _) -> x[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_fixed_bolza()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min;
+        mayer=(x0, xf, v) -> xf[1],
+        lagrange=(_, x, _, _) -> x[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_nonfixed_mayer()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, v) -> (r[1] = v[1] * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_nonauton_fixed_mayer()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, _, _) -> (r[1] = t * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+const OCP_AF_MAYER   = _build_ocp_auton_fixed_mayer()
+const OCP_AF_LAG     = _build_ocp_auton_fixed_lagrange()
+const OCP_AF_BOLZA   = _build_ocp_auton_fixed_bolza()
+const OCP_ANF_MAYER  = _build_ocp_auton_nonfixed_mayer()
+const OCP_NAF_MAYER  = _build_ocp_nonauton_fixed_mayer()
+
+# Pre-built flows (all via generic HamiltonianSystem — OCP rides the generic path)
+const FLOW_AF    = Flows.build_flow(
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_MAYER), DI_BACKEND),
+    INTEG)
+const FLOW_ANF   = Flows.build_flow(
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_ANF_MAYER), DI_BACKEND),
+    INTEG)
+const FLOW_NAF   = Flows.build_flow(
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_NAF_MAYER), DI_BACKEND),
+    INTEG)
+
+# OptimalControlFlow wrappers (for trajectory call → CTModels.Solution)
+const OCF_AF_MAYER = Flows.OptimalControlFlow(FLOW_AF, OCP_AF_MAYER)
+const OCF_ANF      = Flows.OptimalControlFlow(FLOW_ANF, OCP_ANF_MAYER)
+
+# =============================================================================
+# Analytic references
+# =============================================================================
+
+_x_ref(t, t0, x0)       = x0 * exp(λ_TEST * (t - t0))
+_p_ref(t, t0, p0)       = p0 * exp(-λ_TEST * (t - t0))
+_pv_ref(tf, t0, x0, p0) = -p0 * x0 * (tf - t0)   # ℓ=0, ẋ=λx, H=pλx
+_lag_obj(T, x0)          = x0^2 * (exp(2λ_TEST * T) - 1) / (2λ_TEST)
+_may_obj(T, x0)          = x0 * exp(λ_TEST * T)
+
+_xna_ref(t, t0, x0)     = x0 * exp((t^2 - t0^2) / 2)  # ẋ=t·x
+
+# =============================================================================
+
+function test_optimal_control_flow()
+    Test.@testset "Flow(ocp) — end-to-end" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ── construction ──────────────────────────────────────────────────────
+
+        Test.@testset "Construction: isa OptimalControlFlow" begin
+            f = Flows.Flow(OCP_AF_MAYER; alg=Tsit5())
+            Test.@test f isa Flows.OptimalControlFlow
+        end
+
+        Test.@testset "Construction: system/integrator accessors" begin
+            f = Flows.Flow(OCP_AF_MAYER; alg=Tsit5())
+            Test.@test Flows.system(f)     isa Systems.HamiltonianSystem
+            Test.@test Flows.integrator(f) isa Integrators.AbstractIntegrator
+        end
+
+        # ── point eval, Fixed/Autonomous ──────────────────────────────────────
+
+        Test.@testset "Integration: Fixed/Auton (x0,p0,tf) scalar" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            xf, pf = FLOW_AF(t0, x0, p0, tf)
+            Test.@test xf ≈ _x_ref(tf, t0, x0) atol=ATOL
+            Test.@test pf ≈ _p_ref(tf, t0, p0) atol=ATOL
+        end
+
+        Test.@testset "Integration: Fixed/Auton (x0,p0,tf) vector" begin
+            t0, tf = 0.0, 0.5
+            x0, p0 = [2.0], [1.0]
+            xf, pf = FLOW_AF(t0, x0, p0, tf)
+            Test.@test xf[1] ≈ _x_ref(tf, t0, x0[1]) atol=ATOL
+            Test.@test pf[1] ≈ _p_ref(tf, t0, p0[1]) atol=ATOL
+        end
+
+        Test.@testset "Unit: xf/pf shape — scalar inputs → Number" begin
+            t0, tf = 0.0, 0.5
+            xf, pf = FLOW_AF(t0, 1.0, 1.0, tf)
+            Test.@test xf isa Number
+            Test.@test pf isa Number
+        end
+
+        Test.@testset "Unit: xf/pf shape — vector inputs → AbstractVector" begin
+            t0, tf = 0.0, 0.5
+            x0, p0 = [1.0], [1.0]
+            xf, pf = FLOW_AF(t0, x0, p0, tf)
+            Test.@test xf isa AbstractVector
+            Test.@test length(xf) == 1
+            Test.@test pf isa AbstractVector
+            Test.@test length(pf) == 1
+            Test.@test xf[1] ≈ _x_ref(tf, t0, x0[1]) atol=ATOL
+            Test.@test pf[1] ≈ _p_ref(tf, t0, p0[1]) atol=ATOL
+        end
+
+        # ── point eval, NonFixed/Autonomous ──────────────────────────────────
+
+        Test.@testset "Integration: NonFixed/Auton — variable=λ" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            v = [λ_TEST]
+            xf, pf = FLOW_ANF(t0, x0, p0, tf; variable=v)
+            # ẋ = v[1]*x = λ_TEST*x, same analytic solution
+            Test.@test xf ≈ _x_ref(tf, t0, x0) atol=ATOL
+            Test.@test pf ≈ _p_ref(tf, t0, p0) atol=ATOL
+        end
+
+        # ── point eval, Non-autonomous ────────────────────────────────────────
+
+        Test.@testset "Integration: NonAuton/Fixed — ẋ=t·x" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 1.0
+            xf, pf = FLOW_NAF(t0, x0, p0, tf)
+            Test.@test xf ≈ _xna_ref(tf, t0, x0) atol=ATOL
+        end
+
+        # ── variable_costate ─────────────────────────────────────────────────
+
+        Test.@testset "Integration: variable_costate=true — vector variable" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            v = [λ_TEST]
+            xf, pf, pvf = FLOW_ANF(t0, x0, p0, tf; variable=v, variable_costate=true)
+            Test.@test xf    ≈ _x_ref(tf, t0, x0) atol=ATOL
+            Test.@test pf    ≈ _p_ref(tf, t0, p0) atol=ATOL
+            Test.@test pvf[1] ≈ _pv_ref(tf, t0, x0, p0) atol=ATOL
+        end
+
+        Test.@testset "Unit: pvf shape — vector variable → AbstractVector" begin
+            t0, tf = 0.0, 0.5
+            xf, pf, pvf = FLOW_ANF(t0, 1.0, 1.0, tf; variable=[λ_TEST], variable_costate=true)
+            Test.@test pvf isa AbstractVector
+            Test.@test length(pvf) == 1
+        end
+
+        Test.@testset "Unit: pvf shape — scalar variable → Number" begin
+            t0, tf = 0.0, 0.5
+            xf, pf, pvf = FLOW_ANF(t0, 1.0, 1.0, tf; variable=λ_TEST, variable_costate=true)
+            Test.@test pvf isa Number
+        end
+
+        Test.@testset "Integration: scalar variable gives same pvf value as vector" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            _, _, pvf1 = FLOW_ANF(t0, x0, p0, tf; variable=[λ_TEST], variable_costate=true)
+            _, _, pvf2 = FLOW_ANF(t0, x0, p0, tf; variable=λ_TEST,   variable_costate=true)
+            Test.@test pvf1[1] ≈ pvf2 atol=ATOL
+        end
+
+        # ── trajectory → CTModels.Solution ───────────────────────────────────
+
+        Test.@testset "Integration: trajectory call returns CTModels.Solution" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            sol = OCF_AF_MAYER((t0, tf), x0, p0)
+            Test.@test sol isa CTModels.Solutions.Solution
+        end
+
+        Test.@testset "Integration: Mayer objective ≈ analytic" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            sol = OCF_AF_MAYER((t0, tf), x0, p0)
+            Test.@test CTModels.Models.objective(sol) ≈ _may_obj(tf - t0, x0) atol=ATOL
+        end
+
+        Test.@testset "Integration: (co)state(sol)(tf) ≈ analytic (x,p)(tf)" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            sol = OCF_AF_MAYER((t0, tf), x0, p0)
+            xsol = CTModels.Models.state(sol)(tf)
+            psol = CTModels.Solutions.costate(sol)(tf) # 
+            Test.@test xsol ≈ _x_ref(tf, t0, x0) atol=ATOL
+            Test.@test psol ≈ _p_ref(tf, t0, p0) atol=ATOL
+        end
+
+        Test.@testset "Unit: state(sol)(tf) shape — scalar inputs → Number" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            sol = OCF_AF_MAYER((t0, tf), x0, p0)
+            xsol = CTModels.Models.state(sol)(tf)
+            psol = CTModels.Solutions.costate(sol)(tf)
+            Test.@test xsol isa Number
+            Test.@test psol isa Number
+        end
+
+        Test.@testset "Unit: state(sol)(tf) shape — vector inputs → AbstractVector" begin
+            t0, tf = 0.0, 1.0
+            x0, p0 = [1.0], [0.5]
+            sol = OCF_AF_MAYER((t0, tf), x0, p0)
+            xsol = CTModels.Models.state(sol)(tf)
+            psol = CTModels.Solutions.costate(sol)(tf)
+            Test.@test xsol isa Number # AbstractVector
+            # Test.@test length(xsol) == 1
+            Test.@test psol isa Number # AbstractVector
+            # Test.@test length(psol) == 1
+        end
+
+        Test.@testset "Integration: Lagrange objective ≈ analytic" begin
+            flow_lag = Flows.build_flow(
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_LAG), DI_BACKEND),
+                INTEG)
+            ocf_lag = Flows.OptimalControlFlow(flow_lag, OCP_AF_LAG)
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 1.0
+            sol = ocf_lag((t0, tf), x0, p0)
+            Test.@test CTModels.Models.objective(sol) ≈ _lag_obj(tf - t0, x0) atol=ATOL
+        end
+
+        Test.@testset "Integration: Bolza objective ≈ Mayer + Lagrange" begin
+            flow_bolza = Flows.build_flow(
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_BOLZA), DI_BACKEND),
+                INTEG)
+            ocf_bolza = Flows.OptimalControlFlow(flow_bolza, OCP_AF_BOLZA)
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 1.0
+            sol = ocf_bolza((t0, tf), x0, p0)
+            expected = _may_obj(tf - t0, x0) + _lag_obj(tf - t0, x0)
+            Test.@test CTModels.Models.objective(sol) ≈ expected atol=ATOL
+        end
+
+        # ── cross-check: OCP flow vs generic HamiltonianSystem ────────────────
+
+        Test.@testset "Integration: cross-check vs generic HamiltonianSystem" begin
+            # H = p·λx = generic autonomous/fixed Hamiltonian — now same path, regression guard
+            h_generic = Data.Hamiltonian(
+                (x, p) -> p[1] * λ_TEST * x[1];
+                is_autonomous=true, is_variable=false)
+            sys_gen = Systems.HamiltonianSystem(h_generic, DI_BACKEND)
+            flow_gen = Flows.build_flow(sys_gen, INTEG)
+
+            t0, tf = 0.0, 1.0
+            x0, p0 = [1.5], [0.8]
+
+            xf_ocp, pf_ocp = FLOW_AF(t0, x0, p0, tf)
+            xf_gen, pf_gen = flow_gen(t0, x0, p0, tf)
+
+            Test.@test xf_ocp ≈ xf_gen atol=ATOL
+            Test.@test pf_ocp ≈ pf_gen atol=ATOL
+        end
+
+        # ── error guards ──────────────────────────────────────────────────────
+
+        Test.@testset "Error: Fixed model + variable= kwarg" begin
+            Test.@test_throws Exceptions.PreconditionError FLOW_AF(0.0, 1.0, 0.5, 1.0; variable=1.0)
+        end
+
+        Test.@testset "Error: NonFixed model + variable omitted" begin
+            Test.@test_throws Exceptions.PreconditionError FLOW_ANF(0.0, 1.0, 0.5, 1.0)
+        end
+
+        Test.@testset "Error: variable_costate=true on Fixed system" begin
+            Test.@test_throws Exceptions.PreconditionError FLOW_AF(0.0, 1.0, 0.5, 1.0; variable_costate=true)
+        end
+
+        Test.@testset "Error: Flow(ocp, u) — control-free guard" begin
+            err = nothing
+            try
+                Flows.Flow(OCP_AF_MAYER, identity; alg=Tsit5())
+            catch e
+                err = e
+            end
+            Test.@test err isa Exceptions.PreconditionError
+            Test.@test occursin("control-free", err.msg)
+        end
+
+        Test.@testset "Error: Flow(ocp, g, μ) — control-free guard (extra args)" begin
+            Test.@test_throws Exceptions.PreconditionError Flows.Flow(OCP_AF_MAYER, identity, identity; alg=Tsit5())
+        end
+
+    end
+end
+
+end # module
+
+test_optimal_control_flow() = TestOptimalControlFlow.test_optimal_control_flow()

--- a/test/suite/flows/test_ocp_hamiltonian.jl
+++ b/test/suite/flows/test_ocp_hamiltonian.jl
@@ -1,0 +1,225 @@
+"""
+Unit tests for OCPHamiltonianFunction and _ocp_hamiltonian.
+
+Tests the four natural-arity call methods (Auton/Fixed, NonAuton/Fixed,
+Auton/NonFixed, NonAuton/NonFixed), criterion sign, lagrange === nothing branch,
+scalar vs vector inputs, and the _ocp_hamiltonian builder.
+
+No AD extensions required — pure callable evaluation.
+"""
+
+module TestOCPHamiltonianFunction
+
+import Test
+import CTModels
+import CTFlows.Flows: Flows
+import CTFlows.Traits: Traits
+import CTFlows.Data: Data
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+# =============================================================================
+# Shared dynamics (module top-level)
+# =============================================================================
+
+const λ_TEST = 2.0
+
+_dyn_auton_fixed!(r, _, x, _, _)    = (r[1] = λ_TEST * x[1]; nothing)
+_dyn_nonauton_fixed!(r, t, x, _, _) = (r[1] = t * x[1]; nothing)
+_dyn_auton_nf!(r, _, x, _, v)       = (r[1] = v[1] * x[1]; nothing)
+_dyn_nonauton_nf!(r, t, x, _, v)    = (r[1] = t * v[1] * x[1]; nothing)
+
+_lagrange(_, x, _, _) = x[1]^2
+
+# =============================================================================
+# OCPHamiltonianFunction fixtures (module top-level)
+# =============================================================================
+
+const _AU = CTModels.Components.Autonomous
+const _NA = CTModels.Components.NonAutonomous
+
+const H_AF_NL = Flows.OCPHamiltonianFunction{_AU, Traits.Fixed, typeof(_dyn_auton_fixed!), Nothing}(
+    _dyn_auton_fixed!, nothing, -1.0, 1)
+
+const H_AF_LAG = Flows.OCPHamiltonianFunction{_AU, Traits.Fixed, typeof(_dyn_auton_fixed!), typeof(_lagrange)}(
+    _dyn_auton_fixed!, _lagrange, -1.0, 1)
+
+const H_AF_LAG_MAX = Flows.OCPHamiltonianFunction{_AU, Traits.Fixed, typeof(_dyn_auton_fixed!), typeof(_lagrange)}(
+    _dyn_auton_fixed!, _lagrange, +1.0, 1)
+
+const H_NAF_NL = Flows.OCPHamiltonianFunction{_NA, Traits.Fixed, typeof(_dyn_nonauton_fixed!), Nothing}(
+    _dyn_nonauton_fixed!, nothing, -1.0, 1)
+
+const H_ANF_NL = Flows.OCPHamiltonianFunction{_AU, Traits.NonFixed, typeof(_dyn_auton_nf!), Nothing}(
+    _dyn_auton_nf!, nothing, -1.0, 1)
+
+const H_NANF_NL = Flows.OCPHamiltonianFunction{_NA, Traits.NonFixed, typeof(_dyn_nonauton_nf!), Nothing}(
+    _dyn_nonauton_nf!, nothing, -1.0, 1)
+
+# =============================================================================
+# OCP fixtures for _ocp_hamiltonian
+# =============================================================================
+
+function _build_ocp_auton_fixed_mayer()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, _dyn_auton_fixed!)
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_fixed_lagrange_min()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, _dyn_auton_fixed!)
+    CTModels.Building.objective!(pre, :min; lagrange=_lagrange)
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_fixed_lagrange_max()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, _dyn_auton_fixed!)
+    CTModels.Building.objective!(pre, :max; lagrange=_lagrange)
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_nonauton_nonfixed_mayer()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, _dyn_nonauton_nf!)
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+const OCP_AF_MAYER       = _build_ocp_auton_fixed_mayer()
+const OCP_AF_LAG_MIN     = _build_ocp_auton_fixed_lagrange_min()
+const OCP_AF_LAG_MAX     = _build_ocp_auton_fixed_lagrange_max()
+const OCP_NANF_MAYER     = _build_ocp_nonauton_nonfixed_mayer()
+
+# =============================================================================
+
+function test_ocp_hamiltonian()
+    Test.@testset "OCP Hamiltonian Function" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ── call methods ──────────────────────────────────────────────────────
+
+        Test.@testset "Unit: Auton/Fixed (x,p) — no lagrange" begin
+            x = [2.0]; p = [3.0]
+            val = H_AF_NL(x, p)
+            Test.@test val ≈ p[1] * λ_TEST * x[1]
+        end
+
+        Test.@testset "Unit: Auton/Fixed (x,p) — with lagrange (min, sp0=-1)" begin
+            x = [2.0]; p = [3.0]
+            expected = p[1] * λ_TEST * x[1] + (-1.0) * x[1]^2
+            Test.@test H_AF_LAG(x, p) ≈ expected
+        end
+
+        Test.@testset "Unit: Auton/Fixed (x,p) — with lagrange (max, sp0=+1)" begin
+            x = [2.0]; p = [3.0]
+            expected = p[1] * λ_TEST * x[1] + (+1.0) * x[1]^2
+            Test.@test H_AF_LAG_MAX(x, p) ≈ expected
+        end
+
+        Test.@testset "Unit: NonAuton/Fixed (t,x,p)" begin
+            t = 2.0; x = [3.0]; p = [5.0]
+            Test.@test H_NAF_NL(t, x, p) ≈ p[1] * t * x[1]
+        end
+
+        Test.@testset "Unit: Auton/NonFixed (x,p,v)" begin
+            x = [2.0]; p = [3.0]; v = [4.0]
+            Test.@test H_ANF_NL(x, p, v) ≈ p[1] * v[1] * x[1]
+        end
+
+        Test.@testset "Unit: NonAuton/NonFixed (t,x,p,v)" begin
+            t = 2.0; x = [3.0]; p = [5.0]; v = [4.0]
+            Test.@test H_NANF_NL(t, x, p, v) ≈ p[1] * t * v[1] * x[1]
+        end
+
+        # ── scalar inputs (n_x=1 — _asvec rewraps) ──────────────────────────
+
+        Test.@testset "Unit: scalar x and p give same result as 1-vector" begin
+            x_s = 2.0; p_s = 3.0
+            x_v = [2.0]; p_v = [3.0]
+            Test.@test H_AF_NL(x_s, p_s) ≈ H_AF_NL(x_v, p_v)
+        end
+
+        Test.@testset "Unit: scalar x,p,v give same result as 1-vectors (NonFixed)" begin
+            x_s = 2.0; p_s = 3.0; v_s = 4.0
+            x_v = [2.0]; p_v = [3.0]; v_v = [4.0]
+            Test.@test H_ANF_NL(x_s, p_s, v_s) ≈ H_ANF_NL(x_v, p_v, v_v)
+        end
+
+        # ── lagrange=nothing branch ───────────────────────────────────────────
+
+        Test.@testset "Unit: lagrange=nothing → H = p·f exactly" begin
+            x = [1.5]; p = [2.5]
+            Test.@test H_AF_NL(x, p) == p[1] * λ_TEST * x[1]
+        end
+
+        # ── criterion sign ────────────────────────────────────────────────────
+
+        Test.@testset "Unit: min criterion → sp0 = -1.0" begin
+            x = [1.0]; p = [0.0]
+            Test.@test H_AF_LAG(x, p) ≈ -1.0 * x[1]^2
+        end
+
+        Test.@testset "Unit: max criterion → sp0 = +1.0" begin
+            x = [1.0]; p = [0.0]
+            Test.@test H_AF_LAG_MAX(x, p) ≈ +1.0 * x[1]^2
+        end
+
+        # ── OCPHamiltonianFunction <: Function ────────────────────────────────────────
+
+        Test.@testset "Unit: OCPHamiltonianFunction isa Function" begin
+            Test.@test H_AF_NL isa Function
+            Test.@test H_AF_LAG isa Function
+            Test.@test H_NAF_NL isa Function
+            Test.@test H_ANF_NL isa Function
+            Test.@test H_NANF_NL isa Function
+        end
+
+        # ── _ocp_hamiltonian builder ──────────────────────────────────────────
+
+        Test.@testset "Unit: _ocp_hamiltonian returns Data.Hamiltonian" begin
+            h = Flows._ocp_hamiltonian(OCP_AF_MAYER)
+            Test.@test h isa Data.Hamiltonian
+        end
+
+        Test.@testset "Unit: _ocp_hamiltonian TD/VD match OCP (Auton/Fixed)" begin
+            h = Flows._ocp_hamiltonian(OCP_AF_MAYER)
+            Test.@test h isa Data.AbstractHamiltonian{CTModels.Components.Autonomous, Traits.Fixed}
+        end
+
+        Test.@testset "Unit: _ocp_hamiltonian TD/VD match OCP (NonAuton/NonFixed)" begin
+            h = Flows._ocp_hamiltonian(OCP_NANF_MAYER)
+            Test.@test h isa Data.AbstractHamiltonian{CTModels.Components.NonAutonomous, Traits.NonFixed}
+        end
+
+        Test.@testset "Unit: _ocp_hamiltonian min vs max sp0" begin
+            h_min = Flows._ocp_hamiltonian(OCP_AF_LAG_MIN)
+            h_max = Flows._ocp_hamiltonian(OCP_AF_LAG_MAX)
+            x = [2.0]; p = [0.0]
+            val_min = h_min.f(x, p)
+            val_max = h_max.f(x, p)
+            Test.@test val_min ≈ -1.0 * x[1]^2
+            Test.@test val_max ≈ +1.0 * x[1]^2
+        end
+
+    end
+end
+
+end # module
+
+test_ocp_hamiltonian() = TestOCPHamiltonianFunction.test_ocp_hamiltonian()

--- a/test/suite/flows/test_ocp_model_traits.jl
+++ b/test/suite/flows/test_ocp_model_traits.jl
@@ -1,0 +1,117 @@
+"""
+Unit and contract tests for CTFlows.Flows trait methods on CTModels.Models.Model.
+
+Tests that time_dependence / variable_dependence dispatch correctly for all
+combinations of autonomous/non-autonomous and Fixed/NonFixed OCPs.
+No extensions required — pure type-level dispatch.
+"""
+
+module TestOCPModelTraits
+
+import Test
+import CTModels
+import CTFlows.Traits: Traits
+
+const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+# =============================================================================
+# OCP fixtures at module top-level
+# =============================================================================
+
+function _build_ocp_auton_fixed()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_auton_nonfixed()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = v[1]*x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_nonauton_nonfixed()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = t*v[1]*x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+function _build_ocp_nonauton_fixed()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = t*x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+const OCP_AUTON_FIXED       = _build_ocp_auton_fixed()
+const OCP_AUTON_NONFIXED    = _build_ocp_auton_nonfixed()
+const OCP_NONAUTON_NONFIXED = _build_ocp_nonauton_nonfixed()
+const OCP_NONAUTON_FIXED    = _build_ocp_nonauton_fixed()
+
+# =============================================================================
+
+function test_ocp_model_traits()
+    Test.@testset "OCP Model Traits" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        Test.@testset "Unit: time_dependence" begin
+            Test.@test Traits.time_dependence(OCP_AUTON_FIXED)       === CTModels.Components.Autonomous
+            Test.@test Traits.time_dependence(OCP_AUTON_NONFIXED)    === CTModels.Components.Autonomous
+            Test.@test Traits.time_dependence(OCP_NONAUTON_NONFIXED) === CTModels.Components.NonAutonomous
+            Test.@test Traits.time_dependence(OCP_NONAUTON_FIXED)    === CTModels.Components.NonAutonomous
+        end
+
+        Test.@testset "Unit: variable_dependence" begin
+            Test.@test Traits.variable_dependence(OCP_AUTON_FIXED)       === Traits.Fixed
+            Test.@test Traits.variable_dependence(OCP_AUTON_NONFIXED)    === Traits.NonFixed
+            Test.@test Traits.variable_dependence(OCP_NONAUTON_NONFIXED) === Traits.NonFixed
+            Test.@test Traits.variable_dependence(OCP_NONAUTON_FIXED)    === Traits.Fixed
+        end
+
+        Test.@testset "Contract: has_time_dependence_trait returns true for all OCP" begin
+            Test.@test Traits.has_time_dependence_trait(OCP_AUTON_FIXED)       === true
+            Test.@test Traits.has_time_dependence_trait(OCP_AUTON_NONFIXED)    === true
+            Test.@test Traits.has_time_dependence_trait(OCP_NONAUTON_NONFIXED) === true
+            Test.@test Traits.has_time_dependence_trait(OCP_NONAUTON_FIXED)    === true
+        end
+
+        Test.@testset "Contract: has_variable_dependence_trait returns true for all OCP" begin
+            Test.@test Traits.has_variable_dependence_trait(OCP_AUTON_FIXED)       === true
+            Test.@test Traits.has_variable_dependence_trait(OCP_AUTON_NONFIXED)    === true
+            Test.@test Traits.has_variable_dependence_trait(OCP_NONAUTON_NONFIXED) === true
+            Test.@test Traits.has_variable_dependence_trait(OCP_NONAUTON_FIXED)    === true
+        end
+
+        Test.@testset "Contract: OCP isa CTModels.Models.Model" begin
+            Test.@test OCP_AUTON_FIXED    isa CTModels.Models.Model
+            Test.@test OCP_AUTON_NONFIXED isa CTModels.Models.Model
+        end
+
+        Test.@testset "Unit: EmptyVariableModel ↔ Fixed, VariableModel ↔ NonFixed" begin
+            Test.@test CTModels.Models.variable_dimension(OCP_AUTON_FIXED)    == 0
+            Test.@test CTModels.Models.variable_dimension(OCP_AUTON_NONFIXED) == 1
+        end
+
+    end
+end
+
+end # module
+
+test_ocp_model_traits() = TestOCPModelTraits.test_ocp_model_traits()

--- a/test/suite/systems/test_ham_rhs_functors.jl
+++ b/test/suite/systems/test_ham_rhs_functors.jl
@@ -49,7 +49,7 @@ function test_ham_rhs_functors()
 
             ip_rhs = Systems.HamIpRHS(h, backend, 2, identity, identity)
             oop_rhs = Systems.HamOoPRHS(h, backend, 2, identity, identity)
-            aug_rhs = Systems.HamIpAugRHS(h, backend, 2, 1)
+            aug_rhs = Systems.HamIpAugRHS(h, backend, 2, 1, identity, identity)
 
             Test.@test ip_rhs isa Systems.AbstractIPHamRHS
             Test.@test ip_rhs isa Systems.AbstractRHS{Traits.InPlace}
@@ -140,7 +140,7 @@ function test_ham_rhs_functors()
         Test.@testset "HamIpAugRHS — call vector" begin
             backend = FakeADBackend()
             h = FakeHamiltonian
-            rhs = Systems.HamIpAugRHS(h, backend, 2, 1)
+            rhs = Systems.HamIpAugRHS(h, backend, 2, 1, identity, identity)
 
             du = zeros(5)
             u = [1.0, 2.0, 3.0, 4.0, 0.0]
@@ -210,7 +210,7 @@ function test_ham_rhs_functors()
 
             ip_rhs = Systems.HamIpRHS(h, backend, 2, identity, identity)
             oop_rhs = Systems.HamOoPRHS(h, backend, 2, identity, identity)
-            aug_rhs = Systems.HamIpAugRHS(h, backend, 2, 1)
+            aug_rhs = Systems.HamIpAugRHS(h, backend, 2, 1, identity, identity)
 
             Test.@test occursin("HamIpRHS", sprint(show, ip_rhs))
             Test.@test occursin("Hamiltonian AD → in-place interface", sprint(show, ip_rhs))

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -329,7 +329,8 @@ function test_hamiltonian_vector_field_system()
 
             Test.@testset "OOP builds" begin
                 n_x, n_v = 2, 1
-                rhs_aug = Systems.build_rhs_augmented(sys, n_x, n_v)
+                x0, p0 = [1.0, 2.0], [3.0, 4.0]
+                rhs_aug = Systems.build_rhs_augmented(sys, n_x, n_v, x0, p0)
                 Test.@test rhs_aug isa Systems.AbstractIPHVFRHS
             end
 
@@ -338,7 +339,8 @@ function test_hamiltonian_vector_field_system()
                 hvf_ip = Data.HamiltonianVectorField((dx, dp, x, p, v; dpv=nothing, variable_costate::Bool=false) -> nothing; is_autonomous=true, is_variable=true, is_inplace=true)
                 sys_ip = Systems.HamiltonianVectorFieldSystem(hvf_ip)
                 n_x, n_v = 2, 1
-                rhs_aug_ip = Systems.build_rhs_augmented(sys_ip, n_x, n_v)
+                x0, p0 = [1.0, 2.0], [3.0, 4.0]
+                rhs_aug_ip = Systems.build_rhs_augmented(sys_ip, n_x, n_v, x0, p0)
                 Test.@test rhs_aug_ip isa Systems.AbstractIPHVFRHS
             end
         end

--- a/test/suite/systems/test_hvf_rhs_functors.jl
+++ b/test/suite/systems/test_hvf_rhs_functors.jl
@@ -164,7 +164,7 @@ function test_hvf_rhs_functors()
         Test.@testset "IPHVFOoPAugRHS — call" begin
             # Autonomous
             hvf = Data.HamiltonianVectorField(FakeHVFAug; is_autonomous=true, is_variable=true)
-            r = Systems.IPHVFOoPAugRHS(hvf, 2, 1)
+            r = Systems.IPHVFOoPAugRHS(hvf, 2, 1, identity, identity)
 
             du = zeros(5)
             u = [1.0, 2.0, 3.0, 4.0, 0.0]
@@ -178,7 +178,7 @@ function test_hvf_rhs_functors()
 
             # NonAutonomous
             hvf_na = Data.HamiltonianVectorField(FakeHVFAugNA; is_autonomous=false, is_variable=true)
-            r_na = Systems.IPHVFOoPAugRHS(hvf_na, 2, 1)
+            r_na = Systems.IPHVFOoPAugRHS(hvf_na, 2, 1, identity, identity)
 
             du = zeros(5)
             r_na(du, u, λ, t)
@@ -190,7 +190,7 @@ function test_hvf_rhs_functors()
         Test.@testset "IPHVFIpAugRHS — call" begin
             # Autonomous
             hvf = Data.HamiltonianVectorField(FakeHVFAugIP; is_autonomous=true, is_variable=true, is_inplace=true)
-            r = Systems.IPHVFIpAugRHS(hvf, 2, 1)
+            r = Systems.IPHVFIpAugRHS(hvf, 2, 1, identity, identity)
 
             du = zeros(5)
             u = [1.0, 2.0, 3.0, 4.0, 0.0]
@@ -203,7 +203,7 @@ function test_hvf_rhs_functors()
 
             # NonAutonomous
             hvf_na = Data.HamiltonianVectorField(FakeHVFAugIPNA; is_autonomous=false, is_variable=true, is_inplace=true)
-            r_na = Systems.IPHVFIpAugRHS(hvf_na, 2, 1)
+            r_na = Systems.IPHVFIpAugRHS(hvf_na, 2, 1, identity, identity)
 
             du = zeros(5)
             r_na(du, u, λ, t)


### PR DESCRIPTION
This PR reintroduces the ability to build a Hamiltonian flow directly from an OCP, including the **control-free** case (control dimension 0, `EmptyControlModel`) used for parameter estimation / optimal design. The modular refactor dropped that path entirely — no `Flow(ocp)` exists today.

## Key Changes

### 1. Trait contracts for `CTModels.Models.Model`
- New file `src/Flows/ocp_model_traits.jl` implements CTFlows `Traits` contracts (`time_dependence`, `variable_dependence`) for `CTModels.Models.Model`
- Temporary location — will move to CTModels once contracts are stable

### 2. Coercion closures (cx/cp) in augmented RHS
- Added `cx` and `cp` coercion fields to `IPHVFOoPAugRHS`, `IPHVFIpAugRHS`, and `HamIpAugRHS`
- Updated `build_rhs_augmented` and `build_and_solve` to forward coercers
- Enables parameter transformations for state and costate in augmented systems

### 3. OptimalControlFlow type
- New `OptimalControlFlow` wrapper in `src/Flows/optimal_control_flow.jl`
- Carries the OCP model and provides flow interface

### 4. Test coverage
- New test files: `test_optimal_control_flow.jl`, `test_ocp_hamiltonian.jl`, `test_ocp_model_traits.jl`
- Updated existing tests to pass identity coercers in augmented RHS constructors

## Remaining work (from issue #262)
- Differentiation — state-only gradient (∂H/∂x) contract
- Optimized control-free Hamiltonian system implementation
- `Flow(ocp)` constructor in `src/Flows/building.jl`