### PR TITLE
feat: control flows — Flow(ocp, law) / Flow(h̃, law) with :total and :partial (Phases C–F)

### DIFF
--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -184,12 +184,209 @@ function _flow_from_ocp(::Type{Traits.WithControl}, ::CTModels.Models.Model; kwa
     return throw(
         Exceptions.PreconditionError(
             "Flow from a with-control OCP is not supported";
-            reason="this path builds the flow from the OCP structure assuming no control " *
-                   "(ẋ = f(t,x,∅,v)); a problem with a control input would require a control " *
-                   "law u(t,x,p) from the maximisation of the pseudo-Hamiltonian",
-            suggestion="build the Hamiltonian flow yourself from a control law, e.g. " *
-                       "Flow(Hamiltonian(...)), or use a control-free OCP",
-            context="Flow(ocp::CTModels.Models.Model) — control-dependence dispatch",
+            reason = "this path builds the flow from the OCP structure assuming no control " *
+                     "(ẋ = f(t,x,∅,v)); a problem with a control input would require a control " *
+                     "law u(t,x,p) from the maximisation of the pseudo-Hamiltonian",
+            suggestion = "build the Hamiltonian flow yourself from a control law, e.g. " *
+                         "Flow(Hamiltonian(...)), or use a control-free OCP",
+            context = "Flow(ocp::CTModels.Models.Model) — control-dependence dispatch",
+        ),
+    )
+end
+
+# =============================================================================
+# Flow from a pseudo-Hamiltonian and a control law (intermediate constructor)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `HamiltonianFlow` directly from a pseudo-Hamiltonian `H̃(t,x,p,u,v)` and a
+dynamic closed-loop control law `u(t,x,p,v)`, without going through an OCP.
+
+Dispatches on the control law's [`CTBase.Traits.feedback`](@extref) trait, then on the
+`hamiltonian_type` keyword:
+
+- `hamiltonian_type=:total` (default) — build a [`CTBase.Data.ComposedHamiltonian`](@extref)
+  `H(t,x,p,v)=H̃(t,x,p,u(t,x,p,v),v)` and a [`CTFlows.Systems.HamiltonianSystem`](@ref);
+  AD differentiates *through* the law (total derivative).
+- `hamiltonian_type=:partial` — build a [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref);
+  AD takes partials of `H̃` at the fixed feedback value `u`. Coincides with `:total` only
+  where the feedback is stationary (`∂H̃/∂u = 0`).
+
+# Arguments
+- `h̃::Data.PseudoHamiltonian`: the pseudo-Hamiltonian.
+- `law::Data.ControlLaw`: the control law; must carry `DynClosedLoopFeedback`.
+- `hamiltonian_type::Symbol=:total`: `:total` or `:partial`.
+- `kwargs...`: backend / integrator strategy options (as for `Flow(h::AbstractHamiltonian)`).
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): if the law is `OpenLoop`/`ClosedLoop`
+  (a pseudo-Hamiltonian needs the costate `p`, which those laws do not take).
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if `hamiltonian_type` is not
+  `:total` or `:partial`.
+
+See also: [`CTFlows.Flows.Flow`](@ref), [`CTBase.Data.PseudoHamiltonian`](@extref),
+[`CTBase.Data.DynClosedLoop`](@extref).
+"""
+function Flow(h̃::Data.PseudoHamiltonian, law::Data.ControlLaw; kwargs...)
+    return _flow_from_pseudo_hamiltonian(Traits.feedback(law), h̃, law; kwargs...)
+end
+
+function _flow_from_pseudo_hamiltonian(
+    ::Type{Traits.DynClosedLoopFeedback},
+    h̃::Data.PseudoHamiltonian,
+    law::Data.ControlLaw;
+    kwargs...,
+)
+    routed = _route_flow_options(kwargs; action_defs = _flow_action_defs())
+    components = _build_flow_components(routed)
+    ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
+    return _build_pseudo_flow(Val(ht), h̃, law, components)
+end
+
+function _flow_from_pseudo_hamiltonian(
+    ::Type{<:Union{Traits.OpenLoopFeedback,Traits.ClosedLoopFeedback}},
+    ::Data.PseudoHamiltonian,
+    ::Data.ControlLaw;
+    kwargs...,
+)
+    return throw(
+        Exceptions.PreconditionError(
+            "Flow(h̃, law) requires a DynClosedLoop control law";
+            reason = "a pseudo-Hamiltonian H̃(t,x,p,u,v) depends on the costate p, but " *
+                     "OpenLoop u(t,v) and ClosedLoop u(t,x,v) control laws do not take p",
+            suggestion = "use DynClosedLoop(u) to construct a control law u(t,x,p,v)",
+            context = "Flow(h̃::PseudoHamiltonian, law::ControlLaw) — feedback dispatch",
+        ),
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the inner Hamiltonian flow for the `:total` mode: compose the pseudo-Hamiltonian
+with the control law into a [`CTBase.Data.ComposedHamiltonian`](@extref) and wrap it in a
+[`CTFlows.Systems.HamiltonianSystem`](@ref) (AD through the law).
+"""
+function _build_pseudo_flow(::Val{:total}, h̃, law, components)
+    H = Data.ComposedHamiltonian(h̃, law)
+    sys = Systems.build_system(H, components.backend)
+    return build_flow(sys, components.integrator)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the inner Hamiltonian flow for the `:partial` mode: wrap the pseudo-Hamiltonian
+and control law in a [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref) (AD at fixed `u`).
+"""
+function _build_pseudo_flow(::Val{:partial}, h̃, law, components)
+    sys = Systems.build_system(h̃, law, components.backend)
+    return build_flow(sys, components.integrator)
+end
+
+function _build_pseudo_flow(::Val{ht}, h̃, law, components) where {ht}
+    return throw(
+        Exceptions.IncorrectArgument(
+            "unknown hamiltonian_type :$ht";
+            got = ":$ht",
+            expected = ":total or :partial",
+            context = "Flow(…, law::ControlLaw; hamiltonian_type=…)",
+        ),
+    )
+end
+
+# =============================================================================
+# Flow from an OCP and a control law
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Build an `OptimalControlFlow` from an OCP and a **control law** (dynamic closed-loop
+feedback `u(t,x,p,v)`).
+
+Dispatches on the law's [`CTBase.Traits.feedback`](@extref) trait, then on the
+`hamiltonian_type` action option (`:total` default, or `:partial`), the same way as
+[`Flow(h̃::Data.PseudoHamiltonian, law::Data.ControlLaw)`](@ref). The OCP's dynamics and
+cost supply the pseudo-Hamiltonian `H̃(t,x,p,u,v) = p·f + sp0·ℓ`; the trajectory call
+returns a [`CTModels.Solutions.Solution`](@extref) with the control reconstructed from
+the law.
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): if the OCP is control-free.
+- [`CTBase.Exceptions.NotImplemented`](@extref): if the law is `OpenLoop`/`ClosedLoop`
+  (state-only flows are not wired yet).
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if `hamiltonian_type` is invalid.
+
+See also: [`CTFlows.Flows.Flow`](@ref), [`CTFlows.Flows.OptimalControlFlow`](@ref).
+"""
+function Flow(ocp::CTModels.Models.Model, law::Data.ControlLaw; kwargs...)
+    return _flow_from_ocp_control(Traits.feedback(law), ocp, law; kwargs...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convenience constructor: wrap a raw control function `u` in a
+[`CTBase.Data.DynClosedLoop`](@extref) control law and delegate to
+[`Flow(ocp::CTModels.Models.Model, law::Data.ControlLaw)`](@ref).
+
+The control law is given **the same time/variable dependence as the OCP**
+(`is_autonomous(ocp)`, `is_variable(ocp)`), so `u` **must** have the matching natural
+arity — `(x,p)`, `(t,x,p)`, `(x,p,v)`, or `(t,x,p,v)` for
+autonomous/fixed, non-autonomous/fixed, autonomous/non-fixed, non-autonomous/non-fixed
+respectively. To use a control law whose traits differ from the OCP's (e.g. a
+time-varying feedback on an autonomous OCP), build the
+[`CTBase.Data.DynClosedLoop`](@extref) explicitly and call
+[`Flow(ocp::CTModels.Models.Model, law::Data.ControlLaw)`](@ref).
+
+See also: [`Flow(ocp::CTModels.Models.Model, law::Data.ControlLaw)`](@ref).
+"""
+function Flow(ocp::CTModels.Models.Model, u::Function; kwargs...)
+    law = Data.DynClosedLoop(
+        u;
+        is_autonomous = Traits.is_autonomous(ocp),
+        is_variable = Traits.is_variable(ocp),
+    )
+    return Flow(ocp, law; kwargs...)
+end
+
+function _flow_from_ocp_control(
+    ::Type{Traits.DynClosedLoopFeedback},
+    ocp::CTModels.Models.Model,
+    law::Data.ControlLaw;
+    kwargs...,
+)
+    Traits.control_dependence(ocp) === Traits.WithControl || throw(
+        Exceptions.PreconditionError(
+            "Flow(ocp, law) requires a with-control OCP";
+            reason = "the OCP is control-free (no control input), so a control law cannot be applied",
+            suggestion = "use Flow(ocp; kwargs…) for a control-free OCP",
+            context = "Flow(ocp, law::ControlLaw) — control-dependence check",
+        ),
+    )
+    routed = _route_flow_options(kwargs; action_defs = _flow_action_defs())
+    components = _build_flow_components(routed)
+    ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
+    h̃ = _ocp_pseudo_hamiltonian(ocp)
+    inner = _build_pseudo_flow(Val(ht), h̃, law, components)
+    return OptimalControlFlow(inner, ocp, law)
+end
+
+function _flow_from_ocp_control(
+    ::Type{<:Union{Traits.OpenLoopFeedback,Traits.ClosedLoopFeedback}},
+    ::CTModels.Models.Model,
+    ::Data.ControlLaw;
+    kwargs...,
+)
+    return throw(
+        Exceptions.NotImplemented(
+            "Flow(ocp, law) with an OpenLoop/ClosedLoop control law is not implemented yet";
+            required_method = "Flow(ocp, law::ControlLaw{…,OpenLoopFeedback/ClosedLoopFeedback,…})",
+            suggestion = "use a DynClosedLoop control law u(t,x,p,v); state-only flows will be wired later",
+            context = "Flow(ocp, law::ControlLaw) — feedback dispatch",
         ),
     )
 end
@@ -198,10 +395,10 @@ function Flow(::CTModels.Models.Model, ::Any, args...; kwargs...)
     return throw(
         Exceptions.PreconditionError(
             "Flow(ocp, …) with extra positional arguments is not supported";
-            reason="passing a control law, state constraint or multiplier as a positional " *
-                   "argument is not handled by the OCP flow constructor",
-            suggestion="call Flow(ocp; kwargs…) — the OCP flow takes no positional argument beyond the model",
-            context="Flow(ocp::CTModels.Models.Model) — positional-argument guard",
+            reason = "passing a control law, state constraint or multiplier as a positional " *
+                     "argument is not handled by the OCP flow constructor",
+            suggestion = "call Flow(ocp; kwargs…) — the OCP flow takes no positional argument beyond the model",
+            context = "Flow(ocp::CTModels.Models.Model) — positional-argument guard",
         ),
     )
 end

--- a/src/Flows/flow_routing.jl
+++ b/src/Flows/flow_routing.jl
@@ -20,7 +20,8 @@ See also: [`_route_flow_options`](@ref), [`flow_registry`](@ref)
 """
 function _flow_families()
     return (
-        backend=Differentiation.AbstractADBackend, integrator=Integrators.AbstractIntegrator
+        backend = Differentiation.AbstractADBackend,
+        integrator = Integrators.AbstractIntegrator,
     )
 end
 
@@ -81,16 +82,52 @@ routed = Flows._route_flow_options((; reltol=1e-8, ad_backend=ADTypes.AutoForwar
 See also: [`_flow_families`](@ref), [`_build_flow_components`](@ref),
 [`CTBase.Orchestration.route_all_options`](@extref)
 """
-function _route_flow_options(kwargs)
+function _route_flow_options(
+    kwargs;
+    action_defs::Vector{<:Options.OptionDefinition} = Options.OptionDefinition[],
+)
     return Orchestration.route_all_options(
         _FLOW_DESCRIPTION,
         _flow_families(),
-        Options.OptionDefinition[],
+        action_defs,
         (; kwargs...),
         flow_registry();
-        source_mode=:description,
+        source_mode = :description,
     )
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the action-level option definitions for control flows. Currently a single
+option, `hamiltonian_type` (`:total` or `:partial`), routed as a first-class action
+option so it is accepted only where meaningful (the control-law flow constructors) and
+rejected as an unknown option elsewhere.
+
+See also: [`_route_flow_options`](@ref), [`_unwrap_option`](@ref).
+"""
+function _flow_action_defs()
+    return [
+        Options.OptionDefinition(;
+            name = :hamiltonian_type,
+            aliases = (),
+            type = Symbol,
+            default = :total,
+            description = "Hamiltonian type for DynClosedLoop flows: :total or :partial",
+        ),
+    ]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Read an action option value from a routed `action` NamedTuple entry: unwrap an
+[`CTBase.Options.OptionValue`](@extref), or fall back when the entry is `nothing`.
+
+See also: [`_flow_action_defs`](@ref), [`_route_flow_options`](@ref).
+"""
+_unwrap_option(opt::Options.OptionValue, fallback) = opt.value
+_unwrap_option(opt, fallback) = opt === nothing ? fallback : opt
 
 """
 $(TYPEDSIGNATURES)
@@ -123,10 +160,18 @@ function _build_flow_components(routed)
     families = _flow_families()
     resolved = Orchestration.resolve_method(_FLOW_DESCRIPTION, families, flow_registry())
     backend = Orchestration.build_strategy_from_resolved(
-        resolved, :backend, families, flow_registry(); routed.strategies.backend...
+        resolved,
+        :backend,
+        families,
+        flow_registry();
+        routed.strategies.backend...,
     )
     integrator = Orchestration.build_strategy_from_resolved(
-        resolved, :integrator, families, flow_registry(); routed.strategies.integrator...
+        resolved,
+        :integrator,
+        families,
+        flow_registry();
+        routed.strategies.integrator...,
     )
-    return (backend=backend, integrator=integrator)
+    return (backend = backend, integrator = integrator)
 end

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -6,9 +6,10 @@
 # OCPHamiltonianFunction — OCP Hamiltonian H(t,x,p,v) = p·f(t,x,∅,v) + sp0·ℓ(t,x,∅,v)
 #
 # TD/VD are compile-time parameters so dispatch selects the right natural-arity
-# method without runtime branches.  A single _ocp_H core does the work; scalar
-# inputs (x or p as Number when n_x=1) are rewrapped to 1-vectors so the always-
-# in-place CTModels dynamics receives the array it expects.
+# method without runtime branches.  A single _ocp_H core does the work; the state
+# (and variable) are passed to the dynamics as received — scalar for 1-D, vector for
+# n-D — per the "1-D = scalar" convention (CTModels stores the dynamics verbatim and
+# imposes no shape). The derivative buffer r is always a length-n_x vector.
 #
 # sp0 = s·p⁰ where p⁰=-1: sp0=-1 for :min, sp0=+1 for :max.
 # =============================================================================
@@ -49,45 +50,33 @@ const _CTM_Auton = CTModels.Components.Autonomous
 const _CTM_NonAuton = CTModels.Components.NonAutonomous
 
 """
-Rewrap a scalar to a 1-vector; leave arrays unchanged.
-
-This ensures the always-in-place CTModels dynamics receives the array it expects,
-even when the state or costate is a scalar `Number` (which happens when `n_x=1`).
-
-See also: [`OCPHamiltonianFunction`](@ref), `_ocp_H`.
-"""
-_asvec(z::Number) = [z]
-_asvec(z::AbstractVector) = z
-
-"""
 $(TYPEDSIGNATURES)
 
 Core computation of the OCP Hamiltonian value `H(t,x,p,v)`.
 
-Rewraps scalar `x` and `p` to 1-vectors via `_asvec`, calls the in-place dynamics,
-and accumulates `p·f + sp0·ℓ`. When `v === nothing` the variable is treated as an
-empty vector (used by `Fixed`-trait call paths).
+Passes `x` (and the variable `v`) to the in-place dynamics **as received** — a scalar
+for a 1-dimensional quantity, a vector otherwise (the ecosystem "1-D = scalar"
+convention) — and accumulates `p·f + sp0·ℓ`. The derivative buffer `r` is always a
+length-`n_x` vector. When `v === nothing` the variable is an empty vector (used by
+`Fixed`-trait call paths).
 
-See also: [`OCPHamiltonianFunction`](@ref), `_asvec`.
+See also: [`OCPHamiltonianFunction`](@ref).
 """
 function _ocp_H(h::OCPHamiltonianFunction, t, x, p, v)
-    xv = _asvec(x)
-    pv_arg = _asvec(p)
     if v === nothing
-        T = eltype(xv)
-        u = Vector{T}(undef, 0)
+        T = eltype(x)
+        u = Vector{T}(undef, 0)          # empty control (control-free) and variable (Fixed)
         r = Vector{T}(undef, h.n)
-        h.dynamics!(r, t, xv, u, u)
-        val = sum(pv_arg .* r)
-        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, u, u))
+        h.dynamics!(r, t, x, u, u)       # x passed as-is (scalar for 1-D per convention)
+        val = sum(p .* r)
+        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, u))
     else
-        vv = _asvec(v)
-        T = Base.promote_op(*, eltype(xv), eltype(vv))
-        u = Vector{T}(undef, 0)
+        T = Base.promote_op(*, eltype(x), eltype(v))
+        u = Vector{T}(undef, 0)          # empty control (control-free)
         r = Vector{T}(undef, h.n)
-        h.dynamics!(r, t, xv, u, vv)
-        val = sum(pv_arg .* r)
-        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, u, vv))
+        h.dynamics!(r, t, x, u, v)       # x, v passed as-is
+        val = sum(p .* r)
+        h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, v))
     end
     return val
 end
@@ -190,27 +179,25 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Core computation of the OCP pseudo-Hamiltonian value `H̃(t,x,p,u,v)`. Rewraps scalar
-`x`, `p`, `u`, `v` to 1-vectors via `_asvec` (CTModels dynamics is always in-place on
-arrays), calls the dynamics, and accumulates `p·f + sp0·ℓ`.
+Core computation of the OCP pseudo-Hamiltonian value `H̃(t,x,p,u,v)`. Passes `x`, `u`
+(and the variable `v`) to the in-place dynamics **as received** — scalar for a
+1-dimensional quantity, vector otherwise ("1-D = scalar" convention) — and accumulates
+`p·f + sp0·ℓ`. The derivative buffer `r` is always a length-`n_x` vector.
 
-See also: [`OCPPseudoHamiltonianFunction`](@ref), `_asvec`.
+See also: [`OCPPseudoHamiltonianFunction`](@ref).
 """
 function _ocp_pseudo_H(h::OCPPseudoHamiltonianFunction, t, x, p, u, v)
-    xv = _asvec(x)
-    pv_arg = _asvec(p)
-    uv = _asvec(u)
     if v === nothing
-        T = Base.promote_op(*, eltype(xv), eltype(uv))
-        vv = Vector{T}(undef, 0)
+        T = Base.promote_op(*, eltype(x), eltype(u))
+        vv = Vector{T}(undef, 0)   # empty variable for Fixed problems
     else
-        vv = _asvec(v)
-        T = Base.promote_op(*, Base.promote_op(*, eltype(xv), eltype(uv)), eltype(vv))
+        T = Base.promote_op(*, Base.promote_op(*, eltype(x), eltype(u)), eltype(v))
+        vv = v
     end
-    r = Vector{T}(undef, h.n)
-    h.dynamics!(r, t, xv, uv, vv)
-    val = sum(pv_arg .* r)
-    h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, uv, vv))
+    r = Vector{T}(undef, h.n)      # in-place derivative buffer (always length n_x)
+    h.dynamics!(r, t, x, u, vv)    # x, u, v passed as-is (scalar for 1-D per convention)
+    val = sum(p .* r)             # p·f — sum handles scalar p (1-D) or vector p (n-D)
+    h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, vv))
     return val
 end
 
@@ -405,7 +392,7 @@ function _ocp_objective(ocp, x, p, v, t0, tf, integ, law)
         # Integrate ℓ̇(t) = lag(t, x(t), u(t), v) from t0 to tf.
         # Use a 1-element Vector so SciML always has a mutable in-place buffer.
         running = Data.VectorField(
-            (t, ℓ_vec) -> [lag(t, x(t), _asvec(uc(t)), v)];
+            (t, ℓ_vec) -> [lag(t, x(t), uc(t), v)];
             is_autonomous = false,
             is_variable = false,
         )

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -96,17 +96,24 @@ function (h::OCPHamiltonianFunction{_CTM_Auton,Traits.Fixed,DF,LF})(x, p) where 
     return _ocp_H(h, 0.0, x, p, nothing)
 end
 function (h::OCPHamiltonianFunction{_CTM_NonAuton,Traits.Fixed,DF,LF})(
-    t, x, p
+    t,
+    x,
+    p,
 ) where {DF,LF}
     return _ocp_H(h, t, x, p, nothing)
 end
 function (h::OCPHamiltonianFunction{_CTM_Auton,Traits.NonFixed,DF,LF})(
-    x, p, v
+    x,
+    p,
+    v,
 ) where {DF,LF}
     return _ocp_H(h, 0.0, x, p, v)
 end
 function (h::OCPHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed,DF,LF})(
-    t, x, p, v
+    t,
+    x,
+    p,
+    v,
 ) where {DF,LF}
     return _ocp_H(h, t, x, p, v)
 end
@@ -144,6 +151,127 @@ function _ocp_hamiltonian(ocp)
 end
 
 # =============================================================================
+# OCPPseudoHamiltonianFunction — OCP pseudo-Hamiltonian
+#   H̃(t,x,p,u,v) = p·f(t,x,u,v) + sp0·ℓ(t,x,u,v)
+#
+# Same pattern as OCPHamiltonianFunction, but the control u is an explicit argument
+# (not eliminated). Used for both the :total path (composed with a control law via
+# Data.ComposedHamiltonian) and the :partial path (PseudoHamiltonianSystem).
+# =============================================================================
+
+"""
+$(TYPEDEF)
+
+Internal callable representing the pseudo-Hamiltonian of an optimal control problem:
+`H̃(t,x,p,u,v) = p·f(t,x,u,v) + sp0·ℓ(t,x,u,v)` with `sp0 = s·p⁰` (`p⁰=-1`). Unlike
+[`OCPHamiltonianFunction`](@ref), the control `u` is an explicit argument.
+
+# Type Parameters
+- `TD`, `VD`: time- and variable-dependence traits (compile-time dispatch on arity).
+- `DF`: type of the in-place dynamics function.
+- `LF`: type of the Lagrange cost function (or `Nothing`).
+
+# Fields
+- `dynamics!::DF`: in-place dynamics `f!(r, t, x, u, v)` from the OCP.
+- `lagrange::LF`: Lagrange cost `ℓ(t, x, u, v)` or `nothing`.
+- `sp0::Float64`: sign-weighted multiplier `s·p⁰`.
+- `n::Int`: state dimension.
+
+See also: [`OCPHamiltonianFunction`](@ref), `_ocp_pseudo_hamiltonian`,
+[`CTBase.Data.PseudoHamiltonian`](@extref).
+"""
+struct OCPPseudoHamiltonianFunction{TD,VD,DF,LF} <: Function
+    dynamics!::DF
+    lagrange::LF
+    sp0::Float64
+    n::Int
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Core computation of the OCP pseudo-Hamiltonian value `H̃(t,x,p,u,v)`. Rewraps scalar
+`x`, `p`, `u`, `v` to 1-vectors via `_asvec` (CTModels dynamics is always in-place on
+arrays), calls the dynamics, and accumulates `p·f + sp0·ℓ`.
+
+See also: [`OCPPseudoHamiltonianFunction`](@ref), `_asvec`.
+"""
+function _ocp_pseudo_H(h::OCPPseudoHamiltonianFunction, t, x, p, u, v)
+    xv = _asvec(x)
+    pv_arg = _asvec(p)
+    uv = _asvec(u)
+    if v === nothing
+        T = Base.promote_op(*, eltype(xv), eltype(uv))
+        vv = Vector{T}(undef, 0)
+    else
+        vv = _asvec(v)
+        T = Base.promote_op(*, Base.promote_op(*, eltype(xv), eltype(uv)), eltype(vv))
+    end
+    r = Vector{T}(undef, h.n)
+    h.dynamics!(r, t, xv, uv, vv)
+    val = sum(pv_arg .* r)
+    h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, xv, uv, vv))
+    return val
+end
+
+function (h::OCPPseudoHamiltonianFunction{_CTM_Auton,Traits.Fixed,DF,LF})(
+    x,
+    p,
+    u,
+) where {DF,LF}
+    return _ocp_pseudo_H(h, 0.0, x, p, u, nothing)
+end
+function (h::OCPPseudoHamiltonianFunction{_CTM_NonAuton,Traits.Fixed,DF,LF})(
+    t,
+    x,
+    p,
+    u,
+) where {DF,LF}
+    return _ocp_pseudo_H(h, t, x, p, u, nothing)
+end
+function (h::OCPPseudoHamiltonianFunction{_CTM_Auton,Traits.NonFixed,DF,LF})(
+    x,
+    p,
+    u,
+    v,
+) where {DF,LF}
+    return _ocp_pseudo_H(h, 0.0, x, p, u, v)
+end
+function (h::OCPPseudoHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed,DF,LF})(
+    t,
+    x,
+    p,
+    u,
+    v,
+) where {DF,LF}
+    return _ocp_pseudo_H(h, t, x, p, u, v)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build an [`OCPPseudoHamiltonianFunction`](@ref) from an OCP and wrap it in a
+[`CTBase.Data.PseudoHamiltonian`](@extref), giving the uniform `(t,x,p,u,v)` interface
+used by the pseudo-Hamiltonian AD pipeline.
+
+See also: [`OCPPseudoHamiltonianFunction`](@ref), `_ocp_hamiltonian`.
+"""
+function _ocp_pseudo_hamiltonian(ocp)
+    n = CTModels.Models.state_dimension(ocp)
+    dyn! = CTModels.Models.dynamics(ocp)
+    sp0 = CTModels.Components.criterion(ocp) === :min ? -1.0 : 1.0
+    lag = if CTModels.Components.has_lagrange_cost(ocp)
+        CTModels.Components.lagrange(ocp)
+    else
+        nothing
+    end
+    TD = Traits.time_dependence(ocp)
+    VD = Traits.variable_dependence(ocp)
+    h_raw = OCPPseudoHamiltonianFunction{TD,VD,typeof(dyn!),typeof(lag)}(dyn!, lag, sp0, n)
+    return Data.PseudoHamiltonian(h_raw, TD, VD)
+end
+
+# =============================================================================
 # OptimalControlFlow — thin AbstractFlow wrapper that carries the ocp reference
 #
 # The inner HamiltonianFlow handles all point-eval + variable_costate logic.
@@ -167,21 +295,35 @@ rebuilds a full [`CTModels.Solutions.Solution`](@extref) from the problem.
 - `VD <: VariableDependence`: variable-dependence trait, inherited from the problem.
 - `IF`: type of the inner `HamiltonianFlow`.
 - `M`: type of the wrapped optimal control problem model.
+- `CL`: type of the control law (`Nothing` for a control-free OCP, a
+  `CTBase.Data.ControlLaw` when the flow was built from an OCP and a control law).
 
 # Fields
 - `flow::IF`: the inner Hamiltonian flow doing the integration.
 - `ocp::M`: the optimal control problem, kept so trajectory calls can build a solution.
+- `law::CL`: the control law, used to reconstruct `u(t)` along the trajectory (or
+  `nothing` for control-free problems).
 
 See also: [`CTFlows.Flows.Flow`](@ref), [`CTModels.Solutions.Solution`](@extref).
 """
-struct OptimalControlFlow{TD<:Traits.TimeDependence,VD<:Traits.VariableDependence,IF,M} <:
-       AbstractFlow{TD,VD,Traits.HamiltonianDynamics}
+struct OptimalControlFlow{
+    TD<:Traits.TimeDependence,
+    VD<:Traits.VariableDependence,
+    IF,
+    M,
+    CL,
+} <: AbstractFlow{TD,VD,Traits.HamiltonianDynamics}
     flow::IF    # inner HamiltonianFlow
     ocp::M
+    law::CL
 end
 
-function OptimalControlFlow(flow::Flow{TD,VD,Traits.HamiltonianDynamics}, ocp) where {TD,VD}
-    return OptimalControlFlow{TD,VD,typeof(flow),typeof(ocp)}(flow, ocp)
+function OptimalControlFlow(
+    flow::Flow{TD,VD,Traits.HamiltonianDynamics},
+    ocp,
+    law = nothing,
+) where {TD,VD}
+    return OptimalControlFlow{TD,VD,typeof(flow),typeof(ocp),typeof(law)}(flow, ocp, law)
 end
 
 system(F::OptimalControlFlow) = system(F.flow)
@@ -194,9 +336,9 @@ function (F::OptimalControlFlow)(
     x0,
     p0,
     tf::Real;
-    variable=Core.NotProvided,
-    variable_costate::Bool=false,
-    unsafe::Bool=false,
+    variable = Core.NotProvided,
+    variable_costate::Bool = false,
+    unsafe::Bool = false,
 )
     return F.flow(t0, x0, p0, tf; variable, variable_costate, unsafe)
 end
@@ -204,10 +346,14 @@ end
 # ── trajectory call — builds a CTModels.Solution ────────────────────────────
 
 function (F::OptimalControlFlow)(
-    tspan::Tuple{<:Real,<:Real}, x0, p0; variable=Core.NotProvided, unsafe::Bool=false
+    tspan::Tuple{<:Real,<:Real},
+    x0,
+    p0;
+    variable = Core.NotProvided,
+    unsafe::Bool = false,
 )
     sol = F.flow(tspan, x0, p0; variable, unsafe)   # HamiltonianVectorFieldTrajectory
-    return _build_ocp_solution(F.ocp, sol, variable, integrator(F.flow))
+    return _build_ocp_solution(F.ocp, sol, variable, integrator(F.flow), F.law)
 end
 
 # =============================================================================
@@ -227,18 +373,27 @@ _variable_vector(v::Number) = [Float64(v)]
 _variable_vector(v::AbstractVector) = Float64.(v)
 
 """
+Reconstruct the control `u(t)` along a trajectory from a control law and the
+state/costate projections. Returns `t -> Float64[]` when there is no control law
+(control-free OCP), and `t -> law(t, x(t), p(t), v)` otherwise.
+
+See also: `_ocp_objective`, `_build_ocp_solution`.
+"""
+_control_of(::Nothing, x, p, v) = (_ -> Float64[])
+_control_of(law, x, p, v) = (t -> law(t, x(t), p(t), v))
+
+"""
 $(TYPEDSIGNATURES)
 
-Compute the objective value (Mayer + Lagrange) of a control-free OCP along a
-trajectory.
+Compute the objective value (Mayer + Lagrange) of an OCP along a trajectory.
 
-The Mayer term is evaluated at the endpoints `x(t0)` and `x(tf)`. The Lagrange
-term is integrated by building a temporary scalar vector field `ℓ̇(t) = ℓ(t, x(t), ∅, v)`
-and flowing it from `t0` to `tf` using the provided integrator.
+The Mayer term is evaluated at the endpoints `x(t0)` and `x(tf)`. The Lagrange term is
+integrated by flowing `ℓ̇(t) = ℓ(t, x(t), u(t), v)` from `t0` to `tf`, where `u(t)` is
+reconstructed from the control law (empty for a control-free OCP).
 
-See also: `_build_ocp_solution`, `_variable_vector`, [`CTFlows.Flows.Flow`](@ref).
+See also: `_build_ocp_solution`, `_control_of`, `_variable_vector`, [`CTFlows.Flows.Flow`](@ref).
 """
-function _ocp_objective(ocp, x, v, t0, tf, integ)
+function _ocp_objective(ocp, x, p, v, t0, tf, integ, law)
     obj = 0.0
     if CTModels.Components.has_mayer_cost(ocp)
         may = CTModels.Components.mayer(ocp)
@@ -246,11 +401,13 @@ function _ocp_objective(ocp, x, v, t0, tf, integ)
     end
     if CTModels.Components.has_lagrange_cost(ocp)
         lag = CTModels.Components.lagrange(ocp)
-        u_empty = Float64[]
-        # Integrate ℓ̇(t) = lag(t, x(t), ∅, v) from t0 to tf.
+        uc = _control_of(law, x, p, v)
+        # Integrate ℓ̇(t) = lag(t, x(t), u(t), v) from t0 to tf.
         # Use a 1-element Vector so SciML always has a mutable in-place buffer.
         running = Data.VectorField(
-            (t, ℓ_vec) -> [lag(t, x(t), u_empty, v)]; is_autonomous=false, is_variable=false
+            (t, ℓ_vec) -> [lag(t, x(t), _asvec(uc(t)), v)];
+            is_autonomous = false,
+            is_variable = false,
         )
         cost_flow = build_flow(Systems.build_system(running), integ)
         ℓ_tf = cost_flow(t0, [0.0], tf)   # returns [ℓ(tf)]
@@ -271,15 +428,19 @@ trajectory, computes the objective via `_ocp_objective`, and assembles a full
 See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), `_ocp_objective`, `_variable_vector`, [`CTModels.Solutions.Solution`](@extref).
 """
 function _build_ocp_solution(
-    ocp, sol::Trajectories.HamiltonianVectorFieldTrajectory, variable, integ
+    ocp,
+    sol::Trajectories.HamiltonianVectorFieldTrajectory,
+    variable,
+    integ,
+    law = nothing,
 )
     T = collect(Float64, Trajectories.time_grid(sol))
     x = Trajectories.state(sol)    # callable StateProjection: t -> x(t)
     p = Trajectories.costate(sol)  # callable CostateProjection: t -> p(t)
     t0, tf = first(T), last(T)
     v = _variable_vector(variable)
-    u = _ -> Float64[]          # empty control for control-free OCP
-    obj = _ocp_objective(ocp, x, v, t0, tf, integ)
+    u = _control_of(law, x, p, v)  # empty for control-free; law(t,x,p,v) otherwise
+    obj = _ocp_objective(ocp, x, p, v, t0, tf, integ, law)
     return CTModels.Solutions.build_solution(
         ocp,
         T,
@@ -287,12 +448,12 @@ function _build_ocp_solution(
         u,
         v,
         p;
-        objective=obj,
-        iterations=-1,
-        constraints_violation=-1.0,
-        message="Solution computed by CTFlows OCP flow",
-        status=:nostatusmessage,
-        successful=true,
-        control_interpolation=:linear,
+        objective = obj,
+        iterations = -1,
+        constraints_violation = -1.0,
+        message = "Solution computed by CTFlows OCP flow",
+        status = :nostatusmessage,
+        successful = true,
+        control_interpolation = :linear,
     )
 end

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -36,9 +36,8 @@ using DifferentiationInterface: DifferentiationInterface as DI
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 
 const CTFlowsSciMLIntegrator = Base.get_extension(CTFlows, :CTFlowsSciMLIntegrator)
-const CTBaseDifferentiationInterface = Base.get_extension(
-    CTBase, :CTBaseDifferentiationInterface
-)
+const CTBaseDifferentiationInterface =
+    Base.get_extension(CTBase, :CTBaseDifferentiationInterface)
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -49,10 +48,9 @@ const ATOL = 1e-4
 # =============================================================================
 
 const λ_TEST = 2.0
-const INTEG = Integrators.SciML(; alg=Tsit5())
-const DI_BACKEND = Differentiation.DifferentiationInterface(;
-    ad_backend=ADTypes.AutoForwardDiff()
-)
+const INTEG = Integrators.SciML(; alg = Tsit5())
+const DI_BACKEND =
+    Differentiation.DifferentiationInterface(; ad_backend = ADTypes.AutoForwardDiff())
 
 # =============================================================================
 # OCP fixtures (module top-level)
@@ -60,66 +58,69 @@ const DI_BACKEND = Differentiation.DifferentiationInterface(;
 
 function _build_ocp_auton_fixed_mayer()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=true)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1]=λ_TEST * x[1]; nothing))
-    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer = (x0, xf, v) -> xf[1])
     return CTModels.Building.build(pre)
 end
 
 function _build_ocp_auton_fixed_lagrange()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=true)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1]=λ_TEST * x[1]; nothing))
-    CTModels.Building.objective!(pre, :min; lagrange=(_, x, _, _) -> x[1]^2)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (_, x, _, _) -> x[1]^2)
     return CTModels.Building.build(pre)
 end
 
 function _build_ocp_auton_fixed_bolza()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=true)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1]=λ_TEST * x[1]; nothing))
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r[1] = λ_TEST * x[1]; nothing))
     CTModels.Building.objective!(
-        pre, :min; mayer=(x0, xf, v) -> xf[1], lagrange=(_, x, _, _) -> x[1]^2
+        pre,
+        :min;
+        mayer = (x0, xf, v) -> xf[1],
+        lagrange = (_, x, _, _) -> x[1]^2,
     )
     return CTModels.Building.build(pre)
 end
 
 function _build_ocp_auton_nonfixed_mayer()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=true)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
     CTModels.Building.variable!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, _, x, _, v) -> (r[1]=v[1] * x[1]; nothing))
-    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    CTModels.Building.dynamics!(pre, (r, _, x, _, v) -> (r[1] = v[1] * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer = (x0, xf, v) -> xf[1])
     return CTModels.Building.build(pre)
 end
 
 function _build_ocp_nonauton_fixed_mayer()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=false)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = false)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, t, x, _, _) -> (r[1]=t * x[1]; nothing))
-    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    CTModels.Building.dynamics!(pre, (r, t, x, _, _) -> (r[1] = t * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer = (x0, xf, v) -> xf[1])
     return CTModels.Building.build(pre)
 end
 
 # with-control OCP (control! called) → WithControl trait, unsupported by Flow(ocp)
 function _build_ocp_with_control()
     pre = CTModels.Building.PreModel()
-    CTModels.Building.time_dependence!(pre; autonomous=true)
-    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
     CTModels.Building.control!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, _, x, u, _) -> (r[1]=u[1]; nothing))
-    CTModels.Building.objective!(pre, :min; lagrange=(_, x, u, _) -> u[1]^2)
+    CTModels.Building.dynamics!(pre, (r, _, x, u, _) -> (r[1] = u[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (_, x, u, _) -> u[1]^2)
     return CTModels.Building.build(pre)
 end
 
@@ -136,13 +137,16 @@ const OCP_WITH_CTRL = _build_ocp_with_control()
 
 # Pre-built flows (all via generic HamiltonianSystem — OCP rides the generic path)
 const FLOW_AF = Flows.build_flow(
-    Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_MAYER), DI_BACKEND), INTEG
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_MAYER), DI_BACKEND),
+    INTEG,
 )
 const FLOW_ANF = Flows.build_flow(
-    Systems.build_system(Flows._ocp_hamiltonian(OCP_ANF_MAYER), DI_BACKEND), INTEG
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_ANF_MAYER), DI_BACKEND),
+    INTEG,
 )
 const FLOW_NAF = Flows.build_flow(
-    Systems.build_system(Flows._ocp_hamiltonian(OCP_NAF_MAYER), DI_BACKEND), INTEG
+    Systems.build_system(Flows._ocp_hamiltonian(OCP_NAF_MAYER), DI_BACKEND),
+    INTEG,
 )
 
 # OptimalControlFlow wrappers (for trajectory call → CTModels.Solution)
@@ -169,12 +173,12 @@ function test_optimal_control_flow()
         # ── construction ──────────────────────────────────────────────────────
 
         Test.@testset "Construction: isa OptimalControlFlow" begin
-            f = Flows.Flow(OCP_AF_MAYER; alg=Tsit5())
+            f = Flows.Flow(OCP_AF_MAYER; alg = Tsit5())
             Test.@test f isa Flows.OptimalControlFlow
         end
 
         Test.@testset "Construction: system/integrator accessors" begin
-            f = Flows.Flow(OCP_AF_MAYER; alg=Tsit5())
+            f = Flows.Flow(OCP_AF_MAYER; alg = Tsit5())
             Test.@test Flows.system(f) isa Systems.HamiltonianSystem
             Test.@test Flows.integrator(f) isa Integrators.AbstractIntegrator
         end
@@ -222,7 +226,7 @@ function test_optimal_control_flow()
             t0, tf = 0.0, 1.0
             x0, p0 = 1.0, 0.5
             v = [λ_TEST]
-            xf, pf = FLOW_ANF(t0, x0, p0, tf; variable=v)
+            xf, pf = FLOW_ANF(t0, x0, p0, tf; variable = v)
             # ẋ = v[1]*x = λ_TEST*x, same analytic solution
             Test.@test xf ≈ _x_ref(tf, t0, x0) atol=ATOL
             Test.@test pf ≈ _p_ref(tf, t0, p0) atol=ATOL
@@ -243,7 +247,7 @@ function test_optimal_control_flow()
             t0, tf = 0.0, 1.0
             x0, p0 = 1.0, 0.5
             v = [λ_TEST]
-            xf, pf, pvf = FLOW_ANF(t0, x0, p0, tf; variable=v, variable_costate=true)
+            xf, pf, pvf = FLOW_ANF(t0, x0, p0, tf; variable = v, variable_costate = true)
             Test.@test xf ≈ _x_ref(tf, t0, x0) atol=ATOL
             Test.@test pf ≈ _p_ref(tf, t0, p0) atol=ATOL
             Test.@test pvf[1] ≈ _pv_ref(tf, t0, x0, p0) atol=ATOL
@@ -252,23 +256,25 @@ function test_optimal_control_flow()
         Test.@testset "Unit: pvf shape — length-1 vector variable → Number" begin
             # 1-D = scalar: a length-1 variable yields a scalar variable costate.
             t0, tf = 0.0, 0.5
-            xf, pf, pvf = FLOW_ANF(
-                t0, 1.0, 1.0, tf; variable=[λ_TEST], variable_costate=true
-            )
+            xf, pf, pvf =
+                FLOW_ANF(t0, 1.0, 1.0, tf; variable = [λ_TEST], variable_costate = true)
             Test.@test pvf isa Number
         end
 
         Test.@testset "Unit: pvf shape — scalar variable → Number" begin
             t0, tf = 0.0, 0.5
-            xf, pf, pvf = FLOW_ANF(t0, 1.0, 1.0, tf; variable=λ_TEST, variable_costate=true)
+            xf, pf, pvf =
+                FLOW_ANF(t0, 1.0, 1.0, tf; variable = λ_TEST, variable_costate = true)
             Test.@test pvf isa Number
         end
 
         Test.@testset "Integration: scalar variable gives same pvf value as vector" begin
             t0, tf = 0.0, 1.0
             x0, p0 = 1.0, 0.5
-            _, _, pvf1 = FLOW_ANF(t0, x0, p0, tf; variable=[λ_TEST], variable_costate=true)
-            _, _, pvf2 = FLOW_ANF(t0, x0, p0, tf; variable=λ_TEST, variable_costate=true)
+            _, _, pvf1 =
+                FLOW_ANF(t0, x0, p0, tf; variable = [λ_TEST], variable_costate = true)
+            _, _, pvf2 =
+                FLOW_ANF(t0, x0, p0, tf; variable = λ_TEST, variable_costate = true)
             Test.@test pvf1[1] ≈ pvf2 atol=ATOL
         end
 
@@ -322,7 +328,8 @@ function test_optimal_control_flow()
 
         Test.@testset "Integration: Lagrange objective ≈ analytic" begin
             flow_lag = Flows.build_flow(
-                Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_LAG), DI_BACKEND), INTEG
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_AF_LAG), DI_BACKEND),
+                INTEG,
             )
             ocf_lag = Flows.OptimalControlFlow(flow_lag, OCP_AF_LAG)
             t0, tf = 0.0, 1.0
@@ -349,7 +356,9 @@ function test_optimal_control_flow()
         Test.@testset "Integration: cross-check vs generic HamiltonianSystem" begin
             # H = p·λx = generic autonomous/fixed Hamiltonian — now same path, regression guard
             h_generic = Data.Hamiltonian(
-                (x, p) -> p[1] * λ_TEST * x[1]; is_autonomous=true, is_variable=false
+                (x, p) -> p[1] * λ_TEST * x[1];
+                is_autonomous = true,
+                is_variable = false,
             )
             sys_gen = Systems.HamiltonianSystem(h_generic, DI_BACKEND)
             flow_gen = Flows.build_flow(sys_gen, INTEG)
@@ -368,7 +377,11 @@ function test_optimal_control_flow()
 
         Test.@testset "Error: Fixed model + variable= kwarg" begin
             Test.@test_throws Exceptions.PreconditionError FLOW_AF(
-                0.0, 1.0, 0.5, 1.0; variable=1.0
+                0.0,
+                1.0,
+                0.5,
+                1.0;
+                variable = 1.0,
             )
         end
 
@@ -378,24 +391,33 @@ function test_optimal_control_flow()
 
         Test.@testset "Error: variable_costate=true on Fixed system" begin
             Test.@test_throws Exceptions.PreconditionError FLOW_AF(
-                0.0, 1.0, 0.5, 1.0; variable_costate=true
+                0.0,
+                1.0,
+                0.5,
+                1.0;
+                variable_costate = true,
             )
         end
 
-        Test.@testset "Error: Flow(ocp, u) — control-free guard" begin
+        Test.@testset "Error: Flow(ocp, u) on a control-free OCP" begin
+            # A raw function is now recognised as a DynClosedLoop control law, so the
+            # control-free OCP is rejected with a specific message (not the positional guard).
             err = nothing
             try
-                Flows.Flow(OCP_AF_MAYER, identity; alg=Tsit5())
+                Flows.Flow(OCP_AF_MAYER, identity; alg = Tsit5())
             catch e
                 err = e
             end
             Test.@test err isa Exceptions.PreconditionError
-            Test.@test occursin("positional argument", err.msg)
+            Test.@test occursin("with-control", err.msg)
         end
 
         Test.@testset "Error: Flow(ocp, g, μ) — positional-arg guard (extra args)" begin
             Test.@test_throws Exceptions.PreconditionError Flows.Flow(
-                OCP_AF_MAYER, identity, identity; alg=Tsit5()
+                OCP_AF_MAYER,
+                identity,
+                identity;
+                alg = Tsit5(),
             )
         end
 
@@ -405,14 +427,14 @@ function test_optimal_control_flow()
 
         Test.@testset "Dispatch: control-free OCP is ControlFree" begin
             Test.@test Traits.control_dependence(OCP_AF_MAYER) === Traits.ControlFree
-            Test.@test Flows.Flow(OCP_AF_MAYER; alg=Tsit5()) isa Flows.OptimalControlFlow
+            Test.@test Flows.Flow(OCP_AF_MAYER; alg = Tsit5()) isa Flows.OptimalControlFlow
         end
 
         Test.@testset "Error: Flow(with-control OCP) → PreconditionError" begin
             Test.@test Traits.control_dependence(OCP_WITH_CTRL) === Traits.WithControl
             err = nothing
             try
-                Flows.Flow(OCP_WITH_CTRL; alg=Tsit5())
+                Flows.Flow(OCP_WITH_CTRL; alg = Tsit5())
             catch e
                 err = e
             end
@@ -430,8 +452,8 @@ function test_optimal_control_flow()
                 Nothing,
                 nothing,
                 nothing;
-                unsafe=false,
-                variable=nothing,
+                unsafe = false,
+                variable = nothing,
             )
         end
 
@@ -442,8 +464,8 @@ function test_optimal_control_flow()
                 Nothing,
                 FLOW_AF,
                 config;
-                variable=nothing,
-                unsafe=false,
+                variable = nothing,
+                unsafe = false,
             )
         end
     end

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -25,14 +25,15 @@ _opts() = (; alg = Tsit5(), reltol = 1e-12, abstol = 1e-12)
 # =============================================================================
 
 # scalar LQR: ẋ = -x + u, ℓ = 0.5u², :min  (autonomous, fixed)
+# 1-D quantities are scalars (no [1] indexing): exercises the "1-D = scalar" convention.
 function _build_lqr()
     pre = CTModels.Building.PreModel()
     CTModels.Building.time_dependence!(pre; autonomous = true)
     CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
     CTModels.Building.control!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = -x[1] + u[1]; nothing))
-    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = -x + u; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u^2)
     return CTModels.Building.build(pre)
 end
 
@@ -55,11 +56,8 @@ function _build_nonauton()
     CTModels.Building.time!(pre; t0 = 0.0, tf = π / 4)
     CTModels.Building.state!(pre, 1)
     CTModels.Building.control!(pre, 1)
-    CTModels.Building.dynamics!(
-        pre,
-        (r, t, x, u, v) -> (r[1] = u[1] * (1 + tan(t)); nothing),
-    )
-    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = u * (1 + tan(t)); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u^2)
     return CTModels.Building.build(pre)
 end
 
@@ -69,8 +67,62 @@ function _build_control_free()
     CTModels.Building.time_dependence!(pre; autonomous = true)
     CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
     CTModels.Building.state!(pre, 1)
-    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[1]; nothing))
-    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> x[1]^2)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> x^2)
+    return CTModels.Building.build(pre)
+end
+
+# Mayer-only control OCP (no Lagrange): ẋ = -x + u, mayer = xf, :min
+function _build_mayer_control()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = -x + u; nothing))
+    CTModels.Building.objective!(pre, :min; mayer = (x0, xf, v) -> xf)
+    return CTModels.Building.build(pre)
+end
+
+# variable (NonFixed) control OCP: ẋ = v·(-x) + u, ℓ = 0.5u², :min
+function _build_variable_control()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = v * (-x) + u; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+# Type-recording (fake) dynamics: capture the argument types the dynamics is called
+# with, to verify the "1-D = scalar, n-D = vector" boundary convention. `x[1]`/`u[1]`
+# work for both scalars and vectors, so the compute is correct either way.
+const _DYN_SEEN = Ref{Any}(nothing)
+_typed_dyn_1d!(r, t, x, u, v) = (_DYN_SEEN[] = (x, u, v); r[1] = -x[1] + u[1]; nothing)
+_typed_dyn_2d!(r, t, x, u, v) = (_DYN_SEEN[] = (x, u, v); r .= [x[2], u[1]]; nothing)
+
+function _build_typed_1d()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, _typed_dyn_1d!)
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+function _build_typed_2d()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, _typed_dyn_2d!)
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
     return CTModels.Building.build(pre)
 end
 
@@ -78,6 +130,10 @@ const OCP_LQR = _build_lqr()
 const OCP_DI = _build_double_integrator()
 const OCP_NA = _build_nonauton()
 const OCP_CF = _build_control_free()
+const OCP_MAYER = _build_mayer_control()
+const OCP_VAR = _build_variable_control()
+const OCP_TYPED_1D = _build_typed_1d()
+const OCP_TYPED_2D = _build_typed_2d()
 
 function test_ocp_control()
     Test.@testset "OCP control flows" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -184,6 +240,65 @@ function test_ocp_control()
             # costate ṗ = -∂H̃/∂x = p ⇒ p(tf) = p0 e^{tf}
             _, pf = ft(t0, x0, p0, tf)
             Test.@test pf ≈ p0 * exp(tf) atol = 1e-6
+        end
+
+        # ====================================================================
+        # INTEGRATION — variable (NonFixed) control OCP
+        # ====================================================================
+
+        Test.@testset "Integration: variable (NonFixed) control flow" begin
+            # ẋ = v(-x) + u, ℓ = 0.5u², :min ⇒ ∂H̃/∂u = p - u ; stationary law u = p.
+            law = Data.DynClosedLoop((x, p, v) -> p; is_variable = true)
+            ft = Flows.Flow(OCP_VAR, law; hamiltonian_type = :total, _opts()...)
+            fp = Flows.Flow(OCP_VAR, law; hamiltonian_type = :partial, _opts()...)
+            t0, tf, x0, p0, vval = 0.0, 1.0, 1.0, 0.5, 0.5
+            xt, pt = ft(t0, x0, p0, tf; variable = vval)
+            xp, pp = fp(t0, x0, p0, tf; variable = vval)
+            Test.@test xt ≈ xp atol = ATOL             # agree at stationarity
+            Test.@test pt ≈ pp atol = ATOL
+            # costate: ṗ = -∂H̃/∂x = p·v ⇒ p(tf) = p0·e^{v·tf}
+            Test.@test pt ≈ p0 * exp(vval * tf) atol = 1e-6
+        end
+
+        # ====================================================================
+        # INTEGRATION — Mayer-only control OCP (exercises lagrange === nothing)
+        # ====================================================================
+
+        Test.@testset "Integration: Mayer-only control flow (no Lagrange)" begin
+            # ẋ = -x + u, mayer only ; H̃ = p(-x+u) (no running cost).
+            law = Data.DynClosedLoop((x, p) -> p)
+            f = Flows.Flow(OCP_MAYER, law; _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xf, pf = f(t0, x0, p0, tf)
+            Test.@test xf isa Number && isfinite(xf)
+            Test.@test pf isa Number && isfinite(pf)
+            # ṗ = -∂H̃/∂x = p ⇒ p(tf) = p0·e^{tf}
+            Test.@test pf ≈ p0 * exp(tf) atol = 1e-6
+            # objective is the Mayer term x(tf); solution builds without a Lagrange integral
+            sol = f((t0, tf), x0, p0)
+            Test.@test CTModels.objective(sol) ≈ xf atol = 1e-6
+        end
+
+        # ====================================================================
+        # CONTRACT — the dynamics receives scalars for 1-D, vectors for n-D
+        # ====================================================================
+
+        Test.@testset "Contract: dynamics sees scalar x,u for 1-D" begin
+            _DYN_SEEN[] = nothing
+            f = Flows.Flow(OCP_TYPED_1D, Data.DynClosedLoop((x, p) -> p); _opts()...)
+            f(0.0, 1.0, 0.5, 1.0)
+            xseen, useen, _ = _DYN_SEEN[]
+            Test.@test xseen isa Number   # 1-D state → scalar (Dual during AD, still a Number)
+            Test.@test useen isa Number   # 1-D control → scalar
+        end
+
+        Test.@testset "Contract: dynamics sees vector x for n-D" begin
+            _DYN_SEEN[] = nothing
+            f = Flows.Flow(OCP_TYPED_2D, Data.DynClosedLoop((x, p) -> p[2]); _opts()...)
+            f(0.0, [1.0, 0.0], [1.0, 1.0], 1.0)
+            xseen, useen, _ = _DYN_SEEN[]
+            Test.@test xseen isa AbstractVector && length(xseen) == 2   # 2-D state → vector
+            Test.@test useen isa Number   # 1-D control → scalar even when the state is a vector
         end
 
         # ====================================================================

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -1,0 +1,233 @@
+"""
+Integration tests for control flows: Flow(ocp, law) and Flow(h̃, law), with the
+`:total` / `:partial` Hamiltonian modes, on OCPs with a control law.
+"""
+
+module TestOCPControl
+
+using Test: Test
+import CTBase.Data: Data
+import CTBase.Traits: Traits
+import CTBase.Exceptions: Exceptions
+import CTModels: CTModels
+import CTFlows.Flows: Flows
+using OrdinaryDiffEqTsit5: Tsit5
+using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const ATOL = 1e-8
+_opts() = (; alg = Tsit5(), reltol = 1e-12, abstol = 1e-12)
+
+# =============================================================================
+# OCP fixtures at module top-level
+# =============================================================================
+
+# scalar LQR: ẋ = -x + u, ℓ = 0.5u², :min  (autonomous, fixed)
+function _build_lqr()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = -x[1] + u[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# double integrator energy: ẋ = [x₂, u], ℓ = 0.5u², :min  (autonomous, fixed)
+function _build_double_integrator()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= [x[2], u[1]]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# non-autonomous: ẋ = u(1 + tan t), ℓ = 0.5u², :min  (non-autonomous, fixed)
+function _build_nonauton()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = false)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = π / 4)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(
+        pre,
+        (r, t, x, u, v) -> (r[1] = u[1] * (1 + tan(t)); nothing),
+    )
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# control-free OCP (for the guard test)
+function _build_control_free()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = true)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange = (t, x, u, v) -> x[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+const OCP_LQR = _build_lqr()
+const OCP_DI = _build_double_integrator()
+const OCP_NA = _build_nonauton()
+const OCP_CF = _build_control_free()
+
+function test_ocp_control()
+    Test.@testset "OCP control flows" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # INTEGRATION — scalar LQR, stationary law u = p (:min ⇒ ∂H̃/∂u = p - u)
+        # ====================================================================
+
+        Test.@testset "Integration: LQR — :total and :partial agree (stationary)" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            ft = Flows.Flow(OCP_LQR, law; hamiltonian_type = :total, _opts()...)
+            fp = Flows.Flow(OCP_LQR, law; hamiltonian_type = :partial, _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xt, pt = ft(t0, x0, p0, tf)
+            xp, pp = fp(t0, x0, p0, tf)
+            Test.@test xt isa Number   # 1-D = scalar convention
+            Test.@test pt isa Number
+            Test.@test xt ≈ xp atol = ATOL
+            Test.@test pt ≈ pp atol = ATOL
+            # costate: ṗ = p ⇒ p(tf) = p0·e^{tf}
+            Test.@test pt ≈ p0 * exp(tf) atol = 1e-6
+            # state (analytic): x(t) = (x0 - p0/2)e^{-t} + (p0/2)e^{t}
+            Test.@test xt ≈ (x0 - p0 / 2) * exp(-tf) + (p0 / 2) * exp(tf) atol = 1e-6
+        end
+
+        # ====================================================================
+        # INTEGRATION — double integrator energy (reference from save/test)
+        # ====================================================================
+
+        Test.@testset "Integration: double integrator energy → xf ≈ [0,0]" begin
+            law = Data.DynClosedLoop((x, p) -> p[2])   # stationary for :min
+            f = Flows.Flow(OCP_DI, law; _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, [-1.0, 0.0], [12.0, 6.0]
+            xf, pf = f(t0, x0, p0, tf)
+            Test.@test xf isa AbstractVector && length(xf) == 2
+            Test.@test xf ≈ [0.0, 0.0] atol = 1e-6
+
+            fp = Flows.Flow(OCP_DI, law; hamiltonian_type = :partial, _opts()...)
+            xfp, pfp = fp(t0, x0, p0, tf)
+            Test.@test xf ≈ xfp atol = ATOL   # agree at stationarity
+        end
+
+        # ====================================================================
+        # INTEGRATION — non-autonomous + convenience Flow(ocp, u::Function)
+        # ====================================================================
+
+        Test.@testset "Integration: non-autonomous, convenience constructor" begin
+            # law u(t,x,p) = p(1 + tan t) is stationary; reference xf value.
+            # OCP_NA is non-autonomous, so the convenience law inherits (t,x,p) arity.
+            f = Flows.Flow(OCP_NA, (t, x, p) -> p * (1 + tan(t)); _opts()...)
+            t0, tf, x0, p0 = 0.0, π / 4, 0.0, 1.0
+            xf, pf = f(t0, x0, p0, tf)
+            xf_ref = tan(π / 4) - 2 * log(√(2) / 2)
+            Test.@test xf ≈ xf_ref atol = 1e-6
+        end
+
+        # ====================================================================
+        # INTEGRATION — non-stationary law ⇒ :total ≠ :partial (mandatory)
+        # ====================================================================
+
+        Test.@testset "Integration: non-stationary law separates :total and :partial" begin
+            # double integrator, stationary law is u = p[2]; use u = p[2] + 1.
+            law = Data.DynClosedLoop((x, p) -> p[2] + 1.0)
+            ft = Flows.Flow(OCP_DI, law; hamiltonian_type = :total, _opts()...)
+            fp = Flows.Flow(OCP_DI, law; hamiltonian_type = :partial, _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, [-1.0, 0.0], [12.0, 6.0]
+            xt, pt = ft(t0, x0, p0, tf)
+            xp, pp = fp(t0, x0, p0, tf)
+            Test.@test !isapprox(xt, xp; atol = 1e-4)   # genuinely different flows
+        end
+
+        # ====================================================================
+        # SOLUTION — trajectory call builds a CTModels.Solution with control
+        # ====================================================================
+
+        Test.@testset "Solution: objective and reconstructed control" begin
+            law = Data.DynClosedLoop((x, p) -> p[2])
+            f = Flows.Flow(OCP_DI, law; _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, [-1.0, 0.0], [12.0, 6.0]
+            sol = f((t0, tf), x0, p0)
+            obj = CTModels.objective(sol)
+            Test.@test obj > 0                       # ∫0.5u² dt > 0
+            # reconstructed control u(t) = p₂(t); positive Lagrange cost is consistent
+            u = CTModels.control(sol)
+            Test.@test u(t0) isa Union{Number,AbstractVector}
+            # :total and :partial give the same objective at stationarity
+            fp = Flows.Flow(OCP_DI, law; hamiltonian_type = :partial, _opts()...)
+            solp = fp((t0, tf), x0, p0)
+            Test.@test obj ≈ CTModels.objective(solp) atol = 1e-6
+        end
+
+        # ====================================================================
+        # INTEGRATION — Flow(h̃, law) directly (no OCP)
+        # ====================================================================
+
+        Test.@testset "Integration: Flow(h̃, law) direct" begin
+            # H̃(x,p,u) = p(-x+u) + 0.5u² ; law u = -p (stationary for this h̃)
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * (-x + u) + 0.5 * u^2)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            ft = Flows.Flow(h̃, law; hamiltonian_type = :total, _opts()...)
+            fp = Flows.Flow(h̃, law; hamiltonian_type = :partial, _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            Test.@test all(isapprox.(ft(t0, x0, p0, tf), fp(t0, x0, p0, tf); atol = ATOL))
+            # costate ṗ = -∂H̃/∂x = p ⇒ p(tf) = p0 e^{tf}
+            _, pf = ft(t0, x0, p0, tf)
+            Test.@test pf ≈ p0 * exp(tf) atol = 1e-6
+        end
+
+        # ====================================================================
+        # ERROR paths
+        # ====================================================================
+
+        Test.@testset "Error: invalid hamiltonian_type" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR,
+                law;
+                hamiltonian_type = :foo,
+                _opts()...,
+            )
+        end
+
+        Test.@testset "Error: control-free OCP with a law" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.PreconditionError Flows.Flow(
+                OCP_CF,
+                law;
+                _opts()...,
+            )
+        end
+
+        Test.@testset "Error: OpenLoop/ClosedLoop law into Flow(ocp, law) → NotImplemented" begin
+            Test.@test_throws Exceptions.NotImplemented Flows.Flow(
+                OCP_LQR,
+                Data.ClosedLoop(x -> -x[1]);
+                _opts()...,
+            )
+        end
+
+        Test.@testset "Error: OpenLoop law into Flow(h̃, law) → PreconditionError" begin
+            h̃ = Data.PseudoHamiltonian((x, p, u) -> p * u)
+            Test.@test_throws Exceptions.PreconditionError Flows.Flow(
+                h̃,
+                Data.OpenLoop(() -> 1.0);
+                _opts()...,
+            )
+        end
+    end
+end
+
+end # module
+
+test_ocp_control() = TestOCPControl.test_ocp_control()

--- a/test/suite/flows/test_ocp_pseudo_hamiltonian.jl
+++ b/test/suite/flows/test_ocp_pseudo_hamiltonian.jl
@@ -1,0 +1,271 @@
+"""
+Unit tests for OCPPseudoHamiltonianFunction and _ocp_pseudo_hamiltonian.
+
+Mirrors test_ocp_hamiltonian.jl for the with-control pseudo-Hamiltonian
+`H̃(t,x,p,u,v) = p·f(t,x,u,v) + sp0·ℓ(t,x,u,v)`: the four natural-arity call methods,
+criterion sign (min ⇒ sp0=-1, max ⇒ sp0=+1), the `lagrange === nothing` branch,
+scalar vs vector inputs, and the `_ocp_pseudo_hamiltonian` builder.
+
+No AD extensions required — pure callable evaluation.
+"""
+
+module TestOCPPseudoHamiltonianFunction
+
+using Test: Test
+using CTModels: CTModels
+import CTFlows.Flows: Flows
+import CTBase.Traits: Traits
+import CTBase.Data: Data
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# =============================================================================
+# Shared dynamics (with control) and cost — module top-level
+# =============================================================================
+
+const λ_TEST = 2.0
+
+# f(t,x,u,v) for each (TD, VD); all depend on the control u
+_dyn_af!(r, _, x, u, _) = (r[1] = λ_TEST * x[1] + u[1]; nothing)
+_dyn_naf!(r, t, x, u, _) = (r[1] = t * x[1] + u[1]; nothing)
+_dyn_anf!(r, _, x, u, v) = (r[1] = v[1] * x[1] + u[1]; nothing)
+_dyn_nanf!(r, t, x, u, v) = (r[1] = t * v[1] * x[1] + u[1]; nothing)
+
+# ℓ(t,x,u,v) — depends on both x and u
+_lag(_, x, u, _) = x[1]^2 + u[1]^2
+
+const _AU = CTModels.Components.Autonomous
+const _NA = CTModels.Components.NonAutonomous
+
+# =============================================================================
+# OCPPseudoHamiltonianFunction fixtures (module top-level)
+# =============================================================================
+
+const HT_AF_NL =
+    Flows.OCPPseudoHamiltonianFunction{_AU,Traits.Fixed,typeof(_dyn_af!),Nothing}(
+        _dyn_af!,
+        nothing,
+        -1.0,
+        1,
+    )
+const HT_AF_LAG_MIN =
+    Flows.OCPPseudoHamiltonianFunction{_AU,Traits.Fixed,typeof(_dyn_af!),typeof(_lag)}(
+        _dyn_af!,
+        _lag,
+        -1.0,
+        1,
+    )
+const HT_AF_LAG_MAX =
+    Flows.OCPPseudoHamiltonianFunction{_AU,Traits.Fixed,typeof(_dyn_af!),typeof(_lag)}(
+        _dyn_af!,
+        _lag,
+        +1.0,
+        1,
+    )
+const HT_NAF_NL =
+    Flows.OCPPseudoHamiltonianFunction{_NA,Traits.Fixed,typeof(_dyn_naf!),Nothing}(
+        _dyn_naf!,
+        nothing,
+        -1.0,
+        1,
+    )
+const HT_ANF_NL =
+    Flows.OCPPseudoHamiltonianFunction{_AU,Traits.NonFixed,typeof(_dyn_anf!),Nothing}(
+        _dyn_anf!,
+        nothing,
+        -1.0,
+        1,
+    )
+const HT_NANF_NL =
+    Flows.OCPPseudoHamiltonianFunction{_NA,Traits.NonFixed,typeof(_dyn_nanf!),Nothing}(
+        _dyn_nanf!,
+        nothing,
+        -1.0,
+        1,
+    )
+
+# =============================================================================
+# OCP fixtures for _ocp_pseudo_hamiltonian
+# =============================================================================
+
+function _build_ocp(criterion; autonomous = true, variable = false, lagrange = nothing)
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous = autonomous)
+    CTModels.Building.time!(pre; t0 = 0.0, tf = 1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    variable && CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[1] + u[1]; nothing))
+    if lagrange === nothing
+        CTModels.Building.objective!(pre, criterion; mayer = (x0, xf, v) -> xf[1])
+    else
+        CTModels.Building.objective!(pre, criterion; lagrange = lagrange)
+    end
+    return CTModels.Building.build(pre)
+end
+
+const OCP_MIN_LAG = _build_ocp(:min; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+const OCP_MAX_LAG = _build_ocp(:max; lagrange = (t, x, u, v) -> 0.5 * u[1]^2)
+const OCP_MIN_MAYER = _build_ocp(:min)
+const OCP_NANF =
+    _build_ocp(:min; autonomous = false, variable = true, lagrange = (t, x, u, v) -> u[1]^2)
+
+function test_ocp_pseudo_hamiltonian()
+    Test.@testset "OCP PseudoHamiltonian Function" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ── call methods, all four (TD, VD) arities ──────────────────────────
+
+        Test.@testset "Unit: Auton/Fixed (x,p,u) — no lagrange" begin
+            x = [2.0];
+            p = [3.0];
+            u = [4.0]
+            Test.@test HT_AF_NL(x, p, u) ≈ p[1] * (λ_TEST * x[1] + u[1])
+        end
+
+        Test.@testset "Unit: NonAuton/Fixed (t,x,p,u)" begin
+            t = 2.0;
+            x = [3.0];
+            p = [5.0];
+            u = [1.5]
+            Test.@test HT_NAF_NL(t, x, p, u) ≈ p[1] * (t * x[1] + u[1])
+        end
+
+        Test.@testset "Unit: Auton/NonFixed (x,p,u,v)" begin
+            x = [2.0];
+            p = [3.0];
+            u = [1.0];
+            v = [4.0]
+            Test.@test HT_ANF_NL(x, p, u, v) ≈ p[1] * (v[1] * x[1] + u[1])
+        end
+
+        Test.@testset "Unit: NonAuton/NonFixed (t,x,p,u,v)" begin
+            t = 2.0;
+            x = [3.0];
+            p = [5.0];
+            u = [1.0];
+            v = [4.0]
+            Test.@test HT_NANF_NL(t, x, p, u, v) ≈ p[1] * (t * v[1] * x[1] + u[1])
+        end
+
+        # ── criterion sign (min ⇒ sp0=-1, max ⇒ sp0=+1) ──────────────────────
+
+        Test.@testset "Unit: min criterion ⇒ sp0 = -1" begin
+            x = [2.0];
+            p = [3.0];
+            u = [4.0]
+            Test.@test HT_AF_LAG_MIN(x, p, u) ≈
+                       p[1] * (λ_TEST * x[1] + u[1]) - (x[1]^2 + u[1]^2)
+        end
+
+        Test.@testset "Unit: max criterion ⇒ sp0 = +1" begin
+            x = [2.0];
+            p = [3.0];
+            u = [4.0]
+            Test.@test HT_AF_LAG_MAX(x, p, u) ≈
+                       p[1] * (λ_TEST * x[1] + u[1]) + (x[1]^2 + u[1]^2)
+        end
+
+        Test.@testset "Unit: lagrange === nothing ⇒ H̃ = p·f exactly" begin
+            x = [1.5];
+            p = [2.5];
+            u = [0.5]
+            Test.@test HT_AF_NL(x, p, u) == p[1] * (λ_TEST * x[1] + u[1])
+        end
+
+        # ── scalar vs vector inputs (n_x=1) ──────────────────────────────────
+
+        Test.@testset "Unit: scalar x,p,u give same result as 1-vectors" begin
+            Test.@test HT_AF_LAG_MIN(2.0, 3.0, 4.0) ≈ HT_AF_LAG_MIN([2.0], [3.0], [4.0])
+        end
+
+        Test.@testset "Unit: scalar x,p,u,v give same result as 1-vectors (NonFixed)" begin
+            Test.@test HT_ANF_NL(2.0, 3.0, 1.0, 4.0) ≈ HT_ANF_NL([2.0], [3.0], [1.0], [4.0])
+        end
+
+        # ── _ocp_pseudo_hamiltonian builder ──────────────────────────────────
+
+        Test.@testset "Unit: _ocp_pseudo_hamiltonian returns a Data.PseudoHamiltonian" begin
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_MIN_LAG)
+            Test.@test h̃ isa Data.PseudoHamiltonian
+            Test.@test h̃ isa Data.AbstractPseudoHamiltonian{
+                CTModels.Components.Autonomous,
+                Traits.Fixed,
+            }
+        end
+
+        Test.@testset "Unit: _ocp_pseudo_hamiltonian TD/VD match OCP (NonAuton/NonFixed)" begin
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_NANF)
+            Test.@test h̃ isa Data.AbstractPseudoHamiltonian{
+                CTModels.Components.NonAutonomous,
+                Traits.NonFixed,
+            }
+        end
+
+        Test.@testset "Unit: _ocp_pseudo_hamiltonian min vs max sp0" begin
+            h̃_min = Flows._ocp_pseudo_hamiltonian(OCP_MIN_LAG)
+            h̃_max = Flows._ocp_pseudo_hamiltonian(OCP_MAX_LAG)
+            # f(x,u)=x+u, ℓ=0.5u² ; H̃ = p(x+u) + sp0·0.5u²
+            x = [2.0];
+            p = [0.0];
+            u = [3.0]   # p=0 isolates the sp0·ℓ term
+            Test.@test h̃_min(x, p, u) ≈ -0.5 * u[1]^2
+            Test.@test h̃_max(x, p, u) ≈ +0.5 * u[1]^2
+        end
+
+        Test.@testset "Unit: _ocp_pseudo_hamiltonian without lagrange ⇒ H̃ = p·f" begin
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_MIN_MAYER)   # Mayer only, no lagrange
+            x = [2.0];
+            p = [3.0];
+            u = [4.0]
+            Test.@test h̃(x, p, u) ≈ p[1] * (x[1] + u[1])   # f(x,u)=x+u, no running cost
+        end
+
+        # ── ComposedHamiltonian from an OCP (the :total Hamiltonian value) ────
+
+        Test.@testset "Unit: ComposedHamiltonian from OCP — :total Hamiltonian value (min)" begin
+            # OCP_MIN_LAG: f(x,u)=x+u, ℓ=0.5u², :min ⇒ H̃(x,p,u)=p(x+u)-0.5u²
+            # law u(x,p)=-p ⇒ H(x,p)=H̃(x,p,-p)=p(x-p)-0.5p²
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_MIN_LAG)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            H = Data.ComposedHamiltonian(h̃, law)
+            Test.@test H isa Data.AbstractHamiltonian
+            x = [2.0];
+            p = [3.0]
+            Test.@test H(x, p) ≈ p[1] * (x[1] - p[1]) - 0.5 * p[1]^2
+        end
+
+        Test.@testset "Unit: ComposedHamiltonian from OCP — sign flips with :max" begin
+            # OCP_MAX_LAG: same f, ℓ, but :max ⇒ H̃=p(x+u)+0.5u² ; H(x,p)=p(x-p)+0.5p²
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_MAX_LAG)
+            law = Data.DynClosedLoop((x, p) -> -p)
+            H = Data.ComposedHamiltonian(h̃, law)
+            x = [2.0];
+            p = [3.0]
+            Test.@test H(x, p) ≈ p[1] * (x[1] - p[1]) + 0.5 * p[1]^2
+        end
+
+        Test.@testset "Unit: ComposedHamiltonian from OCP — NonAuton/NonFixed value" begin
+            # OCP_NANF: f(x,u)=x+u (autonomous dynamics but declared NonAuton/NonFixed),
+            # ℓ=u², :min ⇒ H̃(t,x,p,u,v)=p(x+u)-u² ; law u(t,x,p,v)=v·p
+            h̃ = Flows._ocp_pseudo_hamiltonian(OCP_NANF)
+            law = Data.DynClosedLoop(
+                (t, x, p, v) -> v[1] * p;
+                is_autonomous = false,
+                is_variable = true,
+            )
+            H = Data.ComposedHamiltonian(h̃, law)
+            t = 0.7;
+            x = [2.0];
+            p = [3.0];
+            v = [1.5]
+            u = v[1] * p[1]
+            Test.@test H(t, x, p, v) ≈ p[1] * (x[1] + u) - u^2
+        end
+    end
+end
+
+end # module
+
+test_ocp_pseudo_hamiltonian() =
+    TestOCPPseudoHamiltonianFunction.test_ocp_pseudo_hamiltonian()


### PR DESCRIPTION
## Summary

Wires the user-facing **control flows** on top of the Systems layer (#303): build a Hamiltonian flow from an OCP (or a pseudo-Hamiltonian) and a **dynamic closed-loop control law** `u(t,x,p,v)`, in two modes:

- **`:total`** (default) — compose the law into the pseudo-Hamiltonian (`Data.ComposedHamiltonian`) and use a `HamiltonianSystem`; AD differentiates *through* the law.
- **`:partial`** — `PseudoHamiltonianSystem`; AD takes partials of `H̃` at the fixed feedback value. Coincides with `:total` only where the feedback is stationary (`∂H̃/∂u = 0`).

## What's added

- `Flow(h̃::PseudoHamiltonian, law::ControlLaw; kwargs...)` — intermediate constructor (no OCP), trait-dispatched on `feedback(law)` then on the `hamiltonian_type` action option.
- `Flow(ocp::Model, law::ControlLaw; kwargs...)` — builds the OCP pseudo-Hamiltonian `H̃ = p·f + sp0·ℓ` (new `OCPPseudoHamiltonianFunction` / `_ocp_pseudo_hamiltonian`), then reuses the `:total`/`:partial` machinery.
- `Flow(ocp, u::Function)` convenience — wraps `u` in a `DynClosedLoop` law with the **OCP's** time/variable dependence (so `u` must match the OCP's arity; use an explicit `DynClosedLoop` for different traits).
- `hamiltonian_type` routed as a first-class **action option** (`_flow_action_defs`, `_unwrap_option`), accepted only on the control-law constructors and rejected elsewhere.
- `OptimalControlFlow` carries the control law (`CL` type param, `nothing` for control-free); the trajectory `Solution` reconstructs `u(t) = law(t,x(t),p(t),v)` for the Lagrange objective and the returned `CTModels.Solution`.

## Error paths

- `OpenLoop`/`ClosedLoop` into `Flow(h̃, law)` → `PreconditionError` (H̃ needs the costate).
- `OpenLoop`/`ClosedLoop` into `Flow(ocp, law)` → `NotImplemented` (state-only flows not wired yet).
- control-free OCP + law → `PreconditionError`; invalid `hamiltonian_type` → `IncorrectArgument`.

## Tests

`test/suite/flows/test_ocp_control.jl`: scalar LQR, double-integrator energy (`xf ≈ [0,0]`, reference from `save/test`), non-autonomous, the **mandatory non-stationary case where `:total ≠ :partial`**, `Flow(h̃, law)` direct, solution/objective agreement, and all error paths. Full suite green: **2092/2092**.

## Depends on

CTBase ≥ 0.26.2 (`ComposedHamiltonian`, `pseudo_variable_gradient`) and the Systems layer from #303 (now on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)