### PR TITLE
fix(flows): dispatch Flow(ocp) on control dependence; harden dispatch tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0-beta] - 2026-06-28
+
+### Fixed
+
+- **`Flow(ocp::CTModels.Models.Model)` now dispatches on control dependence.** Previously the
+  constructor matched *any* model and silently built a Hamiltonian flow even for problems with a
+  control input (ignoring the control — a latent correctness bug). It now re-dispatches on the
+  `CTBase.Traits.ControlDependence` trait: a control-free OCP builds the flow as before, while a
+  with-control OCP throws a descriptive `CTBase.Exceptions.PreconditionError` (the control-law /
+  PMP path is not built here).
+
+### Changed
+
+- **Hardened the closed dispatch tables in `Flows/calling.jl`.** Added catch-all fallbacks for
+  unforeseen `VariableDependence` and variable-costate capability trait values, so an unexpected
+  tag yields a clean `PreconditionError` instead of a raw `MethodError`.
+
+### Tests
+
+- Added with-control and catch-all fallback tests.
+- **Made the AD extension trigger explicit:** added `import ForwardDiff` to the test files that use
+  an `AutoForwardDiff` backend (so `DifferentiationInterfaceForwardDiff`, which provides the fast
+  pushforward path, loads when a file is run in isolation rather than relying on test-run order).
+
+### Dependencies
+
+- Bump CTBase compat to `0.26` (adds the `ControlDependence` trait family) and CTModels compat to
+  `0.14` (implements the trait on `Model`). Requires CTLie ≥ `0.1.1` (widened CTBase compat).
+
 ## [0.9.4-beta] - 2026-06-26
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.9.5-beta"
+version = "0.10.0-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -29,9 +29,9 @@ CTFlowsStaticArrays = ["StaticArrays"]
 [compat]
 ADTypes = "1"
 Aqua = "0.8"
-CTBase = "0.25"
-CTLie = "0.1"
-CTModels = "0.13"
+CTBase = "0.26"
+CTLie = "0.1.1"
+CTModels = "0.14"
 DiffEqBase = "6, 7"
 DifferentiationInterface = "0.7"
 DocStringExtensions = "0.9"

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -120,11 +120,17 @@ end
 """
 $(TYPEDSIGNATURES)
 
-High-level constructor for an `OptimalControlFlow` from a control-free OCP.
+High-level constructor for an `OptimalControlFlow` from an optimal control problem.
 
-Builds a Hamiltonian flow directly from a `CTModels.Models.Model` with control
-dimension 0, exploiting the OCP structure: state equation ẋ = f(t,x,∅,v) is
-computed exactly (no AD), and only ṗ = −∂H/∂x uses automatic differentiation.
+Dispatches on the problem's [`CTBase.Traits.ControlDependence`](@extref) trait:
+
+- **control-free** (`ControlFree`): builds a Hamiltonian flow directly from the OCP,
+  exploiting the structure — the state equation `ẋ = f(t,x,∅,v)` is computed exactly
+  (no AD) and only `ṗ = −∂H/∂x` uses automatic differentiation.
+- **with control** (`WithControl`): currently unsupported — throws a
+  [`CTBase.Exceptions.PreconditionError`](@extref). Closing the loop would require a
+  control law `u(t,x,p)` from the maximisation of the pseudo-Hamiltonian, which this
+  path does not build.
 
 # Arguments
 - `ocp::CTModels.Models.Model`: The optimal control problem model.
@@ -132,13 +138,21 @@ computed exactly (no AD), and only ṗ = −∂H/∂x uses automatic differentia
   (same as `Flow(h::Data.AbstractHamiltonian; kwargs...)`).
 
 # Returns
-- `OptimalControlFlow`: Wraps an inner `HamiltonianFlow` and exposes:
+- `OptimalControlFlow` (control-free case): Wraps an inner `HamiltonianFlow` and exposes:
   - Point eval: `f(t0, x0, p0, tf; variable, variable_costate, unsafe)`
   - Trajectory: `f((t0,tf), x0, p0; variable)` → `CTModels.Solution`
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): If the OCP carries a control input.
 
 See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), [`CTFlows.Flows.Flow`](@ref).
 """
 function Flow(ocp::CTModels.Models.Model; kwargs...)
+    return _flow_from_ocp(Traits.control_dependence(ocp), ocp; kwargs...)
+end
+
+# control-free OCP → build the Hamiltonian flow directly
+function _flow_from_ocp(::Type{Traits.ControlFree}, ocp::CTModels.Models.Model; kwargs...)
     routed     = _route_flow_options(kwargs)
     components = _build_flow_components(routed)
     h          = _ocp_hamiltonian(ocp)
@@ -147,13 +161,26 @@ function Flow(ocp::CTModels.Models.Model; kwargs...)
     return OptimalControlFlow(inner, ocp)
 end
 
+# with-control OCP → not supported on this path
+function _flow_from_ocp(::Type{Traits.WithControl}, ::CTModels.Models.Model; kwargs...)
+    throw(Exceptions.PreconditionError(
+        "Flow from a with-control OCP is not supported";
+        reason     = "this path builds the flow from the OCP structure assuming no control " *
+                     "(ẋ = f(t,x,∅,v)); a problem with a control input would require a control " *
+                     "law u(t,x,p) from the maximisation of the pseudo-Hamiltonian",
+        suggestion = "build the Hamiltonian flow yourself from a control law, e.g. " *
+                     "Flow(Hamiltonian(...)), or use a control-free OCP",
+        context    = "Flow(ocp::CTModels.Models.Model) — control-dependence dispatch",
+    ))
+end
+
 function Flow(::CTModels.Models.Model, ::Any, args...; kwargs...)
     throw(Exceptions.PreconditionError(
-        "Flow(ocp, …) with extra positional arguments is not supported for control-free OCPs";
-        reason     = "this OCP is control-free (EmptyControlModel); passing a control law, " *
-                     "state constraint or multiplier is not handled by this path",
-        suggestion = "call Flow(ocp; kwargs…) — the control-free flow takes no control argument",
-        context    = "Flow(ocp::CTModels.Models.Model) — control-free guard",
+        "Flow(ocp, …) with extra positional arguments is not supported";
+        reason     = "passing a control law, state constraint or multiplier as a positional " *
+                     "argument is not handled by the OCP flow constructor",
+        suggestion = "call Flow(ocp; kwargs…) — the OCP flow takes no positional argument beyond the model",
+        context    = "Flow(ocp::CTModels.Models.Model) — positional-argument guard",
     ))
 end
 

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -351,6 +351,29 @@ function _invoke_flow(::Type{Traits.Fixed}, ::Type{VT}, flow, config; unsafe, va
     ))
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Catch-all fallback for an unforeseen `VariableDependence` trait value.
+
+The four overloads above form a dispatch table that is exhaustive for the closed set
+`{Fixed, NonFixed}`. This fallback exists only so a hypothetical third tag fails with a
+clean [`CTBase.Exceptions.PreconditionError`](@extref) instead of a raw `MethodError`.
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): Always.
+"""
+function _invoke_flow(
+    VD::Type{<:Traits.VariableDependence}, ::Type{VT}, flow, config; unsafe, variable
+) where {VT}
+    throw(Exceptions.PreconditionError(
+        "unsupported variable-dependence trait $(VD)";
+        reason     = "the flow reports a variable-dependence trait outside the supported set {Fixed, NonFixed}",
+        suggestion = "build the flow from a system whose variable_dependence is Fixed or NonFixed",
+        context    = "call — unknown VariableDependence tag",
+    ))
+end
+
 # ==============================================================================
 # _invoke_flow_variable_costate — augmented Hamiltonian integration
 # ==============================================================================
@@ -502,5 +525,32 @@ function _invoke_flow_variable_costate(
         reason     = "Variable costate computation is only implemented for point configurations, not full trajectories",
         suggestion = "Use variable_costate=true with a point configuration (t0, x0, p0, tf) instead of a trajectory configuration (tspan, x0, p0)",
         context    = "HamiltonianFlow call with variable_costate=true and HamiltonianTrajectoryConfig",
+    ))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Catch-all fallback for an unforeseen variable-costate capability trait value.
+
+The overloads above form a dispatch table that is exhaustive for the closed set
+`{SupportsVariableCostate, NoVariableCostate}`. This fallback exists only so a
+hypothetical third capability tag fails with a clean
+[`CTBase.Exceptions.PreconditionError`](@extref) instead of a raw `MethodError`.
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): Always.
+"""
+function _invoke_flow_variable_costate(
+    cap::Type{<:Traits.AbstractVariableCostateCapability},
+    ::Type{VT},
+    flow::AbstractHamiltonianFlow,
+    config::Configs.AbstractHamiltonianConfig; variable, unsafe
+) where {VT}
+    throw(Exceptions.PreconditionError(
+        "unsupported variable-costate capability trait $(cap)";
+        reason     = "the flow reports a variable-costate capability outside the supported set {SupportsVariableCostate, NoVariableCostate}",
+        suggestion = "build the flow from a Hamiltonian system whose variable_costate_trait is one of the supported values",
+        context    = "HamiltonianFlow call with variable_costate=true — unknown capability tag",
     ))
 end

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -24,6 +24,7 @@ import CTFlows: CTFlows
 import CTFlows.Flows: Flows
 import CTFlows.Systems: Systems
 import CTFlows.Integrators: Integrators
+import CTFlows.Configs: Configs
 import CTBase.Differentiation
 import CTBase.Data: Data
 import CTBase.Traits: Traits
@@ -32,6 +33,7 @@ using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface as DI
+import ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 
 const CTFlowsSciMLIntegrator = Base.get_extension(CTFlows, :CTFlowsSciMLIntegrator)
 const CTBaseDifferentiationInterface = Base.get_extension(CTBase, :CTBaseDifferentiationInterface)
@@ -105,11 +107,28 @@ function _build_ocp_nonauton_fixed_mayer()
     return CTModels.Building.build(pre)
 end
 
+# with-control OCP (control! called) → WithControl trait, unsupported by Flow(ocp)
+function _build_ocp_with_control()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, u, _) -> (r[1] = u[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(_, x, u, _) -> u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# Fake closed-set trait tags for catch-all fallback tests (module top-level)
+struct FakeVariableDependence <: Traits.VariableDependence end
+struct FakeCostateCapability <: Traits.AbstractVariableCostateCapability end
+
 const OCP_AF_MAYER   = _build_ocp_auton_fixed_mayer()
 const OCP_AF_LAG     = _build_ocp_auton_fixed_lagrange()
 const OCP_AF_BOLZA   = _build_ocp_auton_fixed_bolza()
 const OCP_ANF_MAYER  = _build_ocp_auton_nonfixed_mayer()
 const OCP_NAF_MAYER  = _build_ocp_nonauton_fixed_mayer()
+const OCP_WITH_CTRL  = _build_ocp_with_control()
 
 # Pre-built flows (all via generic HamiltonianSystem — OCP rides the generic path)
 const FLOW_AF    = Flows.build_flow(
@@ -360,11 +379,51 @@ function test_optimal_control_flow()
                 err = e
             end
             Test.@test err isa Exceptions.PreconditionError
-            Test.@test occursin("control-free", err.msg)
+            Test.@test occursin("positional argument", err.msg)
         end
 
-        Test.@testset "Error: Flow(ocp, g, μ) — control-free guard (extra args)" begin
+        Test.@testset "Error: Flow(ocp, g, μ) — positional-arg guard (extra args)" begin
             Test.@test_throws Exceptions.PreconditionError Flows.Flow(OCP_AF_MAYER, identity, identity; alg=Tsit5())
+        end
+
+        # =====================================================================
+        # Control-dependence dispatch
+        # =====================================================================
+
+        Test.@testset "Dispatch: control-free OCP is ControlFree" begin
+            Test.@test Traits.control_dependence(OCP_AF_MAYER) === Traits.ControlFree
+            Test.@test Flows.Flow(OCP_AF_MAYER; alg=Tsit5()) isa Flows.OptimalControlFlow
+        end
+
+        Test.@testset "Error: Flow(with-control OCP) → PreconditionError" begin
+            Test.@test Traits.control_dependence(OCP_WITH_CTRL) === Traits.WithControl
+            err = nothing
+            try
+                Flows.Flow(OCP_WITH_CTRL; alg=Tsit5())
+            catch e
+                err = e
+            end
+            Test.@test err isa Exceptions.PreconditionError
+            Test.@test occursin("with-control", err.msg)
+        end
+
+        # =====================================================================
+        # Closed dispatch-table catch-all fallbacks
+        # =====================================================================
+
+        Test.@testset "Error: unknown VariableDependence tag → PreconditionError" begin
+            Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow(
+                FakeVariableDependence, Nothing, nothing, nothing;
+                unsafe=false, variable=nothing,
+            )
+        end
+
+        Test.@testset "Error: unknown variable-costate capability tag → PreconditionError" begin
+            config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
+            Test.@test_throws Exceptions.PreconditionError Flows._invoke_flow_variable_costate(
+                FakeCostateCapability, Nothing, FLOW_AF, config;
+                variable=nothing, unsafe=false,
+            )
         end
 
     end

--- a/test/suite/flows/test_calling_flows.jl
+++ b/test/suite/flows/test_calling_flows.jl
@@ -13,6 +13,7 @@ import CTFlows.Configs
 import CTBase.Traits
 import ADTypes
 import DifferentiationInterface
+import ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 import CTBase.Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/flows/test_hamiltonian_getter_flows.jl
+++ b/test/suite/flows/test_hamiltonian_getter_flows.jl
@@ -3,6 +3,7 @@ module TestHamiltonianGetterFlows
 import Test
 import ADTypes
 import DifferentiationInterface
+import ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 import CTFlows.Common
 import CTBase.Traits
 import CTBase.Data

--- a/test/suite/integration/test_goddard.jl
+++ b/test/suite/integration/test_goddard.jl
@@ -6,6 +6,7 @@ import CTLie: CTLie
 import CTFlows.Flows
 import CTFlows.Trajectories
 import DifferentiationInterface
+import ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearSolve, NonlinearProblem, SimpleNewtonRaphson, solve
 

--- a/test/suite/systems/test_hamiltonian_getter.jl
+++ b/test/suite/systems/test_hamiltonian_getter.jl
@@ -3,6 +3,7 @@ module TestHamiltonianGetter
 import Test
 import ADTypes
 import DifferentiationInterface
+import ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 import CTFlows.Common
 import CTBase.Traits
 import CTBase.Data


### PR DESCRIPTION
## Summary

**PR3** of the ecosystem-wide control-dependence rollout (CTBase → CTModels → CTFlows). Fixes a latent correctness bug in `Flow(ocp)` and hardens the trait dispatch tables.

### What changed

1. **`Flow(ocp::CTModels.Models.Model)` now dispatches on control dependence** (`src/Flows/building.jl`):
   - Before: matched *any* model and silently built a Hamiltonian flow even for problems **with a control input**, ignoring the control — a latent correctness bug.
   - After: re-dispatches on the `CTBase.Traits.ControlDependence` trait (Holy-trait pattern, like `_invoke_flow`):
     - **control-free** → builds the Hamiltonian flow as before
     - **with control** → throws a descriptive `PreconditionError` (the control-law / PMP path is not built here)

2. **Hardened the closed dispatch tables** (`src/Flows/calling.jl`): added catch-all fallbacks for unforeseen `VariableDependence` and variable-costate capability tags, so an unexpected tag yields a clean `PreconditionError` instead of a raw `MethodError`.

3. **Tests**: with-control → `PreconditionError`, both catch-all fallbacks, and control-free dispatch.

4. **Test robustness — explicit AD extension trigger**: added `import ForwardDiff` to the 5 test files that build an `AutoForwardDiff` backend. Without it, `DifferentiationInterfaceForwardDiff` (which provides the fast pushforward path) only loaded if another test file imported ForwardDiff first — so running a file in isolation errored with `_prepare_pushforward_aux ... PushforwardFast` MethodErrors. Now each AD test file is self-contained.

5. **Dependencies**: CTBase `0.26`, CTModels `0.14`, CTLie `0.1.1`; version `0.9.5-beta` → `0.10.0-beta`.

### Verification

- **Full CTFlows suite: 2210+ pass, exit 0** (including Aqua).

### Cross-repo ordering ⚠️

Depends on:
- CTBase 0.26.0-beta (merged, `ControlDependence` trait)
- CTModels 0.14.0-beta (merged, trait on `Model`)
- **CTLie ≥ 0.1.1-beta** — see control-toolbox/CTLie.jl#10 (widens CTBase compat). CTLie 0.1.1-beta must be registered before this PR's CI can resolve.

### Behavioural note

`Flow(ocp)` on a **with-control** OCP now throws instead of returning a wrong flow. This is a fix (the previous result was incorrect), but it is an observable behaviour change for any code that relied on the old (buggy) path.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)