### PR TITLE
feat(flows): constrained pseudo-Hamiltonian flow (:total mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta] - 2026-07-10
+
+### Added
+
+- **Constrained pseudo-Hamiltonian flows (`:total` mode)**: `Flow(ocp, law; constraint, multiplier)`
+  builds the flow of the constrained Hamiltonian `H = H̃ + μ·g`, where `g` is a path
+  constraint and `μ` a user-supplied Lagrange multiplier.
+  - `constraint` accepts a `:path` constraint **label** (`Symbol`), a
+    `CTBase.Data.PathConstraint`, or a plain function with the OCP's natural arity.
+  - `multiplier` accepts a `CTBase.Data.Multiplier` or a plain function `μ(x,p)` /
+    `μ(t,x,p)` / `μ(x,p,v)` / `μ(t,x,p,v)`.
+  - The constraint term is differentiated *through* in the `:total` mode (total derivative,
+    chain-rule through the law and `μ`); a dedicated guide chapter on the `:total` vs
+    `:partial` semantics is planned.
+  - `constraint`/`multiplier` are paired (both-or-neither); a single one throws
+    `IncorrectArgument`. Constrained flows with `hamiltonian_type=:partial` are not yet
+    supported (planned for a later release) and are rejected at construction.
+  - The unconstrained flow paths are untouched (dispatch selects the constrained
+    pseudo-Hamiltonian only when a constraint is supplied).
+
+### Requires
+
+- CTBase ≥ 0.27.4-beta and CTModels ≥ 0.15.2-beta (AD-friendly constraint-by-label
+  functors, needed to differentiate a labelled path constraint through the `:total` flow).
+
 ## [0.10.0-beta] - 2026-06-28
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.10.0-beta"
+version = "0.11.0-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -470,9 +470,57 @@ function _flow_from_ocp_control(
     routed = _route_flow_options(kwargs; action_defs=_flow_action_defs())
     components = _build_flow_components(routed)
     ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
-    h̃ = _ocp_pseudo_hamiltonian(ocp)
+    cspec = _unwrap_option(get(routed.action, :constraint, nothing), nothing)
+    mspec = _unwrap_option(get(routed.action, :multiplier, nothing), nothing)
+    h̃ = _ocp_pseudo_hamiltonian_for(ocp, Val(ht), cspec, mspec)
     inner = _build_pseudo_flow(Val(ht), h̃, law, components)
     return OptimalControlFlow(inner, ocp, law)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Select the pseudo-Hamiltonian for an OCP + control-law flow, given the resolved
+`hamiltonian_type` and the (optional) `constraint`/`multiplier` action options.
+
+- Neither given → the plain [`CTFlows.Flows._ocp_pseudo_hamiltonian`](@ref).
+- Both given → a constrained pseudo-Hamiltonian
+  `H̃(t,x,p,u,v) + μ(t,x,p,v)·g(t,x,u,v)` via
+  [`CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`](@ref). Only the `:total` mode is
+  supported for now (`:partial` is planned for a later release).
+- Exactly one given → [`CTBase.Exceptions.IncorrectArgument`](@extref) (they are paired).
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref), [`CTFlows.Flows._resolve_multiplier`](@ref).
+"""
+function _ocp_pseudo_hamiltonian_for(ocp, ::Val, cspec, mspec)
+    (cspec === nothing) == (mspec === nothing) || throw(
+        Exceptions.IncorrectArgument(
+            "`constraint` and `multiplier` must be given together";
+            got=cspec === nothing ? "only `multiplier`" : "only `constraint`",
+            expected="both `constraint` and `multiplier`, or neither",
+            context="Flow(ocp, law; constraint=…, multiplier=…) — pairing check",
+        ),
+    )
+    cspec === nothing && return _ocp_pseudo_hamiltonian(ocp)
+    g = _resolve_constraint(ocp, cspec)
+    μ = _resolve_multiplier(ocp, mspec)
+    return _ocp_constrained_pseudo_hamiltonian(ocp, g, μ)
+end
+
+# Constrained + :partial is not yet supported (planned for a later release): reject it
+# before building anything, so the error is raised at construction with a clear message.
+function _ocp_pseudo_hamiltonian_for(ocp, ::Val{:partial}, cspec, mspec)
+    if !(cspec === nothing && mspec === nothing)
+        throw(
+            Exceptions.IncorrectArgument(
+                "constrained flows are not yet supported with hamiltonian_type=:partial";
+                got="constraint/multiplier with :partial",
+                expected="hamiltonian_type=:total for a constrained flow",
+                context="Flow(ocp, law; constraint=…, multiplier=…, hamiltonian_type=:partial)",
+            ),
+        )
+    end
+    return _ocp_pseudo_hamiltonian(ocp)
 end
 
 """

--- a/src/Flows/flow_routing.jl
+++ b/src/Flows/flow_routing.jl
@@ -97,10 +97,11 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the action-level option definitions for control flows. Currently a single
-option, `hamiltonian_type` (`:total` or `:partial`), routed as a first-class action
-option so it is accepted only where meaningful (the control-law flow constructors) and
-rejected as an unknown option elsewhere.
+Return the action-level option definitions for control flows: `hamiltonian_type`
+(`:total` or `:partial`), and the paired `constraint` / `multiplier` options that turn
+the flow into a constrained pseudo-Hamiltonian flow. All three are routed as first-class
+action options so they are accepted only where meaningful (the control-law flow
+constructors) and rejected as unknown options elsewhere.
 
 See also: [`CTFlows.Flows._route_flow_options`](@ref), [`CTFlows.Flows._unwrap_option`](@ref).
 """
@@ -112,6 +113,24 @@ function _flow_action_defs()
             type=Symbol,
             default=:total,
             description="Hamiltonian type for DynClosedLoop flows: :total or :partial",
+        ),
+        Options.OptionDefinition(;
+            name=:constraint,
+            aliases=(),
+            type=Any,
+            default=nothing,
+            description="Path constraint g for a constrained pseudo-Hamiltonian flow: " *
+                        "a :path constraint label (Symbol), a CTBase.Data.PathConstraint, " *
+                        "or a plain function with the OCP's natural arity. Paired with `multiplier`.",
+        ),
+        Options.OptionDefinition(;
+            name=:multiplier,
+            aliases=(),
+            type=Any,
+            default=nothing,
+            description="Lagrange multiplier μ for the path constraint: a " *
+                        "CTBase.Data.Multiplier or a plain function μ with the OCP's natural " *
+                        "arity μ(x,p)/μ(t,x,p)/μ(x,p,v)/μ(t,x,p,v). Paired with `constraint`.",
         ),
     ]
 end

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -240,6 +240,195 @@ function _ocp_pseudo_hamiltonian(ocp)
 end
 
 # =============================================================================
+# Constrained pseudo-Hamiltonian: H(t,x,p,u,v) = H̃(t,x,p,u,v) + μ(t,x,p,v)·g(t,x,u,v)
+#
+# Wraps an OCPPseudoHamiltonianFunction with a path constraint g and a multiplier μ.
+# Used only for the :total differentiation mode: the whole functor is composed with the
+# control law via Data.ComposedHamiltonian, so AD differentiates through H̃, μ, g and the
+# law (total derivative). For :partial, μ must be frozen in the RHS functor (PR 4).
+#
+# The constraint g is called uniformly as g(t,x,u,v) and the multiplier μ as μ(t,x,p,v);
+# both carriers ignore the arguments their traits do not use.
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `constraint` specification into a [`CTBase.Data.PathConstraint`](@extref).
+
+- `spec::Symbol` is a `:path` constraint **label**: resolved via
+  [`CTModels.Models.constraint`](@extref), which returns an out-of-place `g(t,x,u,v)`.
+  Rejected with [`CTBase.Exceptions.IncorrectArgument`](@extref) if the label is not a
+  `:path` constraint (e.g. `:boundary` or a box constraint). The functor is wrapped as a
+  **non-autonomous, non-fixed** [`CTBase.Data.MixedConstraint`](@extref) so its uniform
+  call `g(t,x,u,v)` forwards verbatim to the resolved functor.
+- `spec::CTBase.Data.PathConstraint` is used as-is.
+- `spec::Function` is a raw function with the OCP's natural arity (`(x,u)`, `(t,x,u)`,
+  `(x,u,v)` or `(t,x,u,v)`), wrapped in a [`CTBase.Data.MixedConstraint`](@extref) with the
+  OCP's time/variable dependence.
+
+See also: [`CTFlows.Flows._resolve_multiplier`](@ref), `CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`.
+"""
+function _resolve_constraint(ocp, spec::Symbol)
+    kind, g_oop, _, _ = CTModels.Models.constraint(ocp, spec)
+    kind === :path || throw(
+        Exceptions.IncorrectArgument(
+            "constraint label :$spec is not a path constraint";
+            got=":$kind constraint",
+            expected="a :path constraint label",
+            context="Flow(ocp, law; constraint=:$spec) — label resolution",
+        ),
+    )
+    # The label functor is always the full uniform arity g(t,x,u,v); wrap it as a
+    # non-autonomous, non-fixed MixedConstraint so its uniform call forwards verbatim.
+    return Data.MixedConstraint(g_oop; is_autonomous=false, is_variable=true)
+end
+
+_resolve_constraint(::Any, spec::Data.PathConstraint) = spec
+
+function _resolve_constraint(ocp, spec::Function)
+    return Data.MixedConstraint(
+        spec; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
+    )
+end
+
+function _resolve_constraint(::Any, spec)
+    return throw(
+        Exceptions.IncorrectArgument(
+            "unsupported constraint specification";
+            got="$(typeof(spec))",
+            expected="a :path label (Symbol), a CTBase.Data.PathConstraint, or a Function",
+            context="Flow(ocp, law; constraint=…) — constraint resolution",
+        ),
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `multiplier` specification into a [`CTBase.Data.Multiplier`](@extref).
+
+- `spec::CTBase.Data.Multiplier` is used as-is.
+- `spec::Function` is a raw function with the OCP's natural arity (`(x,p)`, `(t,x,p)`,
+  `(x,p,v)` or `(t,x,p,v)`), wrapped in a [`CTBase.Data.Multiplier`](@extref) with the OCP's
+  time/variable dependence.
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref), `CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`.
+"""
+_resolve_multiplier(::Any, spec::Data.Multiplier) = spec
+
+function _resolve_multiplier(ocp, spec::Function)
+    return Data.Multiplier(
+        spec; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
+    )
+end
+
+function _resolve_multiplier(::Any, spec)
+    return throw(
+        Exceptions.IncorrectArgument(
+            "unsupported multiplier specification";
+            got="$(typeof(spec))",
+            expected="a CTBase.Data.Multiplier or a Function",
+            context="Flow(ocp, law; multiplier=…) — multiplier resolution",
+        ),
+    )
+end
+
+"""
+$(TYPEDEF)
+
+Internal callable representing the **constrained** pseudo-Hamiltonian of an OCP:
+`H(t,x,p,u,v) = H̃(t,x,p,u,v) + μ(t,x,p,v)·g(t,x,u,v)`, where `H̃` is an
+[`OCPPseudoHamiltonianFunction`](@ref), `g` a [`CTBase.Data.PathConstraint`](@extref)
+(uniform call `g(t,x,u,v)`) and `μ` a [`CTBase.Data.Multiplier`](@extref) (uniform call
+`μ(t,x,p,v)`).
+
+Used for the `:total` differentiation mode only: the whole functor is composed with the
+control law via [`CTBase.Data.ComposedHamiltonian`](@extref), so AD differentiates through
+`H̃`, `μ`, `g` and the law (total derivative). The `(TD, VD)` traits drive natural-arity
+dispatch exactly as for [`OCPPseudoHamiltonianFunction`](@ref).
+
+# Type Parameters
+- `TD`, `VD`: time- and variable-dependence traits (compile-time dispatch on arity).
+- `H`: type of the base pseudo-Hamiltonian functor.
+- `G`: type of the path-constraint carrier.
+- `M`: type of the multiplier carrier.
+
+# Fields
+- `h̃::H`: base pseudo-Hamiltonian `H̃(t,x,p,u,v)`.
+- `g::G`: path constraint `g(t,x,u,v)`.
+- `μ::M`: multiplier `μ(t,x,p,v)`.
+
+See also: [`OCPPseudoHamiltonianFunction`](@ref), `CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`.
+"""
+struct ConstrainedPseudoHamiltonianFunction{TD,VD,H,G,M} <: Function
+    h̃::H
+    g::G
+    μ::M
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Core computation of the constrained pseudo-Hamiltonian value
+`H̃(t,x,p,u,v) + μ(t,x,p,v)·g(t,x,u,v)`. The pairing `μ·g` uses `sum(μ .* g)` so it
+handles both scalar (1-D) and vector constraints (matching the `p·f` idiom in
+[`CTFlows.Flows._ocp_pseudo_H`](@ref)). When `v === nothing` (Fixed problems) an empty
+variable vector is forwarded to `μ`/`g`; their Fixed-trait uniform calls ignore it.
+
+See also: [`CTFlows.Flows.ConstrainedPseudoHamiltonianFunction`](@ref).
+"""
+function _constrained_pseudo_H(h::ConstrainedPseudoHamiltonianFunction, t, x, p, u, v)
+    base = _ocp_pseudo_H(h.h̃, t, x, p, u, v)
+    vv = v === nothing ? Float64[] : v
+    return base + sum(h.μ(t, x, p, vv) .* h.g(t, x, u, vv))
+end
+
+function (h::ConstrainedPseudoHamiltonianFunction{_CTM_Auton,Traits.Fixed})(x, p, u)
+    return _constrained_pseudo_H(h, 0.0, x, p, u, nothing)
+end
+function (h::ConstrainedPseudoHamiltonianFunction{_CTM_NonAuton,Traits.Fixed})(t, x, p, u)
+    return _constrained_pseudo_H(h, t, x, p, u, nothing)
+end
+function (h::ConstrainedPseudoHamiltonianFunction{_CTM_Auton,Traits.NonFixed})(x, p, u, v)
+    return _constrained_pseudo_H(h, 0.0, x, p, u, v)
+end
+function (h::ConstrainedPseudoHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed})(
+    t, x, p, u, v
+)
+    return _constrained_pseudo_H(h, t, x, p, u, v)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a [`CTFlows.Flows.ConstrainedPseudoHamiltonianFunction`](@ref) from an OCP, a
+resolved path constraint `g` and a resolved multiplier `μ`, wrapped in a
+[`CTBase.Data.PseudoHamiltonian`](@extref) so it flows into the `:total` pipeline exactly
+like the unconstrained [`CTFlows.Flows._ocp_pseudo_hamiltonian`](@ref).
+
+See also: [`CTFlows.Flows.ConstrainedPseudoHamiltonianFunction`](@ref),
+[`CTFlows.Flows._resolve_constraint`](@ref), [`CTFlows.Flows._resolve_multiplier`](@ref).
+"""
+function _ocp_constrained_pseudo_hamiltonian(ocp, g, μ)
+    n = CTModels.Models.state_dimension(ocp)
+    dyn! = CTModels.Models.dynamics(ocp)
+    sp0 = CTModels.Components.criterion(ocp) === :min ? -1.0 : 1.0
+    lag = if CTModels.Components.has_lagrange_cost(ocp)
+        CTModels.Components.lagrange(ocp)
+    else
+        nothing
+    end
+    TD = Traits.time_dependence(ocp)
+    VD = Traits.variable_dependence(ocp)
+    h̃_raw = OCPPseudoHamiltonianFunction{TD,VD,typeof(dyn!),typeof(lag)}(dyn!, lag, sp0, n)
+    raw = ConstrainedPseudoHamiltonianFunction{TD,VD,typeof(h̃_raw),typeof(g),typeof(μ)}(
+        h̃_raw, g, μ
+    )
+    return Data.PseudoHamiltonian(raw, TD, VD)
+end
+
+# =============================================================================
 # OCPControlledVectorFieldFunction — OCP controlled dynamics fc(t,x,u,v) = f(t,x,u,v)
 #
 # Out-of-place wrapper of the OCP in-place dynamics, for the OpenLoop/ClosedLoop

--- a/test/suite/flows/test_flow_routing.jl
+++ b/test/suite/flows/test_flow_routing.jl
@@ -98,6 +98,38 @@ function test_flow_routing()
         end
 
         # ====================================================================
+        # ACTION OPTIONS — constraint / multiplier
+        # ====================================================================
+
+        Test.@testset "Unit: _flow_action_defs includes constraint/multiplier" begin
+            names = [d.name for d in Flows._flow_action_defs()]
+            Test.@test :hamiltonian_type in names
+            Test.@test :constraint in names
+            Test.@test :multiplier in names
+        end
+
+        Test.@testset "Unit: constraint/multiplier route as action options" begin
+            routed = Flows._route_flow_options(
+                (; constraint=:g, multiplier=1.0); action_defs=Flows._flow_action_defs()
+            )
+            Test.@test haskey(routed, :action)
+            Test.@test Flows._unwrap_option(
+                get(routed.action, :constraint, nothing), nothing
+            ) === :g
+            Test.@test Flows._unwrap_option(
+                get(routed.action, :multiplier, nothing), nothing
+            ) == 1.0
+        end
+
+        Test.@testset "Error: constraint/multiplier rejected on Flow(h)" begin
+            # Flow(h) routes without action_defs ⇒ these are unknown options.
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(_TEST_H; constraint=:g)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                _TEST_H; multiplier=1.0
+            )
+        end
+
+        # ====================================================================
         # UNIT TESTS - Component Building
         # ====================================================================
 

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -138,7 +138,27 @@ function _build_typed_2d()
     return CTModels.Building.build(pre)
 end
 
+# scalar LQR with a labelled :path constraint g(x)=x and a :boundary constraint.
+# Same dynamics/cost as _build_lqr, so the constrained closed form below applies.
+function _build_lqr_constrained()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1]=(-x + u); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    CTModels.Building.constraint!(
+        pre, :path; f=(r, t, x, u, v) -> (r[1]=x; nothing), lb=[-Inf], ub=[0.0], label=:g
+    )
+    CTModels.Building.constraint!(
+        pre, :boundary; f=(r, x0, xf, v) -> (r[1]=xf; nothing), lb=[0.0], ub=[0.0], label=:bnd
+    )
+    return CTModels.Building.build(pre)
+end
+
 const OCP_LQR = _build_lqr()
+const OCP_LQR_C = _build_lqr_constrained()
 const OCP_DI = _build_double_integrator()
 const OCP_NA = _build_nonauton()
 const OCP_CF = _build_control_free()
@@ -393,6 +413,204 @@ function test_ocp_control()
             xseen, useen, _ = _DYN_SEEN[]
             Test.@test xseen isa AbstractVector && length(xseen) == 2   # 2-D state → vector
             Test.@test useen isa Number   # 1-D control → scalar even when the state is a vector
+        end
+
+        # ====================================================================
+        # CONSTRAINED :total flows — H = H̃ + μ·g
+        #
+        # OCP_LQR: ẋ=-x+u, ℓ=0.5u², :min ⇒ H̃ = p(-x+u) - 0.5u², stationary law u=p.
+        # State constraint g(x)=x with a *constant* multiplier μ≡c gives the composed
+        # Hamiltonian H(x,p) = -px + 0.5p² + c·x, hence
+        #   ṗ = -∂H/∂x = p - c        ⇒ p(t) = c + (p0-c)e^{t}
+        #   ẋ = ∂H/∂p  = -x + p       ⇒ x(t) = (x0-p0/2-c/2)e^{-t} + c + (p0-c)/2·e^{t}
+        # (c=0 recovers the unconstrained LQR closed form).
+        # ====================================================================
+
+        # analytic references for the constrained LQR with constant multiplier c
+        _pc(p0, tf, c) = c + (p0 - c) * exp(tf)
+        _xc(x0, p0, tf, c) =
+            (x0 - p0 / 2 - c / 2) * exp(-tf) + c + (p0 - c) / 2 * exp(tf)
+
+        Test.@testset "Constrained: Data.StateConstraint + Data.Multiplier (closed form)" begin
+            c = 0.3
+            g = Data.StateConstraint(x -> x)       # autonomous, fixed: g(x)
+            μ = Data.Multiplier((x, p) -> c)        # autonomous, fixed, constant
+            law = Data.DynClosedLoop((x, p) -> p)   # stationary for H̃
+            f = Flows.Flow(OCP_LQR, law; constraint=g, multiplier=μ, _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xt, pt = f(t0, x0, p0, tf)
+            Test.@test xt isa Number && pt isa Number
+            Test.@test pt ≈ _pc(p0, tf, c) atol = 1e-6
+            Test.@test xt ≈ _xc(x0, p0, tf, c) atol = 1e-6
+        end
+
+        Test.@testset "Constrained: plain functions match the carrier form" begin
+            c = 0.3
+            law = Data.DynClosedLoop((x, p) -> p)
+            # raw function constraint is wrapped as a MixedConstraint with the OCP traits,
+            # so its natural arity is (x,u); raw multiplier is (x,p).
+            f = Flows.Flow(
+                OCP_LQR, law; constraint=(x, u) -> x, multiplier=(x, p) -> c, _opts()...
+            )
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xt, pt = f(t0, x0, p0, tf)
+            Test.@test pt ≈ _pc(p0, tf, c) atol = 1e-6
+            Test.@test xt ≈ _xc(x0, p0, tf, c) atol = 1e-6
+        end
+
+        Test.@testset "Constrained: :path label resolution matches" begin
+            c = 0.3
+            law = Data.DynClosedLoop((x, p) -> p)
+            f = Flows.Flow(
+                OCP_LQR_C, law; constraint=:g, multiplier=(x, p) -> c, _opts()...
+            )
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xt, pt = f(t0, x0, p0, tf)
+            Test.@test pt ≈ _pc(p0, tf, c) atol = 1e-6
+            Test.@test xt ≈ _xc(x0, p0, tf, c) atol = 1e-6
+        end
+
+        Test.@testset "Constrained: μ≡0 recovers the unconstrained flow" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            f0 = Flows.Flow(
+                OCP_LQR,
+                law;
+                constraint=Data.StateConstraint(x -> x),
+                multiplier=Data.Multiplier((x, p) -> 0.0),
+                _opts()...,
+            )
+            fu = Flows.Flow(OCP_LQR, law; _opts()...)
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            Test.@test all(isapprox.(f0(t0, x0, p0, tf), fu(t0, x0, p0, tf); atol=ATOL))
+        end
+
+        Test.@testset "Constrained: solution builds (EmptyDualModel, no duals)" begin
+            c = 0.3
+            law = Data.DynClosedLoop((x, p) -> p)
+            f = Flows.Flow(
+                OCP_LQR, law; constraint=Data.StateConstraint(x -> x),
+                multiplier=Data.Multiplier((x, p) -> c), _opts()...,
+            )
+            sol = f((0.0, 1.0), 1.0, 0.5)
+            Test.@test CTModels.objective(sol) isa Number
+            Test.@test !CTModels.Solutions.has_duals(sol)   # flow-built ⇒ no duals
+        end
+
+        Test.@testset "Constrained: NonFixed smoke test (variable at call time)" begin
+            c = 0.2
+            # g depends on state only; μ constant. NonFixed OCP composes untouched.
+            g = Data.StateConstraint(x -> x)
+            μ = Data.Multiplier((x, p) -> c)
+            law = Data.DynClosedLoop((x, p, v) -> p; is_variable=true)
+            f = Flows.Flow(OCP_VAR, law; constraint=g, multiplier=μ, _opts()...)
+            xt, pt = f(0.0, 1.0, 0.5, 1.0; variable=0.5)
+            Test.@test isfinite(xt) && isfinite(pt)
+        end
+
+        # ---- getter-based analytic regression tests -----------------------------
+        # Recover the (pseudo-)Hamiltonians and their gradients from the flow and check
+        # them against hand-derived closed forms, freezing exactly what is computed.
+        #   OCP_LQR + g(x)=x + μ≡c + law u=p ⇒
+        #     H̃_c(t,x,p,u,v) = p(-x+u) - 0.5u² + c·x            (control explicit)
+        #     H(x,p)         = H̃_c(x,p,p)   = -p x + 0.5 p² + c x
+        #     ∂ₓH = -p + c,  ∂ₚH = -x + p,  X_H = (∂ₚH,-∂ₓH) = (-x+p, p-c)
+
+        Test.@testset "Constrained: Hamiltonian getters vs analytic derivatives" begin
+            c = 0.3
+            g = Data.StateConstraint(x -> x)
+            μ = Data.Multiplier((x, p) -> c)
+            law = Data.DynClosedLoop((x, p) -> p)
+            f = Flows.Flow(OCP_LQR, law; constraint=g, multiplier=μ, _opts()...)
+            x0, p0, u0 = 0.7, 0.4, -0.2   # u0 ≠ p0 to expose the fixed-u pseudo gradient
+
+            # (1) true Hamiltonian H(x,p) = -p x + 0.5 p² + c x
+            H = Systems.hamiltonian(f)
+            Test.@test H(x0, p0) ≈ -p0 * x0 + 0.5 * p0^2 + c * x0 atol = 1e-10
+
+            # (2) pseudo-Hamiltonian H̃_c(t,x,p,u,v) = p(-x+u) - 0.5u² + c x
+            H̃ = Systems.pseudo_hamiltonian(f)
+            Test.@test H̃(0.0, x0, p0, u0, Float64[]) ≈
+                p0 * (-x0 + u0) - 0.5 * u0^2 + c * x0 atol = 1e-10
+            # the +μ·g term is exactly c·x: difference from the unconstrained H̃
+            fu = Flows.Flow(OCP_LQR, law; _opts()...)
+            H̃u = Systems.pseudo_hamiltonian(fu)
+            Test.@test H̃(0.0, x0, p0, u0, Float64[]) - H̃u(0.0, x0, p0, u0, Float64[]) ≈
+                c * x0 atol = 1e-10
+
+            # (3) total gradient ∇H = (∂ₓH, ∂ₚH) = (-p+c, -x+p) — chain-rule through law
+            ∇H = Systems.hamiltonian_gradient(f)
+            dxH, dpH = ∇H(0.0, x0, p0, Float64[])
+            Test.@test dxH ≈ -p0 + c atol = 1e-8
+            Test.@test dpH ≈ -x0 + p0 atol = 1e-8
+
+            # (4) pseudo gradient at fixed u: ∂ₓH̃_c = -p+c, ∂ₚH̃_c = -x+u
+            ∇H̃ = Systems.pseudo_hamiltonian_gradient(f)
+            dxH̃, dpH̃ = ∇H̃(0.0, x0, p0, u0, Float64[])
+            Test.@test dxH̃ ≈ -p0 + c atol = 1e-8
+            Test.@test dpH̃ ≈ -x0 + u0 atol = 1e-8
+
+            # (5) symplectic gradient X_H = (∂ₚH, -∂ₓH) = (ẋ, ṗ) = (-x+p, p-c),
+            # reconstructed from the total gradient getter (the HVF-by-AD getter is for
+            # flows built from a scalar Data.Hamiltonian, not a ComposedHamiltonian).
+            Test.@test dpH ≈ -x0 + p0 atol = 1e-8    # ẋ = ∂ₚH
+            Test.@test -dxH ≈ p0 - c atol = 1e-8     # ṗ = -∂ₓH
+        end
+
+        # NonFixed constrained: ∂H/∂v carries no constraint term here (μ const, g=x are
+        # v-independent), guarding against a spurious v-coupling from the +μ·g term.
+        #   OCP_VAR: ẋ=v(-x)+u, ℓ=0.5u², law u=p ⇒ H(x,p,v) = -v p x + 0.5 p² + c x,
+        #   so ∂H/∂v = -p x.
+        Test.@testset "Constrained: NonFixed variable gradient (analytic)" begin
+            c = 0.25
+            g = Data.StateConstraint(x -> x)
+            μ = Data.Multiplier((x, p) -> c)
+            law = Data.DynClosedLoop((x, p, v) -> p; is_variable=true)
+            f = Flows.Flow(OCP_VAR, law; constraint=g, multiplier=μ, _opts()...)
+            x0, p0, vv = 0.7, 0.4, 0.5
+            ∇vH = Systems.variable_gradient(f)
+            Test.@test first(∇vH(0.0, x0, p0, vv)) ≈ -p0 * x0 atol = 1e-8
+        end
+
+        # ---- constrained validation matrix --------------------------------------
+
+        Test.@testset "Constrained error: constraint without multiplier" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR, law; constraint=Data.StateConstraint(x -> x), _opts()...
+            )
+        end
+
+        Test.@testset "Constrained error: multiplier without constraint" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR, law; multiplier=Data.Multiplier((x, p) -> 0.0), _opts()...
+            )
+        end
+
+        Test.@testset "Constrained error: non-:path label rejected" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR_C, law; constraint=:bnd, multiplier=(x, p) -> 0.0, _opts()...
+            )
+        end
+
+        Test.@testset "Constrained error: :partial not yet supported" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR,
+                law;
+                constraint=Data.StateConstraint(x -> x),
+                multiplier=Data.Multiplier((x, p) -> 0.0),
+                hamiltonian_type=:partial,
+                _opts()...,
+            )
+        end
+
+        Test.@testset "Constrained error: unsupported constraint spec type" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_LQR, law; constraint=42, multiplier=(x, p) -> 0.0, _opts()...
+            )
         end
 
         # ====================================================================


### PR DESCRIPTION
## Summary

`Flow(ocp, law; constraint, multiplier)` builds the flow of the **constrained** Hamiltonian `H = H̃ + μ·g`, where `g` is a path constraint and `μ` a user-supplied Lagrange multiplier, in the `:total` differentiation mode.

- `constraint` accepts a `:path` constraint **label** (`Symbol`), a `CTBase.Data.PathConstraint`, or a plain function with the OCP's natural arity.
- `multiplier` accepts a `CTBase.Data.Multiplier` or a plain function `μ(x,p)` / `μ(t,x,p)` / `μ(x,p,v)` / `μ(t,x,p,v)`.
- The constraint term is baked into a `ConstrainedPseudoHamiltonianFunction` and composed with the control law via `ComposedHamiltonian`, so `:total` AD differentiates *through* `g`, `μ` and the law (total derivative).

## Semantics (`:total` vs `:partial`)

`:total` composes the pseudo-Hamiltonian with the law **then** differentiates (chain-rule through the law **and** `μ`). Baking `μ` into the functor is correct **for `:total` only** — under `:partial` gradients `μ` would be spuriously differentiated through — so **constrained + `:partial` is rejected** at construction (frozen-`μ` RHS wrapper planned for a later PR).

## Validation

- `constraint`/`multiplier` are paired (both-or-neither → `IncorrectArgument`).
- Non-`:path` labels rejected; unsupported spec types rejected.
- Unconstrained flow paths are untouched (dispatch-selected hot path).

## Tests

- Closed-form constrained-LQR trajectories (`g(x)=x`, constant `μ`, analytic `x`, `p`).
- Validation matrix (label / `PathConstraint` / function; both-or-neither; non-`:path`; `:partial`).
- **Getter-based regression tests**: recover `Systems.hamiltonian(f)` / `pseudo_hamiltonian(f)` and their gradients from the flow, checked against hand-derived derivatives (`H`, `H̃_c`, `∂ₓH`, `∂ₚH`).

## Requires (coordinated release)

- **CTBase ≥ 0.27.4-beta** (control-toolbox/CTBase.jl#486) and **CTModels ≥ 0.15.2-beta** (control-toolbox/CTModels.jl#370) — AD-friendly constraint-by-label functors. Merge/register those betas first; CI here is red until they land. Version bumped to `0.11.0-beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)