### PR TITLE
feat: PseudoHamiltonianSystem + widen HamiltonianSystem to AbstractHamiltonian (Phase B)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ CTFlowsStaticArrays = ["StaticArrays"]
 [compat]
 ADTypes = "1"
 Aqua = "0.8"
-CTBase = "0.26"
+CTBase = "0.26.2"
 CTLie = "0.1.1"
 CTModels = "0.14"
 CTSolvers = "0.4"

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -36,9 +36,11 @@ include(joinpath(@__DIR__, "abstract_system.jl"))
 include(joinpath(@__DIR__, "rhs_functors.jl"))
 include(joinpath(@__DIR__, "hvf_rhs_functors.jl"))
 include(joinpath(@__DIR__, "hamiltonian_rhs_functors.jl"))
+include(joinpath(@__DIR__, "pseudo_hamiltonian_rhs_functors.jl"))
 include(joinpath(@__DIR__, "vector_field_system.jl"))
 include(joinpath(@__DIR__, "hamiltonian_vector_field_system.jl"))
 include(joinpath(@__DIR__, "hamiltonian_system.jl"))
+include(joinpath(@__DIR__, "pseudo_hamiltonian_system.jl"))
 include(joinpath(@__DIR__, "building.jl"))
 include(joinpath(@__DIR__, "hamiltonian_getter.jl"))
 
@@ -51,6 +53,8 @@ export AbstractSystem, AbstractStateSystem, AbstractHamiltonianSystem
 export AbstractRHS, AbstractIPRHS, AbstractOoPRHS
 export AbstractHVFRHS, AbstractIPHVFRHS, AbstractOoPHVFRHS
 export AbstractHamRHS, AbstractIPHamRHS, AbstractOoPHamRHS
+export AbstractPseudoHamRHS, AbstractIPPseudoHamRHS, AbstractOoPPseudoHamRHS
+export PseudoHamIpRHS, PseudoHamOoPRHS, PseudoHamIpAugRHS
 export get_ip_rhs
 export get_oop_rhs
 export get_ip_rhs_augmented
@@ -58,7 +62,9 @@ export hamiltonian_vector_field
 export VectorFieldSystem
 export HamiltonianVectorFieldSystem
 export HamiltonianSystem
+export PseudoHamiltonianSystem
 export build_system
 export hamiltonian, backend
+export pseudo_hamiltonian, control_law
 
 end # module Systems

--- a/src/Systems/building.jl
+++ b/src/Systems/building.jl
@@ -110,7 +110,33 @@ HamiltonianSystem
 See also: [`CTBase.Data.Hamiltonian`](@extref), [`CTFlows.Systems.HamiltonianSystem`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref), [`CTBase.Differentiation.AbstractADBackend`](@extref).
 """
 function build_system(
-    h::Data.AbstractHamiltonian, backend::Differentiation.AbstractADBackend
+    h::Data.AbstractHamiltonian,
+    backend::Differentiation.AbstractADBackend,
 )
     return HamiltonianSystem(h, backend)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref) from a pseudo-Hamiltonian
+`H̃(t,x,p,u,v)`, a dynamic closed-loop control law `u(t,x,p,v)`, and an AD backend.
+
+The resulting system integrates `ẋ = ∂H̃/∂p`, `ṗ = -∂H̃/∂x` with the control held fixed
+at the feedback value `u = u(t,x,p,v)` during differentiation (the `:partial` mode).
+
+# Arguments
+- `h̃::Data.PseudoHamiltonian`: the pseudo-Hamiltonian.
+- `law::Data.ControlLaw`: the control law; must carry `DynClosedLoopFeedback`.
+- `backend::Differentiation.AbstractADBackend`: the AD backend.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref),
+[`CTBase.Data.PseudoHamiltonian`](@extref), [`CTBase.Data.ComposedHamiltonian`](@extref).
+"""
+function build_system(
+    h̃::Data.PseudoHamiltonian,
+    law::Data.ControlLaw{<:Function,Traits.DynClosedLoopFeedback},
+    backend::Differentiation.AbstractADBackend,
+)
+    return PseudoHamiltonianSystem(h̃, law, backend)
 end

--- a/src/Systems/hamiltonian_rhs_functors.jl
+++ b/src/Systems/hamiltonian_rhs_functors.jl
@@ -82,7 +82,7 @@ gradient in-place, following the canonical Hamiltonian equations:
 ```
 
 # Fields
-- `h::Data.Hamiltonian{F,TD,VD}`: The Hamiltonian function.
+- `h::H`: The Hamiltonian function (any `Data.AbstractHamiltonian`).
 - `backend::B`: The AD backend for gradient computation.
 - `N::Int`: State dimension (number of state variables).
 - `cx::CX`: State conversion function.
@@ -105,18 +105,23 @@ gradient in-place, following the canonical Hamiltonian equations:
 
 See also: [`CTFlows.Systems.HamOoPRHS`](@ref), [`CTFlows.Systems.HamIpAugRHS`](@ref).
 """
-struct HamIpRHS{F,TD,VD,B,CX,CP} <: AbstractIPHamRHS
-    h::Data.Hamiltonian{F,TD,VD}
+struct HamIpRHS{H<:Data.AbstractHamiltonian,B,CX,CP} <: AbstractIPHamRHS
+    h::H
     backend::B
     N::Int
     cx::CX
     cp::CP
 end
 
-function (f::HamIpRHS{F,TD,VD,B,CX,CP})(du, u, λ, t) where {F,TD,VD,B,CX,CP}
+function (f::HamIpRHS)(du, u, λ, t)
     x, p = _ham_split(u, f.N)
     ∂x, ∂p = Differentiation.hamiltonian_gradient(
-        f.backend, f.h, t, f.cx(x), f.cp(p), variable(λ)
+        f.backend,
+        f.h,
+        t,
+        f.cx(x),
+        f.cp(p),
+        variable(λ),
     )
     _ham_assign!(du, ∂p, -∂x, f.N)
     return nothing
@@ -136,7 +141,7 @@ gradient out-of-place, following the canonical Hamiltonian equations:
 ```
 
 # Fields
-- `h::Data.Hamiltonian{F,TD,VD}`: The Hamiltonian function.
+- `h::H`: The Hamiltonian function (any `Data.AbstractHamiltonian`).
 - `backend::B`: The AD backend for gradient computation.
 - `N::Int`: State dimension (number of state variables).
 - `cx::CX`: State conversion function.
@@ -159,18 +164,23 @@ gradient out-of-place, following the canonical Hamiltonian equations:
 
 See also: [`CTFlows.Systems.HamIpRHS`](@ref), [`CTFlows.Systems.HamIpAugRHS`](@ref).
 """
-struct HamOoPRHS{F,TD,VD,B,CX,CP} <: AbstractOoPHamRHS
-    h::Data.Hamiltonian{F,TD,VD}
+struct HamOoPRHS{H<:Data.AbstractHamiltonian,B,CX,CP} <: AbstractOoPHamRHS
+    h::H
     backend::B
     N::Int
     cx::CX
     cp::CP
 end
 
-function (f::HamOoPRHS{F,TD,VD,B,CX,CP})(u, λ, t) where {F,TD,VD,B,CX,CP}
+function (f::HamOoPRHS)(u, λ, t)
     x, p = _ham_split(u, f.N)
     ∂x, ∂p = Differentiation.hamiltonian_gradient(
-        f.backend, f.h, t, f.cx(x), f.cp(p), variable(λ)
+        f.backend,
+        f.h,
+        t,
+        f.cx(x),
+        f.cp(p),
+        variable(λ),
     )
     return vcat(∂p, -∂x)
 end
@@ -206,9 +216,9 @@ function _check_aug_batch_compat(u::AbstractMatrix, v::AbstractMatrix)
         throw(
             Exceptions.PreconditionError(
                 "batch size mismatch in augmented Hamiltonian RHS";
-                reason="size(u, 2) = $(size(u, 2)) ≠ size(v, 2) = $(size(v, 2))",
-                context="HamIpAugRHS — matrix batch mode",
-                suggestion="variable v must have the same number of columns as the state u",
+                reason = "size(u, 2) = $(size(u, 2)) ≠ size(v, 2) = $(size(v, 2))",
+                context = "HamIpAugRHS — matrix batch mode",
+                suggestion = "variable v must have the same number of columns as the state u",
             ),
         )
     end
@@ -247,7 +257,7 @@ costate evolution, used in sensitivity analysis and optimal control:
 The state vector is augmented as `[x; p; v]` where `v` is the variable costate.
 
 # Fields
-- `h::Data.Hamiltonian{F,TD,VD}`: The Hamiltonian function.
+- `h::H`: The Hamiltonian function (any `Data.AbstractHamiltonian`).
 - `backend::B`: The AD backend for gradient computation.
 - `n_x::Int`: State dimension (number of state variables).
 - `n_v::Int`: Variable dimension.
@@ -270,8 +280,8 @@ The state vector is augmented as `[x; p; v]` where `v` is the variable costate.
 
 See also: [`CTFlows.Systems.HamIpRHS`](@ref), [`CTFlows.Systems.HamOoPRHS`](@ref).
 """
-struct HamIpAugRHS{F,TD,VD,B,CX,CP} <: AbstractIPHamRHS
-    h::Data.Hamiltonian{F,TD,VD}
+struct HamIpAugRHS{H<:Data.AbstractHamiltonian,B,CX,CP} <: AbstractIPHamRHS
+    h::H
     backend::B
     n_x::Int
     n_v::Int
@@ -279,7 +289,7 @@ struct HamIpAugRHS{F,TD,VD,B,CX,CP} <: AbstractIPHamRHS
     cp::CP
 end
 
-function (f::HamIpAugRHS{F,TD,VD,B,CX,CP})(du, u, λ, t) where {F,TD,VD,B,CX,CP}
+function (f::HamIpAugRHS)(du, u, λ, t)
     v = variable(λ)
     _check_aug_batch_compat(u, v)
     x, p, _ = _aug_split(u, f.n_x, f.n_v)
@@ -317,10 +327,15 @@ function Base.show(io::IO, f::AbstractHamRHS)
     td = Traits.time_dependence(f.h)
     vd = Traits.variable_dependence(f.h)
     wraps = "Hamiltonian: $(Data._td_label(td)), $(Data._vd_label(vd))"
-    Display.print_header(io, nameof(typeof(f)); fmt=fmt)
-    Display.print_field(io, "wraps", wraps; fmt=fmt, value_style="")
+    Display.print_header(io, nameof(typeof(f)); fmt = fmt)
+    Display.print_field(io, "wraps", wraps; fmt = fmt, value_style = "")
     return Display.print_field(
-        io, "converts", _rhs_conversion_label(f); last=true, fmt=fmt, value_style=""
+        io,
+        "converts",
+        _rhs_conversion_label(f);
+        last = true,
+        fmt = fmt,
+        value_style = "",
     )
 end
 

--- a/src/Systems/hamiltonian_system.jl
+++ b/src/Systems/hamiltonian_system.jl
@@ -13,13 +13,16 @@ types, ensuring correct handling of scalar, vector (including length-1), and mat
 inputs with consistent output shapes.
 
 # Type Parameters
-- `F`: concrete type of the wrapped Hamiltonian function.
 - `TD <: TimeDependence`: `Autonomous` or `NonAutonomous`.
 - `VD <: VariableDependence`: `Fixed` or `NonFixed`.
+- `H <: AbstractHamiltonian{TD, VD}`: concrete Hamiltonian type. Any
+  `CTBase.Data.AbstractHamiltonian` is accepted, including a
+  `CTBase.Data.ComposedHamiltonian` (a pseudo-Hamiltonian composed with a control law),
+  so the AD path differentiates *through* the control law.
 - `BACKEND <: AbstractADBackend`: concrete AD backend type.
 
 # Fields
-- `h::Hamiltonian{F, TD, VD}`: the underlying scalar Hamiltonian function.
+- `h::H`: the underlying scalar Hamiltonian function.
 - `backend::BACKEND`: the AD backend for gradient computation.
 
 # Example
@@ -40,12 +43,12 @@ HamiltonianSystem
 See also: [`CTBase.Data.Hamiltonian`](@extref), [`CTFlows.Systems.AbstractHamiltonianSystem`](@ref), [`CTBase.Traits.AbstractADTrait`](@extref), `build_rhs`, `build_oop_rhs`.
 """
 struct HamiltonianSystem{
-    F<:Function,
     TD<:Traits.TimeDependence,
     VD<:Traits.VariableDependence,
+    H<:Data.AbstractHamiltonian{TD,VD},
     BACKEND<:Differentiation.AbstractADBackend,
 } <: AbstractHamiltonianSystem{TD,VD}
-    h::Data.Hamiltonian{F,TD,VD}
+    h::H
     backend::BACKEND
 end
 
@@ -90,9 +93,10 @@ end
 # =============================================================================
 
 function HamiltonianSystem(
-    h::Data.Hamiltonian{F,TD,VD}, backend::Differentiation.AbstractADBackend
-) where {F,TD,VD}
-    return HamiltonianSystem{F,TD,VD,typeof(backend)}(h, backend)
+    h::Data.AbstractHamiltonian{TD,VD},
+    backend::Differentiation.AbstractADBackend,
+) where {TD,VD}
+    return HamiltonianSystem{TD,VD,typeof(h),typeof(backend)}(h, backend)
 end
 
 # =============================================================================
@@ -172,7 +176,8 @@ Lazy implementation: reads `x0`/`p0`/`pv0` from the config to build the augmente
 See also: [`CTFlows.Systems.get_ip_rhs`](@ref), [`CTFlows.Systems.get_oop_rhs`](@ref).
 """
 function get_ip_rhs_augmented(
-    sys::HamiltonianSystem, config::Configs.AbstractAugmentedHamiltonianConfig
+    sys::HamiltonianSystem,
+    config::Configs.AbstractAugmentedHamiltonianConfig,
 )
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
@@ -204,24 +209,29 @@ Display a Hamiltonian system in a human-readable format.
 """
 function Base.show(io::IO, sys::HamiltonianSystem)
     fmt = Display.format_codes(io)
-    Display.print_header(io, "HamiltonianSystem"; fmt=fmt)
+    Display.print_header(io, "HamiltonianSystem"; fmt = fmt)
     Display.print_field(
         io,
         "time_dependence",
         nameof(Traits.time_dependence(sys));
-        fmt=fmt,
-        value_style=fmt.type,
+        fmt = fmt,
+        value_style = fmt.type,
     )
     Display.print_field(
         io,
         "variable_dependence",
         nameof(Traits.variable_dependence(sys));
-        fmt=fmt,
-        value_style=fmt.type,
+        fmt = fmt,
+        value_style = fmt.type,
     )
-    Display.print_field(io, "", sys.h; fmt=fmt, value_style="")
+    Display.print_field(io, "", sys.h; fmt = fmt, value_style = "")
     return Display.print_field(
-        io, "backend", sys.backend; last=true, fmt=fmt, value_style=""
+        io,
+        "backend",
+        sys.backend;
+        last = true,
+        fmt = fmt,
+        value_style = "",
     )
 end
 
@@ -249,7 +259,7 @@ Return the variable costate capability trait of a variable-dependent Hamiltonian
 See also: [`CTBase.Traits.AbstractVariableCostateCapability`](@extref), [`CTBase.Traits.SupportsVariableCostate`](@extref), [`CTBase.Traits.NoVariableCostate`](@extref).
 """
 function Traits.variable_costate_trait(
-    ::HamiltonianSystem{F,TD,Traits.NonFixed,B}
-) where {F,TD,B}
+    ::HamiltonianSystem{TD,Traits.NonFixed,H,B},
+) where {TD,H,B}
     return Traits.SupportsVariableCostate
 end

--- a/src/Systems/pseudo_hamiltonian_rhs_functors.jl
+++ b/src/Systems/pseudo_hamiltonian_rhs_functors.jl
@@ -1,0 +1,200 @@
+# =============================================================================
+# RHS Functors for PseudoHamiltonianSystem
+#
+# Mirror the HamiltonianSystem functors, but the control is *not* differentiated:
+# the feedback value u = law(t, x, p, v) is evaluated first and then held fixed
+# while `pseudo_hamiltonian_gradient` (and `pseudo_variable_gradient`) take partial
+# derivatives of H̃ at that fixed u. This is the `:partial` mode.
+# =============================================================================
+
+# =============================================================================
+# Abstract hierarchy — subtypes AbstractRHS{T} (mutability), not AbstractHamRHS
+# (whose Base.show assumes a single `h` field; here we carry `h̃` and `law`).
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Abstract supertype for pseudo-Hamiltonian right-hand side (RHS) functors. The type
+parameter encodes the mutability trait (in-place vs out-of-place).
+
+See also: [`CTFlows.Systems.AbstractRHS`](@ref), [`CTFlows.Systems.PseudoHamIpRHS`](@ref).
+"""
+abstract type AbstractPseudoHamRHS{T<:Traits.AbstractMutabilityTrait} <: AbstractRHS{T} end
+
+"""
+$(TYPEDEF)
+
+Abstract supertype for in-place pseudo-Hamiltonian RHS functors.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref).
+"""
+abstract type AbstractIPPseudoHamRHS <: AbstractPseudoHamRHS{Traits.InPlace} end
+
+"""
+$(TYPEDEF)
+
+Abstract supertype for out-of-place pseudo-Hamiltonian RHS functors.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref).
+"""
+abstract type AbstractOoPPseudoHamRHS <: AbstractPseudoHamRHS{Traits.OutOfPlace} end
+
+# =============================================================================
+# Standard functors
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+In-place RHS functor for a `PseudoHamiltonianSystem`. Evaluates the feedback control
+`u = law(t, x, p, v)` and then computes, at that fixed `u`,
+
+```
+ẋ =  ∂H̃/∂p
+ṗ = -∂H̃/∂x
+```
+
+# Fields
+- `h̃::PH`: the pseudo-Hamiltonian `H̃(t, x, p, u, v)`.
+- `law::L`: the dynamic closed-loop control law `u(t, x, p, v)`.
+- `backend::B`: the AD backend.
+- `N::Int`: state dimension.
+- `cx::CX`: state coercion.
+- `cp::CP`: costate coercion.
+
+See also: [`CTFlows.Systems.PseudoHamOoPRHS`](@ref), [`CTFlows.Systems.PseudoHamIpAugRHS`](@ref).
+"""
+struct PseudoHamIpRHS{PH<:Data.PseudoHamiltonian,L<:Data.ControlLaw,B,CX,CP} <:
+       AbstractIPPseudoHamRHS
+    h̃::PH
+    law::L
+    backend::B
+    N::Int
+    cx::CX
+    cp::CP
+end
+
+function (f::PseudoHamIpRHS)(du, u, λ, t)
+    x, p = _ham_split(u, f.N)
+    v = variable(λ)
+    cx, cp = f.cx(x), f.cp(p)
+    u_ = f.law(t, cx, cp, v)   # DynClosedLoop uniform call (t, x, p, v)
+    ∂x, ∂p = Differentiation.pseudo_hamiltonian_gradient(f.backend, f.h̃, t, cx, cp, u_, v)
+    _ham_assign!(du, ∂p, -∂x, f.N)
+    return nothing
+end
+
+"""
+$(TYPEDEF)
+
+Out-of-place RHS functor for a `PseudoHamiltonianSystem`; see
+[`CTFlows.Systems.PseudoHamIpRHS`](@ref) for the computation. Returns `vcat(∂p, -∂x)`.
+
+# Fields
+- `h̃::PH`: the pseudo-Hamiltonian `H̃(t, x, p, u, v)`.
+- `law::L`: the dynamic closed-loop control law `u(t, x, p, v)`.
+- `backend::B`: the AD backend.
+- `N::Int`: state dimension.
+- `cx::CX`: state coercion.
+- `cp::CP`: costate coercion.
+
+See also: [`CTFlows.Systems.PseudoHamIpRHS`](@ref).
+"""
+struct PseudoHamOoPRHS{PH<:Data.PseudoHamiltonian,L<:Data.ControlLaw,B,CX,CP} <:
+       AbstractOoPPseudoHamRHS
+    h̃::PH
+    law::L
+    backend::B
+    N::Int
+    cx::CX
+    cp::CP
+end
+
+function (f::PseudoHamOoPRHS)(u, λ, t)
+    x, p = _ham_split(u, f.N)
+    v = variable(λ)
+    cx, cp = f.cx(x), f.cp(p)
+    u_ = f.law(t, cx, cp, v)
+    ∂x, ∂p = Differentiation.pseudo_hamiltonian_gradient(f.backend, f.h̃, t, cx, cp, u_, v)
+    return vcat(∂p, -∂x)
+end
+
+# =============================================================================
+# Augmented functor (variable costate)
+#
+# ẋ =  ∂H̃/∂p ; ṗ = -∂H̃/∂x ; ṗv = -∂H̃/∂v  (all at fixed u = law(t,x,p,v))
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+In-place augmented RHS functor for a `PseudoHamiltonianSystem` with variable costate.
+Extends [`CTFlows.Systems.PseudoHamIpRHS`](@ref) with `ṗv = -∂H̃/∂v` (control fixed),
+computed by [`CTBase.Differentiation.pseudo_variable_gradient`](@extref). The augmented
+state is `[x; p; pv]`.
+
+# Fields
+- `h̃::PH`: the pseudo-Hamiltonian `H̃(t, x, p, u, v)`.
+- `law::L`: the dynamic closed-loop control law `u(t, x, p, v)`.
+- `backend::B`: the AD backend.
+- `n_x::Int`: state dimension.
+- `n_v::Int`: variable dimension.
+- `cx::CX`: state coercion.
+- `cp::CP`: costate coercion.
+
+See also: [`CTFlows.Systems.PseudoHamIpRHS`](@ref), [`CTFlows.Systems.HamIpAugRHS`](@ref).
+"""
+struct PseudoHamIpAugRHS{PH<:Data.PseudoHamiltonian,L<:Data.ControlLaw,B,CX,CP} <:
+       AbstractIPPseudoHamRHS
+    h̃::PH
+    law::L
+    backend::B
+    n_x::Int
+    n_v::Int
+    cx::CX
+    cp::CP
+end
+
+function (f::PseudoHamIpAugRHS)(du, u, λ, t)
+    v = variable(λ)
+    _check_aug_batch_compat(u, v)
+    x, p, _ = _aug_split(u, f.n_x, f.n_v)
+    cx, cp = f.cx(x), f.cp(p)
+    u_ = f.law(t, cx, cp, v)
+    ∂x, ∂p = Differentiation.pseudo_hamiltonian_gradient(f.backend, f.h̃, t, cx, cp, u_, v)
+    ∂pv = Differentiation.pseudo_variable_gradient(f.backend, f.h̃, t, cx, cp, u_, v)
+    _aug_assign!(du, ∂p, -∂x, -∂pv, f.n_x, f.n_v)
+    return nothing
+end
+
+# =============================================================================
+# Display
+# =============================================================================
+
+_rhs_conversion_label(::PseudoHamIpRHS) = "PseudoHamiltonian AD → in-place interface"
+_rhs_conversion_label(::PseudoHamOoPRHS) = "PseudoHamiltonian AD → out-of-place interface"
+function _rhs_conversion_label(::PseudoHamIpAugRHS)
+    return "PseudoHamiltonian AD → in-place augmented interface"
+end
+
+function Base.show(io::IO, f::AbstractPseudoHamRHS)
+    fmt = Display.format_codes(io)
+    td = Traits.time_dependence(f.h̃)
+    vd = Traits.variable_dependence(f.h̃)
+    wraps = "PseudoHamiltonian: $(Data._td_label(td)), $(Data._vd_label(vd))"
+    Display.print_header(io, nameof(typeof(f)); fmt = fmt)
+    Display.print_field(io, "wraps", wraps; fmt = fmt, value_style = "")
+    return Display.print_field(
+        io,
+        "converts",
+        _rhs_conversion_label(f);
+        last = true,
+        fmt = fmt,
+        value_style = "",
+    )
+end
+
+function Base.show(io::IO, ::MIME"text/plain", f::AbstractPseudoHamRHS)
+    return show(io, f)
+end

--- a/src/Systems/pseudo_hamiltonian_system.jl
+++ b/src/Systems/pseudo_hamiltonian_system.jl
@@ -1,0 +1,222 @@
+# =============================================================================
+# PseudoHamiltonianSystem — Hamiltonian system built from a pseudo-Hamiltonian H̃
+# and a dynamic closed-loop control law u(t,x,p,v), differentiating at fixed u.
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Concrete `AbstractHamiltonianSystem` built from a pseudo-Hamiltonian `H̃(t,x,p,u,v)`
+and a dynamic closed-loop control law `u(t,x,p,v)`. It integrates the Hamiltonian
+system
+
+```
+ẋ =  ∂H̃/∂p ,   ṗ = -∂H̃/∂x
+```
+
+with the control **held fixed** at the feedback value `u = u(t,x,p,v)` during
+differentiation (the `:partial` mode). This coincides with the true Hamiltonian flow
+of [`CTBase.Data.ComposedHamiltonian`](@extref) only where the feedback is stationary
+(`∂H̃/∂u = 0`).
+
+# Type Parameters
+- `TD <: TimeDependence`, `VD <: VariableDependence`: traits of the pseudo-Hamiltonian.
+- `PH <: PseudoHamiltonian`: concrete pseudo-Hamiltonian type.
+- `L <: ControlLaw`: concrete control-law type (`DynClosedLoopFeedback`).
+- `BACKEND <: AbstractADBackend`: concrete AD backend type.
+
+# Fields
+- `h̃::PH`: the pseudo-Hamiltonian.
+- `law::L`: the dynamic closed-loop control law.
+- `backend::BACKEND`: the AD backend.
+
+See also: [`CTFlows.Systems.HamiltonianSystem`](@ref),
+[`CTBase.Data.PseudoHamiltonian`](@extref), [`CTBase.Data.ComposedHamiltonian`](@extref).
+"""
+struct PseudoHamiltonianSystem{
+    TD<:Traits.TimeDependence,
+    VD<:Traits.VariableDependence,
+    PH<:Data.PseudoHamiltonian{<:Function,TD,VD},
+    L<:Data.ControlLaw{<:Function,Traits.DynClosedLoopFeedback},
+    BACKEND<:Differentiation.AbstractADBackend,
+} <: AbstractHamiltonianSystem{TD,VD}
+    h̃::PH
+    law::L
+    backend::BACKEND
+end
+
+Traits.ad_trait(::PseudoHamiltonianSystem) = Traits.WithAD
+
+# =============================================================================
+# Constructor
+# =============================================================================
+
+function PseudoHamiltonianSystem(
+    h̃::Data.PseudoHamiltonian{<:Function,TD,VD},
+    law::Data.ControlLaw{<:Function,Traits.DynClosedLoopFeedback},
+    backend::Differentiation.AbstractADBackend,
+) where {TD,VD}
+    return PseudoHamiltonianSystem{TD,VD,typeof(h̃),typeof(law),typeof(backend)}(
+        h̃,
+        law,
+        backend,
+    )
+end
+
+# =============================================================================
+# Getters
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the pseudo-Hamiltonian `H̃` of a `PseudoHamiltonianSystem`.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref), [`CTFlows.Systems.control_law`](@ref).
+"""
+pseudo_hamiltonian(sys::PseudoHamiltonianSystem) = sys.h̃
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the control law `u(t,x,p,v)` of a `PseudoHamiltonianSystem`.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref), [`CTFlows.Systems.pseudo_hamiltonian`](@ref).
+"""
+control_law(sys::PseudoHamiltonianSystem) = sys.law
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the AD backend of a `PseudoHamiltonianSystem`.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref).
+"""
+backend(sys::PseudoHamiltonianSystem) = sys.backend
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the true Hamiltonian of a `PseudoHamiltonianSystem` — the
+[`CTBase.Data.ComposedHamiltonian`](@extref) `H(t,x,p,v) = H̃(t,x,p,u(t,x,p,v),v)`
+obtained by eliminating the control with the feedback law. Built on the fly.
+
+See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.HamiltonianSystem`](@ref).
+"""
+function hamiltonian(sys::PseudoHamiltonianSystem)
+    return Data.ComposedHamiltonian(sys.h̃, sys.law)
+end
+
+# =============================================================================
+# RHS builders (lazy — read the config to build type-specific functors)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the in-place RHS ([`CTFlows.Systems.PseudoHamIpRHS`](@ref)) for a
+`PseudoHamiltonianSystem`.
+
+See also: [`CTFlows.Systems.get_oop_rhs`](@ref).
+"""
+function get_ip_rhs(sys::PseudoHamiltonianSystem, config::Configs.AbstractHamiltonianConfig)
+    x0 = Configs.initial_state(config)
+    p0 = Configs.initial_costate(config)
+    N = _state_dim(x0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
+    return PseudoHamIpRHS(sys.h̃, sys.law, sys.backend, N, cx, cp)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the out-of-place RHS ([`CTFlows.Systems.PseudoHamOoPRHS`](@ref)) for a
+`PseudoHamiltonianSystem`.
+
+See also: [`CTFlows.Systems.get_ip_rhs`](@ref).
+"""
+function get_oop_rhs(
+    sys::PseudoHamiltonianSystem,
+    config::Configs.AbstractHamiltonianConfig,
+)
+    x0 = Configs.initial_state(config)
+    p0 = Configs.initial_costate(config)
+    N = _state_dim(x0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
+    return PseudoHamOoPRHS(sys.h̃, sys.law, sys.backend, N, cx, cp)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the augmented in-place RHS ([`CTFlows.Systems.PseudoHamIpAugRHS`](@ref)) for a
+`PseudoHamiltonianSystem` with variable costate.
+
+See also: [`CTFlows.Systems.get_ip_rhs`](@ref).
+"""
+function get_ip_rhs_augmented(
+    sys::PseudoHamiltonianSystem,
+    config::Configs.AbstractAugmentedHamiltonianConfig,
+)
+    x0 = Configs.initial_state(config)
+    p0 = Configs.initial_costate(config)
+    n_x = _state_dim(x0)
+    pv0 = Configs.initial_variable_costate(config)
+    n_v = _state_dim(pv0)
+    cx = _coerce_state(x0)
+    cp = _coerce_state(p0)
+    return PseudoHamIpAugRHS(sys.h̃, sys.law, sys.backend, n_x, n_v, cx, cp)
+end
+
+# =============================================================================
+# Trait getters
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+A variable-dependent `PseudoHamiltonianSystem` supports variable-costate integration
+(`ṗv = -∂H̃/∂v` at fixed control), analogous to `HamiltonianSystem`.
+
+See also: [`CTBase.Traits.SupportsVariableCostate`](@extref).
+"""
+function Traits.variable_costate_trait(
+    ::PseudoHamiltonianSystem{TD,Traits.NonFixed,PH,L,B},
+) where {TD,PH,L,B}
+    return Traits.SupportsVariableCostate
+end
+
+# =============================================================================
+# Base.show
+# =============================================================================
+
+function Base.show(io::IO, sys::PseudoHamiltonianSystem)
+    fmt = Display.format_codes(io)
+    Display.print_header(io, "PseudoHamiltonianSystem"; fmt = fmt)
+    Display.print_field(
+        io,
+        "time_dependence",
+        nameof(Traits.time_dependence(sys));
+        fmt = fmt,
+        value_style = fmt.type,
+    )
+    Display.print_field(
+        io,
+        "variable_dependence",
+        nameof(Traits.variable_dependence(sys));
+        fmt = fmt,
+        value_style = fmt.type,
+    )
+    Display.print_field(io, "", sys.h̃; fmt = fmt, value_style = "")
+    Display.print_field(io, "", sys.law; fmt = fmt, value_style = "")
+    return Display.print_field(
+        io,
+        "backend",
+        sys.backend;
+        last = true,
+        fmt = fmt,
+        value_style = "",
+    )
+end

--- a/test/suite/systems/test_pseudo_hamiltonian_system.jl
+++ b/test/suite/systems/test_pseudo_hamiltonian_system.jl
@@ -1,0 +1,156 @@
+module TestPseudoHamiltonianSystem
+
+using Test: Test
+import CTBase.Data: Data
+import CTBase.Traits: Traits
+import CTBase.Differentiation: Differentiation
+import CTFlows.Systems: Systems
+using ADTypes: ADTypes
+using DifferentiationInterface: DifferentiationInterface
+using ForwardDiff: ForwardDiff
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+_backend() =
+    Differentiation.DifferentiationInterface(; ad_backend = ADTypes.AutoForwardDiff())
+
+function test_pseudo_hamiltonian_system()
+    Test.@testset "PseudoHamiltonianSystem Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # UNIT — construction, getters, hamiltonian() returns ComposedHamiltonian
+        # ====================================================================
+
+        Test.@testset "Unit: build_system, getters, hamiltonian()" begin
+            # H̃(x,p,u) = p*(-x+u) + 0.5u² ; law u(x,p) = -p
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * (-x + u) + 0.5 * u^2)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            be = _backend()
+            sys = Systems.build_system(h̃, law, be)
+
+            Test.@test sys isa Systems.PseudoHamiltonianSystem
+            Test.@test sys isa Systems.AbstractHamiltonianSystem
+            Test.@test Systems.pseudo_hamiltonian(sys) === h̃
+            Test.@test Systems.control_law(sys) === law
+            Test.@test Systems.backend(sys) === be
+
+            H = Systems.hamiltonian(sys)
+            Test.@test H isa Data.ComposedHamiltonian
+            # H(x,p) = H̃(x,p,-p) = p*(-x-p) + 0.5p² = -px - 0.5p²
+            Test.@test H(2.0, 3.0) ≈ -3.0 * 2.0 - 0.5 * 3.0^2 atol = 1e-12
+        end
+
+        # ====================================================================
+        # UNIT — RHS functors compute the partial-derivative flow (u fixed)
+        # ====================================================================
+
+        Test.@testset "Unit: PseudoHamIpRHS / PseudoHamOoPRHS (scalar)" begin
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * (-x + u) + 0.5 * u^2)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            be = _backend()
+            # x=1, p=2 ⇒ u=-p=-2 ; ∂H̃/∂x=-p=-2, ∂H̃/∂p=-x+u=-3 ⇒ du=[∂p;-∂x]=[-3, 2]
+            ip = Systems.PseudoHamIpRHS(h̃, law, be, 1, only, only)
+            du = zeros(2)
+            ip(du, [1.0, 2.0], Systems.ODEParameters(nothing), 0.0)
+            Test.@test du ≈ [-3.0, 2.0] atol = 1e-10
+
+            oop = Systems.PseudoHamOoPRHS(h̃, law, be, 1, only, only)
+            Test.@test oop([1.0, 2.0], Systems.ODEParameters(nothing), 0.0) ≈ [-3.0, 2.0] atol =
+                1e-10
+        end
+
+        Test.@testset "Unit: PseudoHamIpRHS (2-D)" begin
+            # H̃(x,p,u) = p·x + 0.5‖u‖² ; law u(x,p) = -p (⇒ ∂H̃/∂u = u+... not used here)
+            # ∂H̃/∂x = p, ∂H̃/∂p = x (u held fixed) ⇒ du = [x; -p]
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> sum(p .* x) + 0.5 * sum(u .^ 2))
+            law = Data.DynClosedLoop((x, p) -> -p)
+            be = _backend()
+            ip = Systems.PseudoHamIpRHS(h̃, law, be, 2, identity, identity)
+            du = zeros(4)
+            ip(du, [1.0, 2.0, 3.0, 4.0], Systems.ODEParameters(nothing), 0.0)
+            # x=[1,2], p=[3,4] ⇒ du = [∂p; -∂x] = [x; -p] = [1,2,-3,-4]
+            Test.@test du ≈ [1.0, 2.0, -3.0, -4.0] atol = 1e-10
+        end
+
+        # ====================================================================
+        # UNIT — augmented RHS (variable costate), u held fixed
+        # ====================================================================
+
+        Test.@testset "Unit: PseudoHamIpAugRHS ṗv = -∂H̃/∂v (u fixed)" begin
+            # H̃(x,p,u,v) = p*(-x+u) + 0.5u² + 0.5 v² x ; law u(x,p,v) = -p
+            h̃ = Data.PseudoHamiltonian(
+                (x, p, u, v) -> p * (-x + u) + 0.5 * u^2 + 0.5 * v^2 * x;
+                is_variable = true,
+            )
+            law = Data.DynClosedLoop((x, p, v) -> -p; is_variable = true)
+            be = _backend()
+            aug = Systems.PseudoHamIpAugRHS(h̃, law, be, 1, 1, only, only)
+            du = zeros(3)
+            # x=1,p=2,v=3 ⇒ u=-2 ; ∂H̃/∂x=-p+0.5v²=2.5, ∂H̃/∂p=-x+u=-3, ∂H̃/∂v=v·x=3
+            # du = [∂p; -∂x; -∂v] = [-3; -2.5; -3]
+            aug(du, [1.0, 2.0, 0.0], Systems.ODEParameters(3.0), 0.0)
+            Test.@test du ≈ [-3.0, -2.5, -3.0] atol = 1e-10
+        end
+
+        # ====================================================================
+        # CONTRACT — variable-costate capability trait
+        # ====================================================================
+
+        Test.@testset "Contract: variable_costate_trait" begin
+            be = _backend()
+            fixed = Systems.build_system(
+                Data.PseudoHamiltonian((x, p, u) -> p * u),
+                Data.DynClosedLoop((x, p) -> -p),
+                be,
+            )
+            nonfixed = Systems.build_system(
+                Data.PseudoHamiltonian((x, p, u, v) -> p * u + v; is_variable = true),
+                Data.DynClosedLoop((x, p, v) -> -p; is_variable = true),
+                be,
+            )
+            Test.@test Traits.variable_costate_trait(fixed) === Traits.NoVariableCostate
+            Test.@test Traits.variable_costate_trait(nonfixed) ===
+                       Traits.SupportsVariableCostate
+        end
+
+        # ====================================================================
+        # UNIT — type stability of the hot-path RHS call
+        # ====================================================================
+
+        Test.@testset "Unit: RHS functor call is type-stable" begin
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * (-x + u) + 0.5 * u^2)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            oop = Systems.PseudoHamOoPRHS(h̃, law, _backend(), 1, only, only)
+            Test.@test_nowarn Test.@inferred oop(
+                [1.0, 2.0],
+                Systems.ODEParameters(nothing),
+                0.0,
+            )
+        end
+
+        # ====================================================================
+        # ERROR — build_system rejects a non-DynClosedLoop control law
+        # ====================================================================
+
+        Test.@testset "Error: non-DynClosedLoop law rejected by build_system" begin
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * u)
+            be = _backend()
+            Test.@test_throws MethodError Systems.build_system(
+                h̃,
+                Data.OpenLoop(() -> 1.0),
+                be,
+            )
+            Test.@test_throws MethodError Systems.build_system(
+                h̃,
+                Data.ClosedLoop(x -> -x),
+                be,
+            )
+        end
+    end
+end
+
+end # module
+
+test_pseudo_hamiltonian_system() =
+    TestPseudoHamiltonianSystem.test_pseudo_hamiltonian_system()


### PR DESCRIPTION
## Summary

Phase B of the DynClosedLoop control-flow roadmap. Adds the `PseudoHamiltonianSystem` and widens `HamiltonianSystem` so a control law can be composed into a Hamiltonian flow. **Requires CTBase ≥ 0.26.2** (`ComposedHamiltonian`, `pseudo_variable_gradient`).

Two differentiation modes for a dynamic closed-loop feedback `u(t,x,p,v)`:
- **`:total`** — `HamiltonianSystem` storing a `Data.ComposedHamiltonian`; AD differentiates *through* the law (total derivative).
- **`:partial`** — `PseudoHamiltonianSystem`; AD takes partials of `H̃` at the fixed feedback value (matches the extremal flow only where `∂H̃/∂u = 0`).

## Changes

- **Widen** `HamiltonianSystem{TD,VD,H<:AbstractHamiltonian{TD,VD},BACKEND}` and the `HamIpRHS`/`HamOoPRHS`/`HamIpAugRHS` functors to accept any `Data.AbstractHamiltonian` (so a `ComposedHamiltonian` fits with no wrapping).
- **`PseudoHamiltonianSystem{TD,VD,PH,L,BACKEND}`** — getters `pseudo_hamiltonian`/`control_law`/`backend`; `hamiltonian(sys)` returns the on-the-fly `ComposedHamiltonian`; lazy `get_ip_rhs`/`get_oop_rhs`/`get_ip_rhs_augmented`; `variable_costate_trait(NonFixed) = SupportsVariableCostate`.
- **`PseudoHam{Ip,OoP,IpAug}RHS`** in a dedicated `AbstractPseudoHamRHS{T} <: AbstractRHS{T}` hierarchy; the augmented functor uses `pseudo_variable_gradient` for `ṗv = -∂H̃/∂v` (control fixed). Shared split/assign helpers reused.
- **`build_system(h̃, law::DynClosedLoop, backend)`** overload; CTBase compat → `0.26.2`.

## Tests

New `test/suite/systems/test_pseudo_hamiltonian_system.jl` (unit/contract/error, `@inferred`): RHS analytic correctness (scalar, 2-D, augmented variable-costate), `variable_costate_trait` Fixed vs NonFixed, and rejection of non-DynClosedLoop laws. Full suite green: **2072/2072**.

## Scope

Systems layer only. Flow constructors (`Flow(h̃, law)`, `Flow(ocp, law)` with `hamiltonian_type=:total|:partial`) and the control-aware solution builder come in later phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)