### PR TITLE
refactor: consume CTBase.Core.NotProvided (0.9.4-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-beta] - 2026-06-26
+
+### Changed
+
+- **Breaking (internal sentinel):** `CTFlows.Common.NotProvided` / `CTFlows.Common.NotProvidedType` are removed.
+  The local `struct NotProvided end` is deleted and there is **no re-export** — all code uses
+  `CTBase.Core.NotProvided` (singleton instance of `CTBase.Core.NotProvidedType`) directly.
+- `__variable()` default now returns `CTBase.Core.NotProvided`.
+- `Flows/calling.jl` dispatch updated: `::Type{Common.NotProvided}` → `::Type{Core.NotProvidedType}`.
+- DifferentialGeometry AD-backend sentinel and the SciML extensions consume `CTBase.Core.NotProvided` directly.
+
+### Dependencies
+
+- Bump CTBase compat to `0.25` (CTBase 0.25 moves `NotProvided`/`NotProvidedType` to `CTBase.Core`).
+
 ## [0.8.24-beta] - 2026-04-20
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.9.3-beta"
+version = "0.9.4-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -30,7 +30,7 @@ CTFlowsStaticArrays = ["StaticArrays"]
 [compat]
 ADTypes = "1"
 Aqua = "0.8"
-CTBase = "0.24"
+CTBase = "0.25"
 CTModels = "0.13"
 DiffEqBase = "6, 7"
 DifferentiationInterface = "0.7"

--- a/ext/CTFlowsSciMLFlows/CTFlowsSciMLFlows.jl
+++ b/ext/CTFlowsSciMLFlows/CTFlowsSciMLFlows.jl
@@ -16,6 +16,7 @@ module CTFlowsSciMLFlows
 
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 import CTBase.Exceptions
+import CTBase.Core
 
 using CTFlows: CTFlows
 using CTFlows.Common: Common

--- a/ext/CTFlowsSciMLFlows/problem_flow.jl
+++ b/ext/CTFlowsSciMLFlows/problem_flow.jl
@@ -104,7 +104,7 @@ function (f::SciMLProblemFlow)(
     unsafe = Common.__unsafe(),
 )
     kw = (; u0 = x0, tspan = (t0, tf))
-    if !(variable isa Common.NotProvided)
+    if !(variable isa Core.NotProvidedType)
         kw = merge(kw, (; p = variable))
     end
     prob   = SciMLBase.remake(f.prob; kw...)
@@ -147,7 +147,7 @@ function (f::SciMLProblemFlow)(
     unsafe = Common.__unsafe(),
 )
     kw = (; u0 = x0, tspan = tspan)
-    if !(variable isa Common.NotProvided)
+    if !(variable isa Core.NotProvidedType)
         kw = merge(kw, (; p = variable))
     end
     prob   = SciMLBase.remake(f.prob; kw...)

--- a/ext/CTFlowsSciMLIntegrator/CTFlowsSciMLIntegrator.jl
+++ b/ext/CTFlowsSciMLIntegrator/CTFlowsSciMLIntegrator.jl
@@ -22,7 +22,7 @@ module CTFlowsSciMLIntegrator
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 import CTBase.Exceptions
 import CTBase.Strategies
-import CTBase.Options
+import CTBase.Core
 
 using CTFlows: CTFlows
 using CTFlows.Common: Common

--- a/ext/CTFlowsSciMLIntegrator/strategies.jl
+++ b/ext/CTFlowsSciMLIntegrator/strategies.jl
@@ -56,7 +56,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :maxiters,
             type = Integer,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Maximum number of solver iterations.",
             aliases=(:max_iters, :max_iter, :maxiter, :max_iterations, :maxit),
             validator = x ->
@@ -73,7 +73,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :dt,
             type = Real,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Fixed step size (used when adaptive=false).",
             aliases = (:dt0, :timestep),
             validator = x ->
@@ -90,7 +90,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :adaptive,
             type = Bool,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Whether to use adaptive step-size control.",
             aliases = (:adaptive_step, :adaptive_stepping),
         ),
@@ -103,7 +103,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :saveat,
             type = Union{Real, AbstractVector},
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Times at which to save the solution (Vector or range).",
             aliases = (:save_at, :save_times),
         ),
@@ -116,27 +116,27 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :save_idxs,
             type = AbstractVector{<:Integer},
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Indices of components to save (Vector of integers).",
             aliases = (:saveindices, :save_indices),
         ),
         Strategies.OptionDefinition(;
             name = :tstops,
             type = AbstractVector{<:Real},
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Extra times the solver must step to (for discontinuities).",
             aliases = (:t_stops, :stop_times),
         ),
         Strategies.OptionDefinition(;
             name = :d_discontinuities,
             type = AbstractVector{<:Real},
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Locations of discontinuities in low-order derivatives.",
         ),
         Strategies.OptionDefinition(;
             name = :dtmax,
             type = Real,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Maximum step size for adaptive timestepping.",
             aliases = (:max_dt, :dt_max),
             validator = x ->
@@ -153,7 +153,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :dtmin,
             type = Real,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Minimum step size for adaptive timestepping.",
             aliases = (:min_dt, :dt_min),
             validator = x ->
@@ -170,20 +170,20 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :force_dtmin,
             type = Bool,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Whether to continue forcing minimum dt usage.",
         ),
         Strategies.OptionDefinition(;
             name = :callback,
             type = Any,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Callback function for event handling.",
             aliases = (:callbacks, :cb),
         ),
         Strategies.OptionDefinition(;
             name = :progress,
             type = Bool,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Whether to show progress bar.",
             aliases = (:verbose,),
         ),
@@ -196,7 +196,7 @@ function Strategies.metadata(::Type{Integrators.SciML})
         Strategies.OptionDefinition(;
             name = :save_end,
             type = Bool,
-            default = Options.NotProvided,
+            default = Core.NotProvided,
             description = "Whether to force saving the final timepoint.",
         ),
         Strategies.OptionDefinition(;

--- a/src/Common/Common.jl
+++ b/src/Common/Common.jl
@@ -15,6 +15,7 @@ module Common
 # ==============================================================================
 
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+import CTBase.Core
 
 # ==============================================================================
 # Includes
@@ -28,7 +29,6 @@ include(joinpath(@__DIR__, "internal_norm.jl"))
 # Module exports
 # ==============================================================================
 
-export NotProvided
 export ODEParameters, variable
 export __variable, __unsafe, __hvf_inplace, __variable_costate
 export deepvalue, real_norm

--- a/src/Common/default.jl
+++ b/src/Common/default.jl
@@ -3,34 +3,16 @@
 # =============================================================================
 
 """
-$(TYPEDEF)
-
-Sentinel type indicating that a variable parameter was not provided.
-
-Used as the default value for the `variable` keyword argument in flow calls
-to distinguish between "user did not provide a variable" and "user explicitly
-passed `nothing`". This enables proper dispatch based on the system's
-`VariableDependence` trait.
-
-# Example
-```julia
-# Default value for variable parameter
-__variable()::NotProvided = NotProvided()
-```
-
-See also: [`CTBase.Traits.VariableDependence`](@ref), [`CTBase.Traits.Fixed`](@ref), [`CTBase.Traits.NonFixed`](@ref).
-"""
-struct NotProvided end
-
-"""
 $(TYPEDSIGNATURES)
 
 Default value for variable parameter in user-facing API calls.
 
-Returns `NotProvided()` by default, meaning the variable parameter is optional
-unless required by the system's trait (e.g., NonFixed systems).
+Returns [`CTBase.Core.NotProvided`](@ref) by default, meaning the variable parameter
+is optional unless required by the system's trait (e.g., NonFixed systems).
+
+See also: [`CTBase.Traits.VariableDependence`](@ref), [`CTBase.Traits.Fixed`](@ref), [`CTBase.Traits.NonFixed`](@ref).
 """
-__variable()::NotProvided = NotProvided()
+__variable()::Core.NotProvidedType = Core.NotProvided
 
 """
 $(TYPEDSIGNATURES)

--- a/src/DifferentialGeometry/DifferentialGeometry.jl
+++ b/src/DifferentialGeometry/DifferentialGeometry.jl
@@ -21,17 +21,12 @@ module DifferentialGeometry
 
 import ADTypes
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+import CTBase.Core
 import CTBase.Data
 import CTBase.Differentiation
 import CTBase.Exceptions
 import CTBase.Traits
 import MacroTools: postwalk, @capture
-
-# ==============================================================================
-# Internal sibling-submodule imports
-# ==============================================================================
-
-import ..Common: Common
 
 # ==============================================================================
 # Include files (in dependency order)

--- a/src/DifferentialGeometry/ad.jl
+++ b/src/DifferentialGeometry/ad.jl
@@ -12,7 +12,7 @@ The time dependence and variable dependence are inferred from the `is_autonomous
 # Arguments
 - `X::Function`: Vector field function (returns a vector).
 - `foo::Function`: Scalar or vector field function.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 - `is_autonomous::Bool`: Whether the functions are time-independent (default: from global config).
 - `is_variable::Bool`: Whether the functions depend on a variable parameter (default: from global config).
 
@@ -39,7 +39,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref), [`CTFlows.DifferentialGeome
 """
 function ad(
     X::Function, foo::Function;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
     is_autonomous::Bool = Data.__is_autonomous(),
     is_variable::Bool   = Data.__is_variable(),
 )
@@ -64,7 +64,7 @@ This typed entry point is used by the [`@Lie`](@ref) macro for compile-time disp
 - `foo::Function`: Scalar or vector field function.
 - `::Type{TD}`: Time dependence type (`Autonomous` or `NonAutonomous`).
 - `::Type{VD}`: Variable dependence type ([`CTBase.Traits.Fixed`](@ref) or [`CTBase.Traits.NonFixed`](@ref)).
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - A function with signature depending on TD/VD:
@@ -91,7 +91,7 @@ See also: [`CTFlows.DifferentialGeometry.ad(X::Function, foo::Function)`](@ref),
 function ad(
     X::Function, foo::Function,
     ::Type{TD}, ::Type{VD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD <: Traits.TimeDependence, VD <: Traits.VariableDependence}
     backend = _resolve_backend(ad_backend)
     return _ad(X, foo, backend, TD, VD)

--- a/src/DifferentialGeometry/ad_types.jl
+++ b/src/DifferentialGeometry/ad_types.jl
@@ -71,7 +71,7 @@ Both vector fields must share the same time dependence and variable dependence.
 # Arguments
 - `X::Data.AbstractVectorField{TD, VD, MDX}`: First vector field.
 - `Y::Data.AbstractVectorField{TD, VD, MDY}`: Second vector field.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - `Data.VectorField{TD, VD, Traits.OutOfPlace}`: The Lie bracket as a vector field.
@@ -98,7 +98,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref)
 function ad(
     X::Data.AbstractVectorField{TD, VD, MDX},
     Y::Data.AbstractVectorField{TD, VD, MDY};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD, MDX, MDY}
     _check_not_hvf(X); _check_not_hvf(Y)
     _check_outofplace(MDX)    # static dispatch on type parameter — no runtime call
@@ -118,7 +118,7 @@ Returns a plain function representing the directional derivative `∇f(x)'*X(x)`
 # Arguments
 - `X::Data.AbstractVectorField{TD, VD, MDX}`: Vector field.
 - `f::Function`: Scalar function.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - A function with signature depending on TD/VD that returns a scalar.
@@ -145,7 +145,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref)
 function ad(
     X::Data.AbstractVectorField{TD, VD, MDX},
     f::Function;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD, MDX}
     _check_not_hvf(X)
     _check_outofplace(MDX)    # static dispatch
@@ -164,7 +164,7 @@ dependence types, which is not allowed for the Lie bracket operation.
 # Arguments
 - `X::Data.AbstractVectorField{TD1, VD1, MDX}`: First vector field.
 - `Y::Data.AbstractVectorField{TD2, VD2, MDY}`: Second vector field with mismatched TD/VD.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend (unused).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend (unused).
 
 # Throws
 - `Exceptions.PreconditionError`: Always thrown with details about the TD/VD mismatch.
@@ -178,7 +178,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref)
 function ad(
     X::Data.AbstractVectorField{TD1, VD1, MDX},
     Y::Data.AbstractVectorField{TD2, VD2, MDY};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD1, VD1, MDX, TD2, VD2, MDY}
     throw(Exceptions.PreconditionError(
         "ad: TD/VD mismatch between X and Y";
@@ -203,7 +203,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson`](@ref)
 """
 function ad(
     ::Data.AbstractHamiltonian, ::Data.AbstractHamiltonian;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "ad is not defined for AbstractHamiltonian operands";
@@ -222,7 +222,7 @@ Error method for Hamiltonian as first operand in Lie bracket.
 """
 function ad(
     ::Data.AbstractHamiltonian, ::Any;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "ad is not defined for AbstractHamiltonian operands";
@@ -242,7 +242,7 @@ where the second argument is a Hamiltonian and the first is some other type.
 # Arguments
 - `::Any`: First operand.
 - `::Data.AbstractHamiltonian`: Hamiltonian second operand (not allowed in Lie bracket).
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend (unused).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend (unused).
 
 # Throws
 - `Exceptions.IncorrectArgument`: Always thrown with suggestion to use Poisson bracket.
@@ -251,7 +251,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson`](@ref)
 """
 function ad(
     ::Any, ::Data.AbstractHamiltonian;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "ad is not defined for AbstractHamiltonian operands";

--- a/src/DifferentialGeometry/default.jl
+++ b/src/DifferentialGeometry/default.jl
@@ -9,7 +9,7 @@ in DifferentialGeometry operations. When returned, the global backend
 `DG_AD_BACKEND` is used instead.
 
 # Returns
-- `Common.NotProvided`: Sentinel value indicating backend should use global default.
+- `Core.NotProvided` (singleton `Core.NotProvidedType`): sentinel indicating backend should use global default.
 
 # Notes
 - This is an internal function used by [`CTFlows.DifferentialGeometry._resolve_backend`](@ref).
@@ -17,7 +17,7 @@ in DifferentialGeometry operations. When returned, the global backend
 
 See also: [`CTFlows.DifferentialGeometry.DG_AD_BACKEND`](@ref), [`CTFlows.DifferentialGeometry._resolve_backend`](@ref).
 """
-__dg_ad_backend()::Common.NotProvided = Common.NotProvided()
+__dg_ad_backend()::Core.NotProvidedType = Core.NotProvided
 
 # Global default backend ref — built once at module load
 """
@@ -103,12 +103,12 @@ If `NotProvided`, returns the global backend. If an ADTypes backend,
 builds a fresh backend from the ADType.
 
 # Arguments
-- `::Common.NotProvided`: Sentinel value indicating no backend specified.
+- `::Core.NotProvidedType`: Sentinel value indicating no backend specified.
 - `ad_backend::ADTypes.AbstractADType`: ADTypes backend type to build.
 
 # Returns
 - `Differentiation.AbstractADBackend`: The resolved backend.
 """
-_resolve_backend(::Common.NotProvided) = DG_AD_BACKEND[]
+_resolve_backend(::Core.NotProvidedType) = DG_AD_BACKEND[]
 _resolve_backend(ad_backend::ADTypes.AbstractADType) = Differentiation.build_ad_backend(; ad_backend = ad_backend)
 

--- a/src/DifferentialGeometry/poisson.jl
+++ b/src/DifferentialGeometry/poisson.jl
@@ -10,7 +10,7 @@ The time dependence and variable dependence are inferred from the `is_autonomous
 # Arguments
 - `H::Function`: First Hamiltonian function (returns a scalar).
 - `G::Function`: Second Hamiltonian function (returns a scalar).
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 - `is_autonomous::Bool`: Whether the functions are time-independent (default: from global config).
 - `is_variable::Bool`: Whether the functions depend on a variable parameter (default: from global config).
 
@@ -36,7 +36,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson`](@ref), [`CTFlows.Differential
 """
 function Poisson(
     H::Function, G::Function;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
     is_autonomous::Bool = Data.__is_autonomous(),
     is_variable::Bool   = Data.__is_variable(),
 )
@@ -59,7 +59,7 @@ This typed entry point is used by the [`@Lie`](@ref) macro for compile-time disp
 - `G::Function`: Second Hamiltonian function (returns a scalar).
 - `::Type{TD}`: Time dependence type (`Autonomous` or `NonAutonomous`).
 - `::Type{VD}`: Variable dependence type ([`CTBase.Traits.Fixed`](@ref) or [`CTBase.Traits.NonFixed`](@ref)).
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - A function with signature depending on TD/VD.
@@ -81,7 +81,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson(H::Function, G::Function)`](@re
 function Poisson(
     H::Function, G::Function,
     ::Type{TD}, ::Type{VD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD}
     backend = _resolve_backend(ad_backend)
     return _Poisson(H, G, backend, TD, VD)
@@ -190,7 +190,7 @@ Both Hamiltonians must share the same time dependence and variable dependence.
 # Arguments
 - `H::Data.AbstractHamiltonian{TD, VD}`: First Hamiltonian.
 - `G::Data.AbstractHamiltonian{TD, VD}`: Second Hamiltonian.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - `Data.Hamiltonian{TD, VD}`: The Poisson bracket as a Hamiltonian.
@@ -213,7 +213,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson(H::Function, G::Function)`](@re
 function Poisson(
     H::Data.AbstractHamiltonian{TD, VD},
     G::Data.AbstractHamiltonian{TD, VD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD}
     backend = _resolve_backend(ad_backend)
     closure = _Poisson(H, G, backend, TD, VD)
@@ -231,7 +231,7 @@ dependence types, which is not allowed for the Poisson bracket operation.
 # Arguments
 - `H::Data.AbstractHamiltonian{TD1, VD1}`: First Hamiltonian.
 - `G::Data.AbstractHamiltonian{TD2, VD2}`: Second Hamiltonian with mismatched TD/VD.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend (unused).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend (unused).
 
 # Throws
 - `Exceptions.PreconditionError`: Always thrown with details about the TD/VD mismatch.
@@ -245,7 +245,7 @@ See also: [`CTFlows.DifferentialGeometry.Poisson`](@ref)
 function Poisson(
     H::Data.AbstractHamiltonian{TD1, VD1},
     G::Data.AbstractHamiltonian{TD2, VD2};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD1, VD1, TD2, VD2}
     throw(Exceptions.PreconditionError(
         "Poisson: TD/VD mismatch between H and G";
@@ -270,7 +270,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref)
 """
 function Poisson(
     ::Data.AbstractVectorField, ::Data.AbstractVectorField;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "Poisson is not defined for AbstractVectorField operands";
@@ -289,7 +289,7 @@ Error method for VectorField as first operand in Poisson bracket.
 """
 function Poisson(
     ::Data.AbstractVectorField, ::Any;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "Poisson is not defined for AbstractVectorField operands";
@@ -309,7 +309,7 @@ where the second argument is a VectorField and the first is some other type.
 # Arguments
 - `::Any`: First operand.
 - `::Data.AbstractVectorField`: VectorField second operand (not allowed in Poisson bracket).
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend (unused).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend (unused).
 
 # Throws
 - `Exceptions.IncorrectArgument`: Always thrown with suggestion to use Lie bracket.
@@ -318,7 +318,7 @@ See also: [`CTFlows.DifferentialGeometry.ad`](@ref)
 """
 function Poisson(
     ::Any, ::Data.AbstractVectorField;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     throw(Exceptions.IncorrectArgument(
         "Poisson is not defined for AbstractVectorField operands";

--- a/src/DifferentialGeometry/time_derivative.jl
+++ b/src/DifferentialGeometry/time_derivative.jl
@@ -23,7 +23,7 @@ The input function must accept time as its first argument.
 
 # Arguments
 - `f::Function`: Function that takes time as the first argument.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - A [`TimeDeriv_F`](@ref) callable `(t, args...) -> ∂f/∂t(t, args...)`.
@@ -42,7 +42,7 @@ See also: [`CTFlows.DifferentialGeometry.∂ₜ`](@ref)
 """
 function ∂ₜ(
     f::Function;
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 )
     backend = _resolve_backend(ad_backend)
     return TimeDeriv_F{typeof(f), typeof(backend)}(f, backend)
@@ -58,7 +58,7 @@ For autonomous vector fields, the derivative is zero.
 
 # Arguments
 - `X::Data.AbstractHamiltonianVectorField{TD, VD, MD}`: Hamiltonian vector field.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - `Data.HamiltonianVectorField{Traits.NonAutonomous, VD, Traits.OutOfPlace}`: Time derivative.
@@ -82,7 +82,7 @@ See also: [`CTFlows.DifferentialGeometry.∂ₜ`](@ref)
 """
 function ∂ₜ(
     X::Data.AbstractHamiltonianVectorField{TD, VD, MD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD, MD}
     _check_outofplace(MD)
     backend = _resolve_backend(ad_backend)
@@ -139,7 +139,7 @@ For autonomous vector fields, the derivative is zero.
 
 # Arguments
 - `X::Data.AbstractVectorField{TD, VD, MD}`: Vector field.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - `Data.VectorField{Traits.NonAutonomous, VD, Traits.OutOfPlace}`: Time derivative.
@@ -163,7 +163,7 @@ See also: [`CTFlows.DifferentialGeometry.∂ₜ`](@ref)
 """
 function ∂ₜ(
     X::Data.AbstractVectorField{TD, VD, MD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD, MD}
     _check_outofplace(MD)
     backend = _resolve_backend(ad_backend)
@@ -206,7 +206,7 @@ For autonomous Hamiltonians, the derivative is zero.
 
 # Arguments
 - `H::Data.AbstractHamiltonian{TD, VD}`: Hamiltonian.
-- `ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided}`: AD backend to use (default: global backend).
+- `ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType}`: AD backend to use (default: global backend).
 
 # Returns
 - `Data.Hamiltonian{Traits.NonAutonomous, VD}`: Time derivative.
@@ -227,7 +227,7 @@ See also: [`CTFlows.DifferentialGeometry.∂ₜ`](@ref)
 """
 function ∂ₜ(
     H::Data.AbstractHamiltonian{TD, VD};
-    ad_backend::Union{ADTypes.AbstractADType, Common.NotProvided} = __dg_ad_backend(),
+    ad_backend::Union{ADTypes.AbstractADType, Core.NotProvidedType} = __dg_ad_backend(),
 ) where {TD, VD}
     backend = _resolve_backend(ad_backend)
     closure = _∂ₜ_ham(H, backend, TD, VD)

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -199,7 +199,7 @@ flow_nonfixed = Flow(system_nonfixed, integrator)
 sol = _invoke_flow(flow_nonfixed, config; variable=0.5, unsafe=false)  # OK, variable provided
 \`\`\`
 
-See also: [`CTFlows.Flows.AbstractFlow`](@ref), [`CTBase.Traits.VariableDependence`](), [`CTFlows.Common.NotProvided`](@ref), [`CTFlows.Integrators.build_problem`](@ref), [`CTFlows.Integrators.solve_problem`](@ref), [`CTFlows.Trajectories.build_trajectory`](@ref).
+See also: [`CTFlows.Flows.AbstractFlow`](@ref), [`CTBase.Traits.VariableDependence`](), [`CTBase.Core.NotProvided`](@ref), [`CTFlows.Integrators.build_problem`](@ref), [`CTFlows.Integrators.solve_problem`](@ref), [`CTFlows.Trajectories.build_trajectory`](@ref).
 """
 function _invoke_flow(flow::Flows.AbstractFlow, config::Configs.AbstractConfig; variable, unsafe)
     VD = Traits.variable_dependence(flow)
@@ -278,9 +278,9 @@ the contract that NonFixed systems must receive a variable parameter.
 - `CTBase.Exceptions.PreconditionError`: Always, with message explaining that a variable is required.
 
 # See also
-[`CTBase.Traits.NonFixed`](), [`Common.NotProvided`](@ref).
+[`CTBase.Traits.NonFixed`](), [`CTBase.Core.NotProvided`](@ref).
 """
-function _invoke_flow(::Type{Traits.NonFixed}, ::Type{Common.NotProvided}, flow, config; unsafe, variable)
+function _invoke_flow(::Type{Traits.NonFixed}, ::Type{Core.NotProvidedType}, flow, config; unsafe, variable)
     throw(Exceptions.PreconditionError(
         "variable not provided for a NonFixed flow";
         reason    = "flow depends on an extra variable parameter but none was given",
@@ -302,9 +302,9 @@ forwards to `_core_invoke_flow` with `variable=nothing`.
 - The result of `_core_invoke_flow`.
 
 # See also
-[`CTBase.Traits.Fixed`](), [`Common.NotProvided`](@ref), [`_core_invoke_flow`](@ref).
+[`CTBase.Traits.Fixed`](), [`CTBase.Core.NotProvided`](@ref), [`_core_invoke_flow`](@ref).
 """
-function _invoke_flow(::Type{Traits.Fixed}, ::Type{Common.NotProvided}, flow, config; unsafe, variable)
+function _invoke_flow(::Type{Traits.Fixed}, ::Type{Core.NotProvidedType}, flow, config; unsafe, variable)
     return _core_invoke_flow(flow, config; variable=nothing, unsafe=unsafe)
 end
 
@@ -461,11 +461,11 @@ but the user did not provide the required variable parameter.
 # Throws
 - `CTBase.Exceptions.PreconditionError`: Always, with a descriptive message indicating that the variable parameter must be provided.
 
-See also: [`CTBase.Traits.SupportsVariableCostate`](@ref), [`CTFlows.Common.NotProvided`](@ref).
+See also: [`CTBase.Traits.SupportsVariableCostate`](@ref), [`CTBase.Core.NotProvided`](@ref).
 """
 function _invoke_flow_variable_costate(
     ::Type{Traits.SupportsVariableCostate},
-    ::Type{Common.NotProvided},
+    ::Type{Core.NotProvidedType},
     flow::AbstractHamiltonianFlow,
     config::Configs.HamiltonianEndPointConfig; variable, unsafe
 )

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -102,7 +102,7 @@ integrator(F::OptimalControlFlow) = integrator(F.flow)
 
 function (F::OptimalControlFlow)(
     t0::Real, x0, p0, tf::Real;
-    variable          = Common.NotProvided(),
+    variable          = Core.NotProvided,
     variable_costate::Bool = false,
     unsafe::Bool           = false,
 )
@@ -113,7 +113,7 @@ end
 
 function (F::OptimalControlFlow)(
     tspan::Tuple{<:Real, <:Real}, x0, p0;
-    variable = Common.NotProvided(),
+    variable = Core.NotProvided,
     unsafe::Bool = false,
 )
     sol = F.flow(tspan, x0, p0; variable, unsafe)   # HamiltonianVectorFieldTrajectory
@@ -124,7 +124,7 @@ end
 # Solution helpers
 # =============================================================================
 
-_variable_vector(::Common.NotProvided)  = Float64[]
+_variable_vector(::Core.NotProvidedType)  = Float64[]
 _variable_vector(v::Number)             = [Float64(v)]
 _variable_vector(v::AbstractVector)     = Float64.(v)
 

--- a/test/suite/common/test_common_module.jl
+++ b/test/suite/common/test_common_module.jl
@@ -30,7 +30,6 @@ const CurrentModule = TestCommonModule
 # For other modules, create similar lists with their specific exports.
 
 const EXPORTED_TYPES = (
-    :NotProvided,
     :ODEParameters,
 )
 
@@ -120,10 +119,6 @@ function test_common_module()
         # ====================================================================
 
         Test.@testset "Type hierarchy" begin
-            Test.@testset "NotProvided is concrete" begin
-                Test.@test !isabstracttype(Common.NotProvided)
-            end
-
             Test.@testset "ODEParameters is concrete" begin
                 Test.@test !isabstracttype(Common.ODEParameters)
             end

--- a/test/suite/common/test_default.jl
+++ b/test/suite/common/test_default.jl
@@ -3,6 +3,7 @@ module TestDefault
 import Test
 import CTBase.Data
 import CTFlows.Common
+import CTBase.Core
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -28,7 +29,7 @@ function test_default()
             end
 
             Test.@testset "__variable returns NotProvided" begin
-                Test.@test Common.__variable() isa Common.NotProvided
+                Test.@test Common.__variable() isa Core.NotProvidedType
             end
 
             Test.@testset "__unsafe returns false" begin
@@ -44,14 +45,10 @@ function test_default()
             end
         end
 
-        Test.@testset "NotProvided type" begin
-            Test.@testset "NotProvided is a concrete type" begin
-                Test.@test Common.NotProvided <: Any
-            end
-
-            Test.@testset "NotProvided is exported" begin
-                Test.@test isdefined(Common, :NotProvided)
-            end
+        Test.@testset "NotProvided sentinel (lives in CTBase.Core)" begin
+            Test.@test Core.NotProvidedType <: Any
+            Test.@test isdefined(Core, :NotProvided)
+            Test.@test !isdefined(Common, :NotProvided)
         end
 
         Test.@testset "__variable_costate export" begin

--- a/test/suite/differential_geometry/test_macro_helpers_dg.jl
+++ b/test/suite/differential_geometry/test_macro_helpers_dg.jl
@@ -6,7 +6,7 @@ import CTBase: CTBase  # for Exceptions prefix in @Lie macro
 import CTBase.Exceptions
 import CTFlows: CTFlows
 import CTBase.Traits
-import CTFlows.Common
+import CTBase.Core
 import CTBase.Data
 import CTFlows.DifferentialGeometry
 import MacroTools: @capture
@@ -224,7 +224,7 @@ function test_macro_helpers_dg()
     Test.@testset "_lie_mac" verbose=VERBOSE showtiming=SHOWTIMING begin
         vf1 = _vf(_f1, Traits.Autonomous, Traits.Fixed)
         vf2 = _vf(_f2, Traits.Autonomous, Traits.Fixed)
-        backend = Common.NotProvided()
+        backend = Core.NotProvided
 
         # Function + Function → VectorField
         r = DifferentialGeometry._lie_mac(
@@ -292,7 +292,7 @@ function test_macro_helpers_dg()
     Test.@testset "_poisson_mac" verbose=VERBOSE showtiming=SHOWTIMING begin
         ham1 = _ham(_h1, Traits.Autonomous, Traits.Fixed)
         ham2 = _ham(_h2, Traits.Autonomous, Traits.Fixed)
-        backend = Common.NotProvided()
+        backend = Core.NotProvided
 
         # Function + Function → Hamiltonian
         r = DifferentialGeometry._poisson_mac(

--- a/test/suite/flows/test_calling_flows.jl
+++ b/test/suite/flows/test_calling_flows.jl
@@ -8,6 +8,7 @@ import CTFlows.Flows
 import CTFlows.Integrators
 import CTFlows.Trajectories
 import CTFlows.Common
+import CTBase.Core
 import CTFlows.Configs
 import CTBase.Traits
 import ADTypes
@@ -182,7 +183,7 @@ function test_calling_flows()
                 config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
                 
                 # Execute
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
                 
                 # Verify all steps were called
                 Test.@test integ.build_problem_called === true
@@ -209,7 +210,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -224,7 +225,7 @@ function test_calling_flows()
                 config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
                 # Call with unsafe=true
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=true)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=true)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -238,7 +239,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -252,7 +253,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -272,7 +273,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -288,7 +289,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -302,7 +303,7 @@ function test_calling_flows()
                 flow = FakeFlowForCalling(sys, integ)
                 config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
-                result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+                result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
                 Test.@test integ.build_problem_called === true
                 Test.@test integ.build_options_called === true
@@ -322,7 +323,7 @@ function test_calling_flows()
             flow = FakeFlowForCalling(sys, integ)
             config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
-            result = Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+            result = Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
 
             Test.@test integ.build_problem_called === true
             Test.@test integ.build_options_called === true
@@ -359,7 +360,7 @@ function test_calling_flows()
             flow = FakeFlowForCalling(sys, integ)
             config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 
-            Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(flow, config; variable=Common.NotProvided(), unsafe=false)
+            Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(flow, config; variable=Core.NotProvided, unsafe=false)
         end
 
         # ====================================================================


### PR DESCRIPTION
## Summary

CTBase 0.25 moves `NotProvided`/`NotProvidedType` to `CTBase.Core` and removes them from `CTBase.Options`. CTFlows now consumes the canonical `Core` sentinel **directly, with no re-export alias**:

- `CTFlows.Common`: local `struct NotProvided end` deleted; **no `import/export NotProvided`**. `CTFlows.Common.NotProvided` / `NotProvidedType` no longer exist. `__variable()` returns `Core.NotProvided`.
- `Flows/calling.jl` + `optimal_control_flow.jl`: dispatch on `Core.NotProvidedType`, defaults use `Core.NotProvided`.
- `DifferentialGeometry`: AD-backend sentinel → `Core.NotProvidedType`; dropped now-unused `import ..Common`.
- SciML extensions (`problem_flow`, integrator `strategies`) → `Core.NotProvided`; dropped now-unused `Options`/`Common` imports.
- Tests repointed to `Core`; `NotProvided` removed from `Common`'s expected-exports lists.

## Dependencies

- Bump CTBase compat to `0.25`.

## Test plan

- [x] Full CTFlows suite green against dev-linked CTBase 0.25.0-beta + CTModels 0.13.3-beta

> Depends on CTBase #468 (merged), CTModels #349 released to ct-registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)