### PR TITLE
Replace HVF-getter closures with callable structs

### DIFF
--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -64,6 +64,15 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                 joinpath("Systems", "pseudo_hamiltonian_system.jl"),
                 joinpath("Systems", "building.jl"),
                 joinpath("Systems", "hamiltonian_getter.jl"),
+                joinpath("Systems", "hamiltonian_getters_extra.jl"),
+            ),
+        ),
+        (
+            mod=CTFlows.Display,
+            title="Display",
+            filename="display",
+            files=src(
+                joinpath("Display", "Display.jl"),
             ),
         ),
         (
@@ -124,7 +133,16 @@ function generate_api_reference(src_dir::String, ext_dir::String)
             title="Plots Extension",
             title_in_menu="Plots",
             filename="ext_plots",
-            files=ext("CTFlowsPlots.jl"),
+            files=ext(
+                "CTFlowsPlots.jl",
+                joinpath("CTFlowsPlots", "PlotEngine", "PlotEngine.jl"),
+                joinpath("CTFlowsPlots", "PlotEngine", "panel.jl"),
+                joinpath("CTFlowsPlots", "PlotEngine", "render.jl"),
+                joinpath("CTFlowsPlots", "TrajectoryPlots", "TrajectoryPlots.jl"),
+                joinpath("CTFlowsPlots", "TrajectoryPlots", "description.jl"),
+                joinpath("CTFlowsPlots", "TrajectoryPlots", "panels.jl"),
+                joinpath("CTFlowsPlots", "TrajectoryPlots", "plot.jl"),
+            ),
         ),
         (
             sym=:CTFlowsSciMLIntegrator,

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -28,7 +28,18 @@ import CTBase.Core
 # Tree characters (styled with the `muted` palette role at print time)
 # ==============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Tree-branch prefix for a mid-list field (`├─ `), styled with the `muted` palette role at print time.
+"""
 const BRANCH_MID = "├─ "
+
+"""
+$(TYPEDSIGNATURES)
+
+Tree-branch prefix for the last field in a list (`└─ `), styled with the `muted` palette role at print time.
+"""
 const BRANCH_END = "└─ "
 
 """

--- a/src/Flows/abstract_flow.jl
+++ b/src/Flows/abstract_flow.jl
@@ -301,7 +301,7 @@ control law, in either the `:partial` or the `:total` mode. Delegates to
 # Throws
 - `CTBase.Exceptions.IncorrectArgument`: for a flow that carries no control law.
 
-See also: [`CTFlows.Flows.hamiltonian`](@ref), [`CTFlows.Flows.control_law`](@ref).
+See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.control_law`](@ref).
 """
 function Systems.pseudo_hamiltonian(
     f::AbstractFlow{
@@ -320,7 +320,7 @@ control law. Delegates to [`CTFlows.Systems.control_law`](@ref).
 # Throws
 - `CTBase.Exceptions.IncorrectArgument`: for a flow that carries no control law.
 
-See also: [`CTFlows.Flows.pseudo_hamiltonian`](@ref).
+See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref).
 """
 function Systems.control_law(
     f::AbstractFlow{
@@ -337,7 +337,7 @@ Return a callable `(t, x, p, v) -> (∂H/∂x, ∂H/∂p)` for the true Hamilton
 Hamiltonian flow. Delegates to [`CTFlows.Systems.hamiltonian_gradient`](@ref); the
 `ad_backend` keyword (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Flows.hamiltonian`](@ref), [`CTFlows.Flows.variable_gradient`](@ref).
+See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.variable_gradient`](@ref).
 """
 function Systems.hamiltonian_gradient(
     f::AbstractFlow{
@@ -356,7 +356,7 @@ flow — the quantity (before negation) driving `ṗv = -∂H/∂v`. Delegates t
 [`CTFlows.Systems.variable_gradient`](@ref); the `ad_backend` keyword (default: the
 system's backend) selects the AD backend.
 
-See also: [`CTFlows.Flows.hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.hamiltonian_gradient`](@ref).
 """
 function Systems.variable_gradient(
     f::AbstractFlow{
@@ -375,7 +375,7 @@ Hamiltonian flow (differentiated at fixed control), when available. Delegates to
 [`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref); the `ad_backend` keyword
 (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Flows.pseudo_hamiltonian`](@ref), [`CTFlows.Flows.pseudo_variable_gradient`](@ref).
+See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.pseudo_variable_gradient`](@ref).
 """
 function Systems.pseudo_hamiltonian_gradient(
     f::AbstractFlow{
@@ -394,7 +394,7 @@ Hamiltonian flow (differentiated at fixed control), when available. Delegates to
 [`CTFlows.Systems.pseudo_variable_gradient`](@ref); the `ad_backend` keyword
 (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Flows.pseudo_hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref).
 """
 function Systems.pseudo_variable_gradient(
     f::AbstractFlow{

--- a/src/Flows/controlled_flow.jl
+++ b/src/Flows/controlled_flow.jl
@@ -55,7 +55,7 @@ system(F::ControlledFlow) = system(F.flow)
 """
 $(TYPEDSIGNATURES)
 
-Return the underlying [`CTFlows.Integrators.AbstractIntegrator`](@ref) of the inner
+Return the underlying [`CTSolvers.Integrators.AbstractIntegrator`](@extref) of the inner
 state flow.
 """
 integrator(F::ControlledFlow) = integrator(F.flow)

--- a/src/Systems/hamiltonian_getter.jl
+++ b/src/Systems/hamiltonian_getter.jl
@@ -3,303 +3,156 @@
 # ==============================================================================
 
 # ==============================================================================
-# Out-of-place closure factories (4 variants)
+# Getter functors — callable structs replacing the per-trait closure factories.
+#
+# `HVFOoPFunctor` / `HVFIpFunctor` store the Hamiltonian and the AD backend in fields
+# and compute X_H = (∂H/∂p, -∂H/∂x) on call. Being `<: Function` lets them be stored in
+# a `Data.HamiltonianVectorField` (whose field is constrained `F <: Function`). The call
+# operator is dispatched on the time/variable-dependence traits carried by the wrapped
+# Hamiltonian `H`, mirroring the call operators of `CTBase.Data.Hamiltonian`.
 # ==============================================================================
 
 """
-$(TYPEDSIGNATURES)
+$(TYPEDEF)
 
-Create an out-of-place Hamiltonian vector field closure for the Autonomous/Fixed case.
+Out-of-place Hamiltonian vector field functor: computes `X_H = (∂H/∂p, -∂H/∂x)` from a
+scalar Hamiltonian by automatic differentiation, allocating and returning the result.
 
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for an autonomous
-Hamiltonian system with fixed parameters. The signature is `(x, p) -> (∂p, -∂x)`.
+# Fields
+- `h::H`: the scalar Hamiltonian.
+- `backend::B`: the AD backend used to compute the gradients.
 
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.Autonomous}: Type parameter indicating autonomous time dependence.
-- `::Type{Traits.Fixed}`: Type parameter indicating fixed variable dependence.
+# Call signatures
 
-# Returns
-- `Function`: A closure `(x, p) -> (∂p, -∂x)` computing the Hamiltonian vector field.
+Dispatched on the Hamiltonian's time/variable-dependence traits:
+- Autonomous/Fixed — `(x, p) -> (∂p, -∂x)`
+- NonAutonomous/Fixed — `(t, x, p) -> (∂p, -∂x)`
+- Autonomous/NonFixed — `(x, p, v; variable_costate=false) -> (∂p, -∂x)`, or
+  `(∂p, -∂x, -∂v)` when `variable_costate=true`
+- NonAutonomous/NonFixed — `(t, x, p, v; variable_costate=false) -> (∂p, -∂x)`, or
+  `(∂p, -∂x, -∂v)` when `variable_costate=true`
 
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref)
+See also: [`CTFlows.Systems.HVFIpFunctor`](@ref), [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
 """
-function _make_oop_hvf(h, backend, ::Type{Traits.Autonomous}, ::Type{Traits.Fixed})
-    return (x, p) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, nothing, x, p, nothing)
-        return (∂p, -∂x)
-    end
+struct HVFOoPFunctor{H<:Data.Hamiltonian,B<:Differentiation.AbstractADBackend} <: Function
+    h::H
+    backend::B
+end
+
+function (g::HVFOoPFunctor{<:Data.Hamiltonian{<:Function,Traits.Autonomous,Traits.Fixed}})(
+    x, p
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, nothing, x, p, nothing)
+    return (∂p, -∂x)
+end
+
+function (g::HVFOoPFunctor{<:Data.Hamiltonian{<:Function,Traits.NonAutonomous,Traits.Fixed}})(
+    t, x, p
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, t, x, p, nothing)
+    return (∂p, -∂x)
+end
+
+function (g::HVFOoPFunctor{<:Data.Hamiltonian{<:Function,Traits.Autonomous,Traits.NonFixed}})(
+    x, p, v; variable_costate::Bool=false
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, nothing, x, p, v)
+    variable_costate || return (∂p, -∂x)
+    ∂v = Differentiation.variable_gradient(g.backend, g.h, nothing, x, p, v)
+    return (∂p, -∂x, -∂v)
+end
+
+function (g::HVFOoPFunctor{<:Data.Hamiltonian{<:Function,Traits.NonAutonomous,Traits.NonFixed}})(
+    t, x, p, v; variable_costate::Bool=false
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, t, x, p, v)
+    variable_costate || return (∂p, -∂x)
+    ∂v = Differentiation.variable_gradient(g.backend, g.h, t, x, p, v)
+    return (∂p, -∂x, -∂v)
 end
 
 """
-$(TYPEDSIGNATURES)
+$(TYPEDEF)
 
-Create an out-of-place Hamiltonian vector field closure for the NonAutonomous/Fixed case.
+In-place Hamiltonian vector field functor: writes `X_H = (∂H/∂p, -∂H/∂x)` into the
+preallocated buffers `dx`, `dp`.
 
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for a non-autonomous
-Hamiltonian system with fixed parameters. The signature is `(t, x, p) -> (∂p, -∂x)`.
+# Fields
+- `h::H`: the scalar Hamiltonian.
+- `backend::B`: the AD backend used to compute the gradients.
 
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.NonAutonomous}`: Type parameter indicating non-autonomous time dependence.
-- `::Type{Traits.Fixed}`: Type parameter indicating fixed variable dependence.
+# Call signatures
 
-# Returns
-- `Function`: A closure `(t, x, p) -> (∂p, -∂x)` computing the Hamiltonian vector field.
+Dispatched on the Hamiltonian's time/variable-dependence traits:
+- Autonomous/Fixed — `(dx, dp, x, p) -> nothing`
+- NonAutonomous/Fixed — `(dx, dp, t, x, p) -> nothing`
+- Autonomous/NonFixed — `(dx, dp, x, p, v; dpv=nothing, variable_costate=false) -> nothing`
+- NonAutonomous/NonFixed — `(dx, dp, t, x, p, v; dpv=nothing, variable_costate=false) -> nothing`
 
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
+When `variable_costate=true`, the preallocated buffer `dpv` (matching the shape of `v`)
+is filled with `-∂H/∂v`; it must be provided or a `PreconditionError` is thrown.
 
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref)
+See also: [`CTFlows.Systems.HVFOoPFunctor`](@ref), [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
 """
-function _make_oop_hvf(h, backend, ::Type{Traits.NonAutonomous}, ::Type{Traits.Fixed})
-    return (t, x, p) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, nothing)
-        return (∂p, -∂x)
-    end
+struct HVFIpFunctor{H<:Data.Hamiltonian,B<:Differentiation.AbstractADBackend} <: Function
+    h::H
+    backend::B
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Create an out-of-place Hamiltonian vector field closure for the Autonomous/NonFixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for an autonomous
-Hamiltonian system with variable parameters. The signature is `(x, p, v; variable_costate=false) -> (∂p, -∂x)`
-or `(x, p, v; variable_costate=true) -> (∂p, -∂x, -∂v)` when the variable costate is requested.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.Autonomous}`: Type parameter indicating autonomous time dependence.
-- `::Type{Traits.NonFixed}`: Type parameter indicating non-fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(x, p, v; variable_costate=false)` computing the Hamiltonian vector field.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- When `variable_costate=true`, the closure also returns `-∂H/∂v` (the negative gradient with respect to variables).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref), [`CTBase.Differentiation.variable_gradient`](@extref)
-"""
-function _make_oop_hvf(h, backend, ::Type{Traits.Autonomous}, ::Type{Traits.NonFixed})
-    return (x, p, v; variable_costate::Bool=false) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, nothing, x, p, v)
-        variable_costate || return (∂p, -∂x)
-        ∂v = Differentiation.variable_gradient(backend, h, nothing, x, p, v)
-        return (∂p, -∂x, -∂v)
-    end
+function (g::HVFIpFunctor{<:Data.Hamiltonian{<:Function,Traits.Autonomous,Traits.Fixed}})(
+    dx, dp, x, p
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, nothing, x, p, nothing)
+    dx .= ∂p
+    dp .= .-∂x
+    return nothing
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Create an out-of-place Hamiltonian vector field closure for the NonAutonomous/NonFixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for a non-autonomous
-Hamiltonian system with variable parameters. The signature is `(t, x, p, v; variable_costate=false) -> (∂p, -∂x)`
-or `(t, x, p, v; variable_costate=true) -> (∂p, -∂x, -∂v)` when the variable costate is requested.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.NonAutonomous}`: Type parameter indicating non-autonomous time dependence.
-- `::Type{Traits.NonFixed}`: Type parameter indicating non-fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(t, x, p, v; variable_costate=false)` computing the Hamiltonian vector field.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- When `variable_costate=true`, the closure also returns `-∂H/∂v` (the negative gradient with respect to variables).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref), [`CTBase.Differentiation.variable_gradient`](@extref)
-"""
-function _make_oop_hvf(h, backend, ::Type{Traits.NonAutonomous}, ::Type{Traits.NonFixed})
-    return (t, x, p, v; variable_costate::Bool=false) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, v)
-        variable_costate || return (∂p, -∂x)
-        ∂v = Differentiation.variable_gradient(backend, h, t, x, p, v)
-        return (∂p, -∂x, -∂v)
-    end
+function (g::HVFIpFunctor{<:Data.Hamiltonian{<:Function,Traits.NonAutonomous,Traits.Fixed}})(
+    dx, dp, t, x, p
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, t, x, p, nothing)
+    dx .= ∂p
+    dp .= .-∂x
+    return nothing
 end
 
-# ==============================================================================
-# In-place closure factories (4 variants)
-# ==============================================================================
-
-"""
-$(TYPEDSIGNATURES)
-
-Create an in-place Hamiltonian vector field closure for the Autonomous/Fixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for an autonomous
-Hamiltonian system with fixed parameters, writing the result in-place. The signature is
-`(dx, dp, x, p) -> nothing` and fills `dx .= ∂p, dp .= -∂x`.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.Autonomous}`: Type parameter indicating autonomous time dependence.
-- `::Type{Traits.Fixed}`: Type parameter indicating fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(dx, dp, x, p) -> nothing` that fills the output arrays in-place.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-- Output arrays `dx` and `dp` must be pre-allocated with the correct dimensions.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref)
-"""
-function _make_ip_hvf(h, backend, ::Type{Traits.Autonomous}, ::Type{Traits.Fixed})
-    return (dx, dp, x, p) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, nothing, x, p, nothing)
-        dx .= ∂p
-        dp .= .-∂x
-        return nothing
+function (g::HVFIpFunctor{<:Data.Hamiltonian{<:Function,Traits.Autonomous,Traits.NonFixed}})(
+    dx, dp, x, p, v; dpv=nothing, variable_costate::Bool=false
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, nothing, x, p, v)
+    dx .= ∂p
+    dp .= .-∂x
+    if variable_costate
+        dpv === nothing && throw(
+            Exceptions.PreconditionError(
+                "dpv buffer must be provided when variable_costate=true";
+                context="hamiltonian_vector_field IP Autonomous/NonFixed",
+            ),
+        )
+        ∂v = Differentiation.variable_gradient(g.backend, g.h, nothing, x, p, v)
+        dpv .= .-∂v
     end
+    return nothing
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Create an in-place Hamiltonian vector field closure for the NonAutonomous/Fixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for a non-autonomous
-Hamiltonian system with fixed parameters, writing the result in-place. The signature is
-`(dx, dp, t, x, p) -> nothing` and fills `dx .= ∂p, dp .= -∂x`.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.NonAutonomous}`: Type parameter indicating non-autonomous time dependence.
-- `::Type{Traits.Fixed}`: Type parameter indicating fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(dx, dp, t, x, p) -> nothing` that fills the output arrays in-place.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-- Output arrays `dx` and `dp` must be pre-allocated with the correct dimensions.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref)
-"""
-function _make_ip_hvf(h, backend, ::Type{Traits.NonAutonomous}, ::Type{Traits.Fixed})
-    return (dx, dp, t, x, p) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, nothing)
-        dx .= ∂p
-        dp .= .-∂x
-        return nothing
+function (g::HVFIpFunctor{<:Data.Hamiltonian{<:Function,Traits.NonAutonomous,Traits.NonFixed}})(
+    dx, dp, t, x, p, v; dpv=nothing, variable_costate::Bool=false
+)
+    ∂x, ∂p = Differentiation.hamiltonian_gradient(g.backend, g.h, t, x, p, v)
+    dx .= ∂p
+    dp .= .-∂x
+    if variable_costate
+        dpv === nothing && throw(
+            Exceptions.PreconditionError(
+                "dpv buffer must be provided when variable_costate=true";
+                context="hamiltonian_vector_field IP NonAutonomous/NonFixed",
+            ),
+        )
+        ∂v = Differentiation.variable_gradient(g.backend, g.h, t, x, p, v)
+        dpv .= .-∂v
     end
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Create an in-place Hamiltonian vector field closure for the Autonomous/NonFixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for an autonomous
-Hamiltonian system with variable parameters, writing the result in-place. The signature is
-`(dx, dp, x, p, v) -> nothing` and fills `dx .= ∂p, dp .= -∂x`.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.Autonomous}`: Type parameter indicating autonomous time dependence.
-- `::Type{Traits.NonFixed}`: Type parameter indicating non-fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(dx, dp, x, p, v; dpv=nothing, variable_costate=false) -> nothing` that fills the output arrays in-place.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-- Output arrays `dx` and `dp` must be pre-allocated with the correct dimensions.
-- When `variable_costate=true`, `dpv` must be a pre-allocated mutable array matching the shape of `v`; it is filled with `-∂H/∂v`.
-
-# Throws
-- `Exceptions.PreconditionError`: When `variable_costate=true && dpv === nothing`.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref), [`CTBase.Differentiation.variable_gradient`](@extref)
-"""
-function _make_ip_hvf(h, backend, ::Type{Traits.Autonomous}, ::Type{Traits.NonFixed})
-    return (dx, dp, x, p, v; dpv=nothing, variable_costate::Bool=false) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, nothing, x, p, v)
-        dx .= ∂p
-        dp .= .-∂x
-        if variable_costate
-            dpv === nothing && throw(
-                Exceptions.PreconditionError(
-                    "dpv buffer must be provided when variable_costate=true";
-                    context="hamiltonian_vector_field IP Autonomous/NonFixed",
-                ),
-            )
-            ∂v = Differentiation.variable_gradient(backend, h, nothing, x, p, v)
-            dpv .= .-∂v
-        end
-        return nothing
-    end
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Create an in-place Hamiltonian vector field closure for the NonAutonomous/NonFixed case.
-
-The closure computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for a non-autonomous
-Hamiltonian system with variable parameters, writing the result in-place. The signature is
-`(dx, dp, t, x, p, v) -> nothing` and fills `dx .= ∂p, dp .= -∂x`.
-
-# Arguments
-- `h::Data.Hamiltonian`: The scalar Hamiltonian function.
-- `backend::Differentiation.AbstractADBackend`: The AD backend for gradient computation.
-- `::Type{Traits.NonAutonomous}`: Type parameter indicating non-autonomous time dependence.
-- `::Type{Traits.NonFixed}`: Type parameter indicating non-fixed variable dependence.
-
-# Returns
-- `Function`: A closure `(dx, dp, t, x, p, v; dpv=nothing, variable_costate=false) -> nothing` that fills the output arrays in-place.
-
-# Notes
-- This is an internal factory function used by [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
-- The closure uses automatic differentiation via the provided backend to compute gradients.
-- Output arrays `dx` and `dp` must be pre-allocated with the correct dimensions.
-- When `variable_costate=true`, `dpv` must be a pre-allocated mutable array matching the shape of `v`; it is filled with `-∂H/∂v`.
-
-# Throws
-- `Exceptions.PreconditionError`: When `variable_costate=true && dpv === nothing`.
-
-See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.hamiltonian_gradient`](@extref), [`CTBase.Differentiation.variable_gradient`](@extref)
-"""
-function _make_ip_hvf(h, backend, ::Type{Traits.NonAutonomous}, ::Type{Traits.NonFixed})
-    return (dx, dp, t, x, p, v; dpv=nothing, variable_costate::Bool=false) -> begin
-        ∂x, ∂p = Differentiation.hamiltonian_gradient(backend, h, t, x, p, v)
-        dx .= ∂p
-        dp .= .-∂x
-        if variable_costate
-            dpv === nothing && throw(
-                Exceptions.PreconditionError(
-                    "dpv buffer must be provided when variable_costate=true";
-                    context="hamiltonian_vector_field IP NonAutonomous/NonFixed",
-                ),
-            )
-            ∂v = Differentiation.variable_gradient(backend, h, t, x, p, v)
-            dpv .= .-∂v
-        end
-        return nothing
-    end
+    return nothing
 end
 
 # ==============================================================================
@@ -312,20 +165,21 @@ $(TYPEDSIGNATURES)
 Get the Hamiltonian vector field from a scalar Hamiltonian function.
 
 This function computes the Hamiltonian vector field X_H = (∂H/∂p, -∂H/∂x) for a given scalar
-Hamiltonian function using automatic differentiation. The returned vector field is a closure
-with the correct signature based on the Hamiltonian's time and variable dependence traits.
+Hamiltonian function using automatic differentiation. The returned vector field wraps a
+callable [`CTFlows.Systems.HVFOoPFunctor`](@ref) or [`CTFlows.Systems.HVFIpFunctor`](@ref)
+whose call signature matches the Hamiltonian's time and variable dependence traits.
 
 # Arguments
 - `h::Data.Hamiltonian{F, TD, VD}`: The scalar Hamiltonian function with traits `TD` (time dependence) and `VD` (variable dependence).
 - `ad_backend`: AD backend type (default: `Differentiation.__ad_backend()` = `AutoForwardDiff()`) or an `AbstractADBackend` instance.
-- `inplace::Bool`: Whether to return an in-place closure (default: `__hvf_inplace()` = `false`).
+- `inplace::Bool`: Whether to return an in-place functor (default: `__hvf_inplace()` = `false`).
 
 # Returns
 - `Data.HamiltonianVectorField`: The Hamiltonian vector field with correct traits matching the input Hamiltonian.
 
 # Notes
 - If `ad_backend` is an `AbstractADBackend` instance, it is used directly; otherwise it is wrapped via `Differentiation.build_ad_backend`.
-- The closure signature depends on the Hamiltonian's traits:
+- The functor call signature depends on the Hamiltonian's traits:
   - Autonomous/Fixed: `(x, p) -> (∂p, -∂x)` or `(dx, dp, x, p) -> nothing` (in-place)
   - NonAutonomous/Fixed: `(t, x, p) -> (∂p, -∂x)` or `(dx, dp, t, x, p) -> nothing` (in-place)
   - Autonomous/NonFixed: `(x, p, v; variable_costate=false) -> (∂p, -∂x)` or `(x, p, v; variable_costate=true) -> (∂p, -∂x, -∂v)`
@@ -344,7 +198,7 @@ function hamiltonian_vector_field(
     else
         Differentiation.build_ad_backend(; ad_backend=ad_backend)
     end
-    f = inplace ? _make_ip_hvf(h, backend, TD, VD) : _make_oop_hvf(h, backend, TD, VD)
+    f = inplace ? HVFIpFunctor(h, backend) : HVFOoPFunctor(h, backend)
     return Data.HamiltonianVectorField(
         f;
         is_autonomous=TD <: Traits.Autonomous,

--- a/src/Systems/hamiltonian_getter.jl
+++ b/src/Systems/hamiltonian_getter.jl
@@ -92,6 +92,9 @@ Dispatched on the Hamiltonian's time/variable-dependence traits:
 When `variable_costate=true`, the preallocated buffer `dpv` (matching the shape of `v`)
 is filled with `-∂H/∂v`; it must be provided or a `PreconditionError` is thrown.
 
+# Throws
+- `Exceptions.PreconditionError`: when `variable_costate=true` and `dpv` is `nothing`.
+
 See also: [`CTFlows.Systems.HVFOoPFunctor`](@ref), [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
 """
 struct HVFIpFunctor{H<:Data.Hamiltonian,B<:Differentiation.AbstractADBackend} <: Function
@@ -271,6 +274,10 @@ Get the Hamiltonian vector field from any `AbstractHamiltonianSystem`, dispatchi
 - `WithoutAD` systems: throws `NotImplemented` — the system must implement
   `hamiltonian_vector_field` directly (as `HamiltonianVectorFieldSystem` does).
 
+# Throws
+- `Exceptions.NotImplemented`: when the system's AD trait is `WithoutAD` and no
+  specialized `hamiltonian_vector_field` overload exists for the system type.
+
 See also: [`CTFlows.Systems.HamiltonianSystem`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
 """
 function hamiltonian_vector_field(
@@ -298,6 +305,18 @@ function _hamiltonian_vector_field_by_ad(
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Throw `NotImplemented` for a `WithoutAD` system that does not provide a specialized
+`hamiltonian_vector_field` overload.
+
+# Throws
+- `Exceptions.NotImplemented`: always, with a suggestion to implement
+  `hamiltonian_vector_field` for the system type or use `HamiltonianVectorFieldSystem`.
+
+See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref).
+"""
 function _hamiltonian_vector_field_by_ad(
     ::Type{Traits.WithoutAD}, sys::AbstractHamiltonianSystem; kwargs...
 )

--- a/test/suite/systems/test_hamiltonian_getter.jl
+++ b/test/suite/systems/test_hamiltonian_getter.jl
@@ -739,6 +739,35 @@ function test_hamiltonian_getter()
         end
 
         # ====================================================================
+        # FUNCTOR TYPE (callable structs, not closures)
+        # ====================================================================
+
+        Test.@testset "Getter wraps HVFOoPFunctor / HVFIpFunctor (still <: Function)" begin
+            h = Data.Hamiltonian(
+                (x, p) -> 0.5 * sum(x .^ 2) + 0.5 * sum(p .^ 2);
+                is_autonomous=true,
+                is_variable=false,
+            )
+            backend = Differentiation.DifferentiationInterface(;
+                ad_backend=ADTypes.AutoForwardDiff()
+            )
+            sys = Systems.HamiltonianSystem(h, backend)
+
+            hvf_oop = Systems.hamiltonian_vector_field(sys; inplace=false)
+            hvf_ip = Systems.hamiltonian_vector_field(sys; inplace=true)
+            # the getter now wraps callable structs rather than anonymous closures
+            Test.@test hvf_oop.f isa Systems.HVFOoPFunctor
+            Test.@test hvf_ip.f isa Systems.HVFIpFunctor
+            # subtyping Function is what lets them live in Data.HamiltonianVectorField
+            Test.@test hvf_oop.f isa Function
+            Test.@test hvf_ip.f isa Function
+            # the functors carry the Hamiltonian and backend in fields (no captured closure)
+            g = Systems.HVFOoPFunctor(h, backend)
+            Test.@test g.h === h
+            Test.@test g.backend === backend
+        end
+
+        # ====================================================================
         # EXPORTS
         # ====================================================================
 


### PR DESCRIPTION
## Summary

- Replaces the 8 closure factories (`_make_oop_hvf` / `_make_ip_hvf` × 4 trait combinations) in `src/Systems/hamiltonian_getter.jl` — which returned anonymous closures — with two callable structs, `HVFOoPFunctor` and `HVFIpFunctor` (`<: Function`), storing the Hamiltonian and AD backend in fields.
- The call operator dispatches on the wrapped Hamiltonian's time/variable-dependence traits, mirroring `CTBase.Data.Hamiltonian`'s own call operators. Subtyping `Function` lets the functors live in `Data.HamiltonianVectorField` (whose field is constrained `F<:Function`), exactly like the existing `OCPHamiltonianFunction` and the trajectory projection functors.
- Removes the last anonymous-closure factories in `src/`, continuing the "callable structs over closures" effort (cf. #245, #256) for the HVF getter — better readability, stack traces, and introspection.

## Behavior

Unchanged. The returned `.f` keeps the same trait-dependent call signatures, including the `variable_costate` / `dpv` keywords and the missing-`dpv` `PreconditionError`. Net diff is −117 lines.

## Test plan

- [x] `test/suite/systems/test_hamiltonian_getter.jl` and `test/suite/flows/test_hamiltonian_getter_flows.jl` pass unchanged — the existing per-trait `hvf.f(...)` assertions are the behavioral regression guard.
- [x] Added a testset asserting the getter now wraps `HVFOoPFunctor` / `HVFIpFunctor` (still `isa Function`) and that the functors carry `h` / `backend` in fields.
- [x] Full suite `Pkg.test()` green: 2209/2209, including Aqua (no method ambiguity from the 4+4 call operators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)