### PR TITLE
refactor: enforce "1-D = scalar" convention for Hamiltonian/OCP flows

### DIFF
--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -494,7 +494,7 @@ function _invoke_flow_variable_costate(
     t0 = Configs.initial_time(config)
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
-    pv0 = Core.make_coerce(variable)(zeros(eltype(x0), length(variable)))
+    pv0 = Systems._coerce_state(variable)(zeros(eltype(x0), length(variable)))
     tf = Configs.final_time(config)
     config_aug = Configs.AugmentedHamiltonianEndPointConfig(t0, x0, p0, pv0, tf)
     return _invoke_flow(flow, config_aug; variable=variable, unsafe=unsafe)

--- a/src/Systems/hamiltonian_system.jl
+++ b/src/Systems/hamiltonian_system.jl
@@ -123,8 +123,8 @@ function get_ip_rhs(sys::HamiltonianSystem, config::Configs.AbstractHamiltonianC
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
     N = _state_dim(x0)
-    cx = Core.make_coerce(x0)
-    cp = Core.make_coerce(p0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
     h, backend = sys.h, sys.backend
     return HamIpRHS(h, backend, N, cx, cp)
 end
@@ -149,8 +149,8 @@ function get_oop_rhs(sys::HamiltonianSystem, config::Configs.AbstractHamiltonian
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
     N = _state_dim(x0)
-    cx = Core.make_coerce(x0)
-    cp = Core.make_coerce(p0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
     h, backend = sys.h, sys.backend
     return HamOoPRHS(h, backend, N, cx, cp)
 end
@@ -179,8 +179,8 @@ function get_ip_rhs_augmented(
     n_x = _state_dim(x0)
     pv0 = Configs.initial_variable_costate(config)
     n_v = _state_dim(pv0)
-    cx = Core.make_coerce(x0)
-    cp = Core.make_coerce(p0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
     h, backend = sys.h, sys.backend
     return HamIpAugRHS(h, backend, n_x, n_v, cx, cp)
 end

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -74,6 +74,34 @@ _state_dim(::Number) = 1
 _state_dim(x::AbstractVector) = length(x)
 _state_dim(x::AbstractMatrix) = size(x, 1)
 
+"""
+    _coerce_state(::Number) = only
+    _coerce_state(::AbstractMatrix) = identity
+    _coerce_state(x::AbstractVector) = length(x) == 1 ? only : identity
+
+Return the coercion applied to a 1-D quantity (state, costate, variable costate)
+of a **Hamiltonian/OCP flow** so that it is represented as a **scalar** when it has
+length 1, and left untouched otherwise.
+
+This enforces the ecosystem convention *"a 1-dimensional quantity is a scalar"* for
+the control-theoretic layer: both `2.0` and `[2.0]` collapse to the scalar `2.0`
+via `only`, regardless of how the user supplied the initial condition. Vectors of
+length ≥ 2 and matrices (batch mode) are left untouched via `identity`.
+
+Scope: applied only on Hamiltonian paths (`HamiltonianSystem`,
+`HamiltonianVectorFieldSystem`, augmented variable-costate, and the
+`HamiltonianDynamics` trajectory builders). **State-only flows** (bare
+`VectorField`, SciMLBase ODE adapters) stay shape-preserving via
+`CTBase.Core.make_coerce`, because a raw ODE state carries no 1-D control
+convention — the user's array is the contract there.
+
+Differs from `CTBase.Core.make_coerce` only in that a length-1 vector collapses to
+a scalar (`only`) instead of being kept as a 1-vector (`identity`).
+"""
+_coerce_state(::Number) = only
+_coerce_state(::AbstractMatrix) = identity
+_coerce_state(x::AbstractVector) = length(x) == 1 ? only : identity
+
 # =============================================================================
 # Internal helpers for split/assign (dispatch on array type)
 # =============================================================================
@@ -230,7 +258,7 @@ function get_ip_rhs(
 ) where {F,TD,VD}
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
-    return IPHVFOoPRHS(sys.hvf, _state_dim(x0), Core.make_coerce(x0), Core.make_coerce(p0))
+    return IPHVFOoPRHS(sys.hvf, _state_dim(x0), _coerce_state(x0), _coerce_state(p0))
 end
 
 """
@@ -255,7 +283,7 @@ function get_ip_rhs(
 ) where {F,TD,VD}
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
-    return IPHVFIpRHS(sys.hvf, _state_dim(x0), Core.make_coerce(x0), Core.make_coerce(p0))
+    return IPHVFIpRHS(sys.hvf, _state_dim(x0), _coerce_state(x0), _coerce_state(p0))
 end
 
 """
@@ -280,7 +308,7 @@ function get_oop_rhs(
 ) where {F,TD,VD}
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
-    return OoPHVFOoPRHS(sys.hvf, _state_dim(x0), Core.make_coerce(x0), Core.make_coerce(p0))
+    return OoPHVFOoPRHS(sys.hvf, _state_dim(x0), _coerce_state(x0), _coerce_state(p0))
 end
 
 """
@@ -312,10 +340,10 @@ function get_oop_rhs(
     if !ismutable(x0)
         @warn "InPlace HamiltonianVectorField with immutable u0 (e.g. SVector): consider using an out-of-place function for better performance."
         return OoPHVFIpFinalizeRHS(
-            sys.hvf, _state_dim(x0), Core.make_coerce(x0), Core.make_coerce(p0)
+            sys.hvf, _state_dim(x0), _coerce_state(x0), _coerce_state(p0)
         )
     end
-    return OoPHVFIpRHS(sys.hvf, _state_dim(x0), Core.make_coerce(x0), Core.make_coerce(p0))
+    return OoPHVFIpRHS(sys.hvf, _state_dim(x0), _coerce_state(x0), _coerce_state(p0))
 end
 
 """
@@ -343,7 +371,7 @@ function get_ip_rhs_augmented(
     n_x = _state_dim(x0)
     pv0 = Configs.initial_variable_costate(config)
     n_v = _state_dim(pv0)
-    return IPHVFOoPAugRHS(sys.hvf, n_x, n_v, Core.make_coerce(x0), Core.make_coerce(p0))
+    return IPHVFOoPAugRHS(sys.hvf, n_x, n_v, _coerce_state(x0), _coerce_state(p0))
 end
 
 """
@@ -371,7 +399,7 @@ function get_ip_rhs_augmented(
     n_x = _state_dim(x0)
     pv0 = Configs.initial_variable_costate(config)
     n_v = _state_dim(pv0)
-    return IPHVFIpAugRHS(sys.hvf, n_x, n_v, Core.make_coerce(x0), Core.make_coerce(p0))
+    return IPHVFIpAugRHS(sys.hvf, n_x, n_v, _coerce_state(x0), _coerce_state(p0))
 end
 
 # =============================================================================

--- a/src/Trajectories/building.jl
+++ b/src/Trajectories/building.jl
@@ -30,6 +30,10 @@ function build_trajectory(
     result::Integrators.AbstractIntegrationResult,
     variable=Core.NotProvided,
 )
+    # State-only flows (bare VectorField, SciMLBase ODE adapters) are shape-preserving:
+    # the user's array is the contract, so a length-1 vector round-trips as a length-1
+    # vector (`make_coerce`). The "1-D = scalar" collapse applies only to Hamiltonian/OCP
+    # flows (costate/control semantics), handled by the HamiltonianDynamics methods below.
     return Core.make_coerce(Configs.initial_state(config))(Integrators.final_state(result))
 end
 
@@ -86,9 +90,9 @@ For Hamiltonian systems, `n_p = n_x` always, so the augmented state is `[x; p; p
 function _aug_split_solution(u, x0, pv0)
     n = length(x0)
     return (
-        Core.make_coerce(x0)(u[1:n]),
-        Core.make_coerce(x0)(u[(n + 1):2n]),
-        Core.make_coerce(pv0)(u[(2n + 1):end]),
+        Systems._coerce_state(x0)(u[1:n]),
+        Systems._coerce_state(x0)(u[(n + 1):2n]),
+        Systems._coerce_state(pv0)(u[(2n + 1):end]),
     )
 end
 
@@ -128,7 +132,7 @@ function build_trajectory(
     u = Integrators.final_state(result)
     x0 = Configs.initial_state(config)
     x, p = _ham_split_solution(u, x0)
-    return (Core.make_coerce(x0)(x), Core.make_coerce(x0)(p))
+    return (Systems._coerce_state(x0)(x), Systems._coerce_state(x0)(p))
 end
 
 """

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -204,16 +204,16 @@ function test_optimal_control_flow()
             Test.@test pf isa Number
         end
 
-        Test.@testset "Unit: xf/pf shape — vector inputs → AbstractVector" begin
+        Test.@testset "Unit: xf/pf shape — length-1 vector inputs → Number" begin
+            # 1-D = scalar: a length-1 vector initial condition collapses to a scalar
+            # output (via `only`), regardless of how the user supplied it.
             t0, tf = 0.0, 0.5
             x0, p0 = [1.0], [1.0]
             xf, pf = FLOW_AF(t0, x0, p0, tf)
-            Test.@test xf isa AbstractVector
-            Test.@test length(xf) == 1
-            Test.@test pf isa AbstractVector
-            Test.@test length(pf) == 1
-            Test.@test xf[1] ≈ _x_ref(tf, t0, x0[1]) atol=ATOL
-            Test.@test pf[1] ≈ _p_ref(tf, t0, p0[1]) atol=ATOL
+            Test.@test xf isa Number
+            Test.@test pf isa Number
+            Test.@test xf ≈ _x_ref(tf, t0, x0[1]) atol=ATOL
+            Test.@test pf ≈ _p_ref(tf, t0, p0[1]) atol=ATOL
         end
 
         # ── point eval, NonFixed/Autonomous ──────────────────────────────────
@@ -249,13 +249,13 @@ function test_optimal_control_flow()
             Test.@test pvf[1] ≈ _pv_ref(tf, t0, x0, p0) atol=ATOL
         end
 
-        Test.@testset "Unit: pvf shape — vector variable → AbstractVector" begin
+        Test.@testset "Unit: pvf shape — length-1 vector variable → Number" begin
+            # 1-D = scalar: a length-1 variable yields a scalar variable costate.
             t0, tf = 0.0, 0.5
             xf, pf, pvf = FLOW_ANF(
                 t0, 1.0, 1.0, tf; variable=[λ_TEST], variable_costate=true
             )
-            Test.@test pvf isa AbstractVector
-            Test.@test length(pvf) == 1
+            Test.@test pvf isa Number
         end
 
         Test.@testset "Unit: pvf shape — scalar variable → Number" begin

--- a/test/suite/flows/test_variable_costate_flows.jl
+++ b/test/suite/flows/test_variable_costate_flows.jl
@@ -75,7 +75,9 @@ end
 # Analytical solution: x(t) = x0 + p0 * (t-t0) / sum(v), p(t) = p0, pv(t) = pv0 - sum(p0^2) * (t-t0) / (2 * sum(v)^2)
 H_LINEAR(x, p, v) = sum(abs2, p) / (2 * sum(v))
 function solve_linear(t, t0, x0, p0, v)
-    pv0 = Core.make_coerce(v)(zeros(length(v)))
+    # Align the reference costate shape with the "1-D = scalar" convention:
+    # a length-1 variable yields a scalar variable costate (like the flow).
+    pv0 = Systems._coerce_state(v)(zeros(length(v)))
     dt = t - t0
     sv = sum(v)
     x = x0 .+ p0 .* (dt / sv)
@@ -298,7 +300,7 @@ function test_variable_costate_flows()
                 hflow = Flows.build_flow(HSYS_DI, INTEG)
                 t0, tf = 0.0, 1.0
                 x0, p0 = 1.0, 2.0
-                v = [3.0] # TODO: should work with a scalar.
+                v = [3.0] # length-1 variable → scalar variable costate (1-D = scalar)
                 xf, pf, pvf = hflow(t0, x0, p0, tf; variable=v, variable_costate=true)
 
                 # Analytical solution
@@ -306,7 +308,7 @@ function test_variable_costate_flows()
 
                 Test.@test xf isa Real
                 Test.@test pf isa Real
-                # Test.@test pvf isa Real
+                Test.@test pvf isa Real
                 Test.@test xf ≈ xf_ref atol=ATOL
                 Test.@test pf ≈ pf_ref atol=ATOL
                 Test.@test pvf ≈ pvf_ref atol=ATOL


### PR DESCRIPTION
## Summary

This PR enforces the ecosystem convention **"a 1-dimensional quantity is a scalar"** on all Hamiltonian/OCP flow paths.

## Changes

### New helper: `Systems._coerce_state`

Added in `src/Systems/hamiltonian_vector_field_system.jl`:

- `_coerce_state(::Number) = only`
- `_coerce_state(::AbstractMatrix) = identity`
- `_coerce_state(x::AbstractVector) = length(x) == 1 ? only : identity`

This differs from `CTBase.Core.make_coerce` only in that a **length-1 vector collapses to a scalar** (`only`) instead of being kept as a 1-vector (`identity`).

### Where it replaces `CTBase.Core.make_coerce`

All Hamiltonian paths now use `_coerce_state` instead of `Core.make_coerce`:

- `src/Systems/hamiltonian_system.jl` — `get_ip_rhs`, `get_oop_rhs`, `get_ip_rhs_augmented`
- `src/Systems/hamiltonian_vector_field_system.jl` — all `get_ip_rhs` / `get_oop_rhs` / `get_ip_rhs_augmented` methods
- `src/Trajectories/building.jl` — `_aug_split_solution`, `build_trajectory` (HamiltonianDynamics methods)
- `src/Flows/calling.jl` — `_invoke_flow_variable_costate`

### Where `CTBase.Core.make_coerce` is kept (unchanged)

**State-only flows** (bare `VectorField`, SciMLBase ODE adapters) remain shape-preserving via `CTBase.Core.make_coerce`, because a raw ODE state carries no 1-D control convention — the user's array is the contract there. This is documented with a comment in `src/Trajectories/building.jl`.

### Test updates

- `test/suite/extensions/test_optimal_control_flow.jl`: length-1 vector inputs now expect `Number` outputs (scalar collapse).
- `test/suite/flows/test_variable_costate_flows.jl`: reference costate shape aligned with the new convention; previously commented-out `pvf isa Real` assertion re-enabled.

## Rationale

Both `2.0` and `[2.0]` should collapse to the scalar `2.0` via `only`, regardless of how the user supplied the initial condition. Vectors of length ≥ 2 and matrices (batch mode) are left untouched via `identity`.