### PR TITLE
feat(flows): multiple constraints (tuples) + multiphase OCP reconstruction (PR5, WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0-beta] - 2026-07-11
+
+### Added
+
+- **Multiple simultaneous path constraints**: `constraint`/`multiplier` accept **tuples**
+  of matched length to combine several separately-defined constraints —
+  `Flow(ocp, law; constraint=(g1, g2), multiplier=(μ1, μ2))` — resolved by concatenation
+  (`Σᵢ μᵢ·gᵢ`), in both `:total` and `:partial`. A single constraint carrier that is itself
+  vector-valued (a `:path` label or function returning a vector, paired with a vector
+  multiplier) already worked with no code changes — the tuple form is for combining
+  *distinct* carriers.
+- **MultiPhase reconstruction for OCP-built flows**: a multi-phase `*` concatenation of
+  `OptimalControlFlow`s (built via `Flow(ocp, law)`) now evaluates — previously it errored
+  with `MethodError: no method matching _evaluate_phase(::OptimalControlFlow, …)`. A
+  trajectory call returns a `CTModels.Solution` with a **piecewise** control reconstructed
+  from the per-phase laws and switching times, matching the return type of a single-phase
+  OCP flow. Requires all phases to share the same OCP.
+- **MultiPhase reconstruction for `ControlledFlow` concatenation**: the symmetric state-flow
+  case — a multi-phase `*` of `ControlledFlow`s (`Flow(ocp, law)` with an `OpenLoop` /
+  `ClosedLoop` law, or `Flow(fc, law)`) now returns a `ControlledTrajectory` with piecewise
+  reconstructed control, previously erroring the same way.
+- **Arity-checking for OCP convenience constructors**: `Flow(ocp, u::Function)` and raw
+  `Function` `constraint`/`multiplier` specs wrap the user's function with the OCP's own
+  time/variable dependence; when the function has a single method (arity detection is
+  skipped if ambiguous — multiple dispatch or default arguments), a mismatched arity is now
+  caught up front and raised as one `CTBase.Exceptions.IncorrectArgument` naming the real
+  expected syntax for every mismatched control law / constraint / multiplier, instead of
+  surfacing as an opaque `MethodError` deep inside AD or integration. The error also points
+  to the explicit constructors (`DynClosedLoop`/`OpenLoop`/`ClosedLoop`,
+  `MixedConstraint`/`StateConstraint`/`ControlConstraint`, `Multiplier`) as an escape hatch.
+- **[Constrained flows](https://control-toolbox.org/CTFlows.jl/dev/flows/constrained.html)
+  guide chapter**: the `constraint`/`multiplier` API, the `g ≥ 0` sign convention (vs.
+  Maurer's `c ≤ 0`), multiple constraints, the `:total`/`:partial` semantics with the PMP
+  symplectic-gradient decomposition explaining *why* the two modes agree on a constrained
+  arc, and two worked examples (Goddard, order 1; double integrator, order 2).
+
 ## [0.12.0-beta] - 2026-07-10
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.12.0-beta"
+version = "0.13.0-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -98,6 +98,7 @@ with_api_reference(src_dir, ext_dir) do api_pages
                 "Multi-phase flows" => "flows/multiphase.md",
                 "Optimal control" => "flows/optimal_control.md",
                 "Control laws" => "flows/control_laws.md",
+                "Constrained flows" => "flows/constrained.md",
                 "SciML flows" => "flows/sciml.md",
             ],
             "API Reference" => api_pages,

--- a/docs/src/flows/constrained.md
+++ b/docs/src/flows/constrained.md
@@ -1,0 +1,213 @@
+# Constrained flows
+
+```@meta
+CurrentModule = CTFlows
+```
+
+`Flow(ocp, law; constraint, multiplier)` augments the pseudo-Hamiltonian with a **path
+constraint** term, for OCPs whose Pontryagin's Maximum Principle carries a state or mixed
+constraint alongside the control. This chapter covers the API, the sign convention, the
+`hamiltonian_type` semantics for constrained flows (`:total` vs `:partial`, and *why* they
+agree on a constrained arc), and two worked examples.
+
+```@setup flows_constrained
+using CTFlows
+using CTBase.Data
+using CTBase.Traits
+using CTFlows.Flows
+using CTModels
+import OrdinaryDiffEqTsit5
+import DifferentiationInterface, ForwardDiff
+```
+
+---
+
+## The augmented pseudo-Hamiltonian
+
+Given the OCP's own pseudo-Hamiltonian ``\tilde{H}(t,x,p,u,v) = p \cdot f + s\,p^0\,\ell``
+(see [Optimal control](optimal_control.md)), a **path constraint** ``g(t,x,u,v) \ge 0``
+with **multiplier** ``\mu(t,x,p,v)`` augments it as
+
+```math
+\tilde{H}_c(t,x,p,u,v) = \tilde{H}(t,x,p,u,v) + \mu(t,x,p,v)^\top g(t,x,u,v).
+```
+
+Pass `constraint`/`multiplier` to `Flow(ocp, law; …)` alongside a `DynClosedLoop` law —
+they must be given **together**:
+
+```@example flows_constrained
+# OCP: ẋ = -x + u, min ∫ 0.5*u^2 dt  (autonomous, fixed, 1-D — scalar convention)
+pre = CTModels.Building.PreModel()
+CTModels.Building.time_dependence!(pre; autonomous=true)
+CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+CTModels.Building.state!(pre, 1)
+CTModels.Building.control!(pre, 1)
+CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = -x + u; nothing))
+CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+ocp = CTModels.Building.build(pre)
+
+law = Data.DynClosedLoop((x, p) -> p)   # u = p (from ∂H̃/∂u = p - u = 0)
+c = 0.3
+f = Flows.Flow(
+    ocp, law;
+    constraint=Data.StateConstraint(x -> x),
+    multiplier=Data.Multiplier((x, p) -> c),
+    reltol=1e-10,
+)
+nothing # hide
+```
+
+A raw `Function` is accepted directly for `constraint`/`multiplier` (wrapped in a
+`MixedConstraint`/`Multiplier` with the OCP's own time/variable dependence, just like
+`Flow(ocp, u::Function)` — see [Control laws](control_laws.md)):
+
+```@example flows_constrained
+f2 = Flows.Flow(ocp, law; constraint=(x, u) -> x, multiplier=(x, p) -> c, reltol=1e-10)
+xf, pf = f2(0.0, 1.0, 0.5, 1.0)
+xf, pf
+```
+
+A labelled `:path` constraint from the OCP itself also resolves — pass its `Symbol` label
+as `constraint`.
+
+---
+
+## Sign convention
+
+`Flow(ocp, law; constraint, multiplier)` uses ``g \ge 0`` with ``H = \tilde{H} + \mu \cdot
+g``. This is the opposite sign from Pontryagin's Maximum Principle as usually stated with a
+constraint ``c(x) \le 0`` and multiplier ``\eta \le 0`` (Maurer's formulation): the two are
+related by
+
+```math
+g = -c, \qquad \mu = -\eta.
+```
+
+Under `g ≥ 0`, the multiplier is ``\mu \ge 0`` on an active (boundary) arc, and
+``\mu \equiv 0`` off it.
+
+---
+
+## Multiple constraints
+
+A single constraint carrier — a `:path` label or a raw function — can already be
+**vector-valued** (returning a vector, paired with a vector `multiplier`): the
+``\mu \cdot g`` pairing is dimension-agnostic, so this needs no special support.
+
+To combine **separately-defined** constraints, pass **tuples** of matched length:
+
+```@example flows_constrained
+g1(x, u) = x
+g2(x, u) = 1.0 - x
+μ1(x, p) = 0.4
+μ2(x, p) = 0.1
+ft = Flows.Flow(ocp, law; constraint=(g1, g2), multiplier=(μ1, μ2), reltol=1e-10)
+nothing # hide
+```
+
+Each `gᵢ`/`μᵢ` is resolved independently (raw functions, `:path` labels, or explicit
+carriers can be mixed within the tuple); the flow sums ``\sum_i \mu_i \cdot g_i``. Both
+tuples must be given together, and both must have the same length — otherwise
+`Flow` throws a `CTBase.Exceptions.IncorrectArgument`.
+
+---
+
+## `hamiltonian_type` for constrained flows
+
+The `hamiltonian_type` keyword (`:total` default, `:partial`) works as for unconstrained
+flows (see [Control laws](control_laws.md)), extended to the constraint term:
+
+- **`:total`**: compose ``\tilde{H}_c`` with the law into a
+  `CTBase.Data.ComposedHamiltonian` and differentiate **through** the law **and** the
+  multiplier (total derivative in ``x``, ``p``, ``v``).
+- **`:partial`**: freeze **both** the control ``u_\star = \gamma(t,x,p,v)`` **and** the
+  multiplier ``\mu_\star = \mu(t,x,p,v)`` at their feedback values, then differentiate
+  ``\tilde{H} + \mu_\star^\top g`` at those fixed values — ``g`` is differentiated in
+  ``(x,p,v)``, ``\mu`` is not.
+
+```@example flows_constrained
+ft_ = Flows.Flow(
+    ocp, law; constraint=Data.StateConstraint(x -> x),
+    multiplier=Data.Multiplier((x, p) -> c), hamiltonian_type=:total, reltol=1e-10,
+)
+fp_ = Flows.Flow(
+    ocp, law; constraint=Data.StateConstraint(x -> x),
+    multiplier=Data.Multiplier((x, p) -> c), hamiltonian_type=:partial, reltol=1e-10,
+)
+x0, p0, tf = 1.0, 0.5, 1.0
+ft_(0.0, x0, p0, tf), fp_(0.0, x0, p0, tf)   # constant μ, stationary law ⇒ agree
+```
+
+### Why `:total` and `:partial` agree on a constrained arc
+
+Pontryagin's Maximum Principle with a state constraint ``c(x) \le 0`` (Maurer's
+formulation; ``c = -g`` in this package's convention — see above) gives a
+pseudo-Hamiltonian ``H(x,p,u,\eta) = \langle p, F_0(x) + u\,F_1(x)\rangle + \eta\,c(x)``.
+On an active arc the *true* (closed-loop) Hamiltonian bakes in the optimal control
+``u_c(x)`` and multiplier ``\eta_c(z)`` (``z = (x,p)``); its symplectic gradient decomposes
+as
+
+```math
+H_c'(z) \;=\; \underbrace{\partial_z H}_{\texttt{:partial}}
+\;+\; \underbrace{(\partial_u H)\,u_c'(z)}_{=\,H_1(z)\,u_c'(z)}
+\;+\; \underbrace{(\partial_\eta H)\,\eta_c'(z)}_{=\,c(x)\,\eta_c'(z)}.
+```
+
+`:partial` is exactly ``\partial_z H`` — the genuine PMP field with the control and
+multiplier frozen at their feedback values — correct **everywhere**. `:total` adds the two
+extra chain-rule terms. Both vanish **on the arc**:
+
+- ``c(x)\,\eta_c'(z)`` vanishes because ``c \equiv 0`` on the arc (any constraint order).
+- ``H_1(z)\,u_c'(z)`` vanishes either because ``H_1 \equiv 0`` (an invariant of the
+  constrained dynamics — order 1: ``\Sigma^0_1``; order 2: a richer invariant), or because
+  ``u_c'\equiv 0`` (order 2: a constant control on the arc).
+
+So `:total` and `:partial` **coincide on a constrained arc**, and a shooting method's entry
+conditions put the trajectory exactly there — this is why both modes converge to the same
+solution in practice, as the two worked examples below demonstrate.
+
+---
+
+## Worked example: Goddard problem (order 1)
+
+The [Goddard rocket problem](https://en.wikipedia.org/wiki/Goddard_problem) (maximise final
+mass under a velocity path constraint, free final time) has four arcs — two bang arcs
+(``u=0``, ``u=1``), a singular arc, and a velocity-boundary arc where the state constraint
+is active. On the boundary arc, ``H_1 \equiv 0`` is a genuine invariant of the order-1
+constrained dynamics (``\Sigma^0_1``): both `:total` and `:partial` converge, from the
+known solution and from a perturbed Newton restart, to the **same** shooting solution
+(residual `< 1e-7` in both modes). This is also an end-to-end integration test of the whole
+convenience surface — raw-function control law, raw-function constraint (`MixedConstraint`,
+``\partial g/\partial u = 0``), raw-function multiplier, and a `NonFixed` free final time —
+built directly from a `CTModels.Model` and rebuilt across all four arcs with `Flow(ocp,
+law; constraint, multiplier)`, then reconstructed across phases with the `*` multi-phase
+operator (see [Multi-phase flows](multiphase.md)) into a single `CTModels.Solution`. See
+`test/suite/integration/test_goddard_ocp.jl` in the repository.
+
+## Worked example: double integrator (order 2)
+
+The time-minimal double integrator with a **second-order** position constraint
+``q \le a`` (``\ddot{q} = u``) has a boundary arc where the constrained dynamics sit in a
+different corner of the theory: the boundary control is **constant** (``u_c \equiv 0``) and
+the multiplier is identically zero (``\mu \equiv 0``) on the arc — so `H_1\,u_c'` vanishes
+because ``u_c' \equiv 0`` rather than because ``H_1 \equiv 0``, a distinct reason for the
+same `:total` ≡ `:partial` equivalence. The costate **jumps** at the two junctions between
+the interior and boundary arcs (`f1 * (t1, jump, f2)`, see [Multi-phase
+flows](multiphase.md)), and the reconstructed multi-phase solution's control is exactly
+``0`` on the boundary arc and non-zero on both interior arcs. Ported from the OptimalControl.jl
+state-constraint example. See `test/suite/integration/test_double_integrator_state.jl`.
+
+---
+
+## See also
+
+- [`CTFlows.Flows.Flow(ocp::CTModels.Models.Model, law::CTBase.Data.ControlLaw)`](@ref) —
+  the constructor accepting `constraint`/`multiplier`.
+- `CTFlows.Flows._resolve_constraint`, `CTFlows.Flows._resolve_multiplier` — spec
+  resolution (label, carrier, function, tuple).
+- [`CTBase.Data.StateConstraint`](@extref), [`CTBase.Data.ControlConstraint`](@extref),
+  [`CTBase.Data.MixedConstraint`](@extref), [`CTBase.Data.Multiplier`](@extref) — explicit
+  constructors.
+- [Control laws](control_laws.md) — `hamiltonian_type`, the raw-function convenience.
+- [Multi-phase flows](multiphase.md) — `*` concatenation, costate jumps.
+- [Optimal control](optimal_control.md) — the unconstrained pseudo-Hamiltonian.

--- a/docs/src/flows/control_laws.md
+++ b/docs/src/flows/control_laws.md
@@ -265,4 +265,5 @@ x_c(0.5), u_c(0.5)
 - [`CTBase.Data.OpenLoop`](@extref), [`CTBase.Data.ClosedLoop`](@extref), [`CTBase.Data.DynClosedLoop`](@extref) — control law constructors.
 - `Data.PseudoHamiltonian`, `Data.ControlledVectorField` — data types for controlled systems.
 - [Optimal control](optimal_control.md) — `Flow(ocp)` for control-free problems.
+- [Constrained flows](constrained.md) — `constraint`/`multiplier` on `Flow(ocp, law)`.
 - [Building a flow](building_a_flow.md) — the general pipeline.

--- a/docs/src/flows/integrating.md
+++ b/docs/src/flows/integrating.md
@@ -162,7 +162,7 @@ This separation is useful when the same config must be passed to several flows.
 
 ---
 
-## Integrator options {#integrator-options}
+## [Integrator options](@id integrator-options)
 
 Options are passed as keyword arguments to `Flows.Flow(data; opts...)` or
 `Integrators.build_integrator(; opts...)`.

--- a/docs/src/flows/optimal_control.md
+++ b/docs/src/flows/optimal_control.md
@@ -127,4 +127,5 @@ Traits.time_dependence(f)
 - [`CTFlows.Flows.Flow`](@ref) — the constructor family, including `Flow(ocp)`.
 - [`CTModels.Solutions.Solution`](@extref), [`CTModels.Components.objective`](@extref) — the trajectory-call result and its accessors.
 - [Control laws](control_laws.md) — `Flow(ocp, law)` for with-control problems.
+- [Constrained flows](constrained.md) — `constraint`/`multiplier` path-constraint terms.
 - [Building a flow](building_a_flow.md) — AD-backed Hamiltonian flows.

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -34,6 +34,7 @@ Each layer has a single responsibility:
 | [Multi-phase flows](multiphase.md) | Concatenating flows with switching times | `MultiPhaseStateFlow`, `*` |
 | [Optimal control](optimal_control.md) | Flows from optimal control problems | `OptimalControlFlow`, `Flow(ocp)` |
 | [Control laws](control_laws.md) | Flows with control laws | `ControlledFlow`, `Flow(ocp, law)`, `OpenLoop`, `ClosedLoop`, `DynClosedLoop` |
+| [Constrained flows](constrained.md) | Path-constraint terms on `Flow(ocp, law)` | `constraint`, `multiplier`, `hamiltonian_type` |
 | [SciML flows](sciml.md) | Flows from SciML functions and problems | `Flow(::ODEFunction)`, `SciMLProblemFlow` |
 
 The **data layer** (wrapping functions as `VectorField`, `Hamiltonian`,

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -522,6 +522,27 @@ function _validate_constraint_pair(cspec, mspec)
             context="Flow(ocp, law; constraint=…, multiplier=…) — pairing check",
         ),
     )
+    # Multiple constraints: if either side is a tuple, both must be tuples of equal length
+    # (element `i` of `constraint` pairs with element `i` of `multiplier`).
+    if cspec isa Tuple || mspec isa Tuple
+        (cspec isa Tuple && mspec isa Tuple) || throw(
+            Exceptions.IncorrectArgument(
+                "`constraint` and `multiplier` must both be tuples for multiple constraints";
+                got=cspec isa Tuple ? "tuple `constraint`, non-tuple `multiplier`" :
+                    "non-tuple `constraint`, tuple `multiplier`",
+                expected="both `constraint` and `multiplier` given as tuples",
+                context="Flow(ocp, law; constraint=(…,), multiplier=(…,)) — pairing check",
+            ),
+        )
+        length(cspec) == length(mspec) || throw(
+            Exceptions.IncorrectArgument(
+                "`constraint` and `multiplier` tuples must have the same length";
+                got="$(length(cspec)) constraints, $(length(mspec)) multipliers",
+                expected="matched tuple lengths",
+                context="Flow(ocp, law; constraint=(…,), multiplier=(…,)) — pairing check",
+            ),
+        )
+    end
     return nothing
 end
 

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -509,9 +509,14 @@ end
 $(TYPEDSIGNATURES)
 
 Validate the `constraint`/`multiplier` pairing: they must be given **together** (both or
-neither). Throws [`CTBase.Exceptions.IncorrectArgument`](@extref) if exactly one is given.
+neither), and for multiple constraints both must be tuples of equal length (element `i` of
+`constraint` pairs with element `i` of `multiplier`).
 
-See also: [`CTFlows.Flows._build_ocp_pseudo_flow`](@ref).
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if exactly one of the two is given; if one
+  is a tuple and the other is not; or if the two tuples have different lengths.
+
+See also: [`CTFlows.Flows._build_ocp_pseudo_flow`](@ref), [`CTFlows.Flows._CombinedConstraint`](@ref).
 """
 function _validate_constraint_pair(cspec, mspec)
     (cspec === nothing) == (mspec === nothing) || throw(

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -448,6 +448,183 @@ function Flow(ocp::CTModels.Models.Model, law::Data.ControlLaw; kwargs...)
     return _flow_from_ocp_control(Traits.feedback(law), ocp, law; kwargs...)
 end
 
+# =============================================================================
+# Convenience-constructor arity checking
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Natural arity expected of a raw convenience function (control law, constraint, or
+multiplier) for an OCP with the given time/variable dependence.
+
+The natural signatures of a control law `u(x,p)`, a constraint `g(x,u)` and a multiplier
+`μ(x,p)` all share the same shape: 2 fixed arguments, plus `t` if the OCP is
+non-autonomous, plus `v` if the OCP is non-fixed (`is_variable`).
+
+# Arguments
+- `ocp::CTModels.Models.Model`: the OCP, used to read its time/variable dependence.
+
+# Returns
+- `Int`: the expected number of positional arguments.
+
+See also: [`CTFlows.Flows._arity_issue`](@ref).
+"""
+_expected_arity(ocp) = 2 + !Traits.is_autonomous(ocp) + Traits.is_variable(ocp)
+
+"""
+$(TYPEDSIGNATURES)
+
+Natural-syntax example for a raw convenience function, given its symbol and second
+argument name and an OCP's time/variable dependence — used in arity-mismatch messages.
+
+# Arguments
+- `label::AbstractString`: the symbol name shown in the example (e.g. `"u"`).
+- `second::AbstractString`: the name of the second natural argument (`"p"` for a control
+  law/multiplier, `"u"` for a constraint).
+- `ocp::CTModels.Models.Model`: the OCP, used to read its time/variable dependence.
+
+# Returns
+- `String`: e.g. `"u(t, x, p)"`.
+
+See also: [`CTFlows.Flows._arity_issue`](@ref).
+"""
+function _natural_syntax(label::AbstractString, second::AbstractString, ocp)
+    args = String[]
+    Traits.is_autonomous(ocp) || push!(args, "t")
+    push!(args, "x", second)
+    Traits.is_variable(ocp) && push!(args, "v")
+    return "$label($(join(args, ", ")))"
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Check the arity of a raw convenience function `f` against the natural arity expected for
+an OCP with the given time/variable dependence.
+
+Mirrors the mutability-detection pattern used for vector fields
+(`CTBase.Data._detect_mutability_vf`): a single-method guard makes arity detection
+unambiguous via `first(methods(f)).nargs`. Unlike that pattern, this check **skips**
+(returns `nothing`) rather than throws when `f` has more than one method — the caller
+cannot tell which arity the user intended, so no diagnostic is possible.
+
+# Arguments
+- `f::Function`: the raw function to inspect (control law, constraint, or multiplier).
+- `ocp::CTModels.Models.Model`: the OCP, used to infer the expected arity.
+- `label::AbstractString`: the symbol name used in the natural-syntax example (e.g. `"u"`).
+- `second::AbstractString`: the name of the second natural argument (`"p"` for a control
+  law/multiplier, `"u"` for a constraint).
+- `kind::AbstractString`: a human-readable description of the role (e.g. `"control law"`),
+  used in the diagnostic message.
+
+# Returns
+- `Nothing`: if the arity matches, or if `f` has more than one method (ambiguous).
+- `String`: a one-line diagnostic naming the expected natural syntax, otherwise.
+
+See also: [`CTFlows.Flows._expected_arity`](@ref), [`CTFlows.Flows._natural_syntax`](@ref).
+"""
+function _arity_issue(
+    f::Function, ocp, label::AbstractString, second::AbstractString, kind::AbstractString
+)
+    length(methods(f)) == 1 || return nothing
+    arity = first(methods(f)).nargs - 1
+    expected = _expected_arity(ocp)
+    arity == expected && return nothing
+    syntax = _natural_syntax(label, second, ocp)
+    return "$kind `$label` has arity $arity, expected $expected — natural syntax is `$syntax`"
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Collect arity issues from a convenience spec into `issues`, dispatching on the spec's
+shape: skip `nothing`; check a raw `Function` directly; check each `Function` element of a
+`Tuple` (multi-constraint/multiplier case, labelled `label1`, `label2`, …); skip anything
+else (`Symbol`, `CTBase.Data.PathConstraint`, `CTBase.Data.Multiplier` — not raw functions).
+
+# Arguments
+- `issues::Vector{String}`: accumulator, mutated in place.
+- `ocp::CTModels.Models.Model`: the OCP, used to infer the expected arity.
+- `spec`: the convenience spec (`nothing`, `Function`, `Tuple`, or an already-resolved
+  carrier).
+- `label::AbstractString`, `second::AbstractString`, `kind::AbstractString`: forwarded to
+  [`CTFlows.Flows._arity_issue`](@ref).
+
+See also: [`CTFlows.Flows._check_convenience_arities`](@ref).
+"""
+_spec_arity_issues!(issues, ocp, ::Nothing, label, second, kind) = nothing
+function _spec_arity_issues!(
+    issues, ocp, spec::Function, label::AbstractString, second::AbstractString, kind::AbstractString
+)
+    issue = _arity_issue(spec, ocp, label, second, kind)
+    issue === nothing || push!(issues, issue)
+    return nothing
+end
+function _spec_arity_issues!(
+    issues, ocp, spec::Tuple, label::AbstractString, second::AbstractString, kind::AbstractString
+)
+    for (i, s) in enumerate(spec)
+        s isa Function || continue
+        issue = _arity_issue(s, ocp, "$label$i", second, "$kind #$i")
+        issue === nothing || push!(issues, issue)
+    end
+    return nothing
+end
+_spec_arity_issues!(issues, ocp, spec, label, second, kind) = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
+Check the arities of the raw functions passed to an OCP convenience constructor — the
+control law `u`, and (if given as raw `Function`s) the `constraint`/`multiplier` specs —
+against the OCP's time/variable dependence.
+
+Collects every mismatch (a function with a single method and a wrong arity) into one
+[`CTBase.Exceptions.IncorrectArgument`](@extref), naming the expected natural syntax for
+each and suggesting the explicit constructors as an escape hatch. Functions with more than
+one method are skipped (arity cannot be determined); `Tuple` constraint/multiplier specs
+are checked element-wise; `nothing` is skipped (no spec given).
+
+# Arguments
+- `ocp::CTModels.Models.Model`: the OCP.
+- `u`: the control-law spec (`nothing` or a raw `Function`).
+- `cspec`: the `constraint` spec (`nothing`, `Symbol`, `Function`, `Tuple`, or
+  `CTBase.Data.PathConstraint`).
+- `mspec`: the `multiplier` spec (`nothing`, `Function`, `Tuple`, or `CTBase.Data.Multiplier`).
+
+A control-free OCP is skipped entirely (no throw): a control law's arity is only
+meaningful relative to an OCP that actually has a control, and a control-free OCP is
+already rejected with a clearer, more fundamental `PreconditionError` downstream.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if at least one raw function has a
+  single method and a mismatched arity, on a with-control OCP.
+
+See also: [`CTFlows.Flows._arity_issue`](@ref), [`CTFlows.Flows._spec_arity_issues!`](@ref).
+"""
+function _check_convenience_arities(ocp, u, cspec, mspec)
+    Traits.control_dependence(ocp) === Traits.WithControl || return nothing
+    issues = String[]
+    _spec_arity_issues!(issues, ocp, u, "u", "p", "control law")
+    _spec_arity_issues!(issues, ocp, cspec, "g", "u", "constraint")
+    _spec_arity_issues!(issues, ocp, mspec, "μ", "p", "multiplier")
+    isempty(issues) && return nothing
+    throw(
+        Exceptions.IncorrectArgument(
+            "convenience-constructor arity mismatch ($(length(issues)) issue(s))";
+            got=join(issues, "; "),
+            expected="each raw function's arity to match the OCP's time/variable dependence",
+            suggestion="pass explicit constructors instead — Data.DynClosedLoop/Data.OpenLoop/Data.ClosedLoop " *
+                       "for the control law, Data.MixedConstraint/Data.StateConstraint/Data.ControlConstraint " *
+                       "for the constraint, Data.Multiplier for the multiplier — with the time/variable " *
+                       "dependence you intend; this check only runs when the raw function has a single " *
+                       "method (skipped if ambiguous, e.g. multiple dispatch or default arguments)",
+            context="Flow(ocp, u::Function; constraint=…, multiplier=…) — convenience arity check",
+        ),
+    )
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -464,9 +641,21 @@ time-varying feedback on an autonomous OCP), build the
 [`CTBase.Data.DynClosedLoop`](@extref) explicitly and call
 [`CTFlows.Flows.Flow(ocp::CTModels.Models.Model, law::CTBase.Data.ControlLaw)`](@ref).
 
-See also: [`CTFlows.Flows.Flow(ocp::CTModels.Models.Model, law::CTBase.Data.ControlLaw)`](@ref).
+If `u` (and, when given as raw `Function`s, the `constraint`/`multiplier` keyword specs)
+has a single method, its arity is checked against the OCP's time/variable dependence —
+see [`CTFlows.Flows._check_convenience_arities`](@ref).
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if `u`, `constraint`, or `multiplier`
+  has a single method and a mismatched arity.
+
+See also: [`CTFlows.Flows.Flow(ocp::CTModels.Models.Model, law::CTBase.Data.ControlLaw)`](@ref),
+[`CTFlows.Flows._check_convenience_arities`](@ref).
 """
 function Flow(ocp::CTModels.Models.Model, u::Function; kwargs...)
+    _check_convenience_arities(
+        ocp, u, get(kwargs, :constraint, nothing), get(kwargs, :multiplier, nothing)
+    )
     law = Data.DynClosedLoop(
         u; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
     )
@@ -479,7 +668,20 @@ $(TYPEDSIGNATURES)
 Build an [`CTFlows.Flows.OptimalControlFlow`](@ref) from the OCP pseudo-Hamiltonian and
 a `DynClosedLoop` law, dispatching on the `hamiltonian_type` action option.
 
-See also: [`CTFlows.Flows._build_pseudo_flow`](@ref), [`CTFlows.Flows._ocp_pseudo_hamiltonian`](@ref).
+If `constraint`/`multiplier` are given as raw `Function`s with a single method, their
+arity is checked against the OCP's time/variable dependence — see
+[`CTFlows.Flows._check_convenience_arities`](@ref). `law` itself is not checked here: it
+may have been built explicitly with traits that deliberately differ from the OCP's (the
+arity of a raw `u` is only checked in
+[`CTFlows.Flows.Flow(ocp::CTModels.Models.Model, u::Function)`](@ref), which builds the
+law itself from the OCP's traits).
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if `constraint` or `multiplier` has a
+  single method and a mismatched arity.
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref), [`CTFlows.Flows._ocp_pseudo_hamiltonian`](@ref),
+[`CTFlows.Flows._check_convenience_arities`](@ref).
 """
 function _flow_from_ocp_control(
     ::Type{Traits.DynClosedLoopFeedback},
@@ -500,6 +702,7 @@ function _flow_from_ocp_control(
     ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
     cspec = _unwrap_option(get(routed.action, :constraint, nothing), nothing)
     mspec = _unwrap_option(get(routed.action, :multiplier, nothing), nothing)
+    _check_convenience_arities(ocp, nothing, cspec, mspec)
     _validate_constraint_pair(cspec, mspec)
     inner = _build_ocp_pseudo_flow(Val(ht), ocp, law, components, cspec, mspec)
     return OptimalControlFlow(inner, ocp, law)

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -266,6 +266,9 @@ Resolve a `constraint` specification into a [`CTBase.Data.PathConstraint`](@extr
 - `spec::Function` is a raw function with the OCP's natural arity (`(x,u)`, `(t,x,u)`,
   `(x,u,v)` or `(t,x,u,v)`), wrapped in a [`CTBase.Data.MixedConstraint`](@extref) with the
   OCP's time/variable dependence.
+- `spec::Tuple` is a non-empty tuple of simultaneous constraints, each resolved recursively
+  and wrapped in a [`CTFlows.Flows._CombinedConstraint`](@ref) (empty tuple rejected with
+  [`CTBase.Exceptions.IncorrectArgument`](@extref)).
 
 See also: [`CTFlows.Flows._resolve_multiplier`](@ref), `CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`.
 """
@@ -292,12 +295,31 @@ function _resolve_constraint(ocp, spec::Function)
     )
 end
 
-# Combined carrier for a tuple of simultaneous constraints: resolves each element and
-# concatenates their uniform `(t,x,u,v)` values, so the downstream `sum(μ .* g)` pairing
-# computes `Σᵢ μᵢ·gᵢ` with no change to the pseudo-Hamiltonian functors.
+"""
+$(TYPEDEF)
+
+Carrier for a tuple of simultaneous path constraints. Its uniform call concatenates the
+per-constraint values `gᵢ(t,x,u,v)`, so the downstream `sum(μ .* g)` pairing computes
+`Σᵢ μᵢ·gᵢ` with no change to the pseudo-Hamiltonian functors. Paired element-wise with a
+[`CTFlows.Flows._CombinedMultiplier`](@ref) built from the matching multiplier tuple.
+
+# Type Parameters
+- `G <: Tuple`: type of the tuple of resolved per-constraint carriers.
+
+# Fields
+- `parts::G`: the resolved per-constraint carriers (each a [`CTBase.Data.PathConstraint`](@extref)).
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref), [`CTFlows.Flows._CombinedMultiplier`](@ref).
+"""
 struct _CombinedConstraint{G<:Tuple}
     parts::G
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Uniform call: concatenate (`vcat`) the per-constraint values `gᵢ(t,x,u,v)` in tuple order.
+"""
 (c::_CombinedConstraint)(t, x, u, v) = reduce(vcat, map(g -> g(t, x, u, v), c.parts))
 
 function _resolve_constraint(ocp, spec::Tuple)
@@ -332,6 +354,9 @@ Resolve a `multiplier` specification into a [`CTBase.Data.Multiplier`](@extref).
 - `spec::Function` is a raw function with the OCP's natural arity (`(x,p)`, `(t,x,p)`,
   `(x,p,v)` or `(t,x,p,v)`), wrapped in a [`CTBase.Data.Multiplier`](@extref) with the OCP's
   time/variable dependence.
+- `spec::Tuple` is a non-empty tuple of multipliers, each resolved recursively and wrapped in
+  a [`CTFlows.Flows._CombinedMultiplier`](@ref) — matched element-wise with the constraint
+  tuple (empty tuple rejected with [`CTBase.Exceptions.IncorrectArgument`](@extref)).
 
 See also: [`CTFlows.Flows._resolve_constraint`](@ref), `CTFlows.Flows._ocp_constrained_pseudo_hamiltonian`.
 """
@@ -343,11 +368,30 @@ function _resolve_multiplier(ocp, spec::Function)
     )
 end
 
-# Combined carrier for a tuple of multipliers, paired element-wise with a `_CombinedConstraint`:
-# concatenates the uniform `(t,x,p,v)` values in the same order, so `sum(μ .* g)` = `Σᵢ μᵢ·gᵢ`.
+"""
+$(TYPEDEF)
+
+Carrier for a tuple of multipliers, paired element-wise with a
+[`CTFlows.Flows._CombinedConstraint`](@ref). Its uniform call concatenates the per-multiplier
+values `μᵢ(t,x,p,v)` in the same order, so `sum(μ .* g)` = `Σᵢ μᵢ·gᵢ`.
+
+# Type Parameters
+- `M <: Tuple`: type of the tuple of resolved per-multiplier carriers.
+
+# Fields
+- `parts::M`: the resolved per-multiplier carriers (each a [`CTBase.Data.Multiplier`](@extref)).
+
+See also: [`CTFlows.Flows._resolve_multiplier`](@ref), [`CTFlows.Flows._CombinedConstraint`](@ref).
+"""
 struct _CombinedMultiplier{M<:Tuple}
     parts::M
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Uniform call: concatenate (`vcat`) the per-multiplier values `μᵢ(t,x,p,v)` in tuple order.
+"""
 (m::_CombinedMultiplier)(t, x, p, v) = reduce(vcat, map(μ -> μ(t, x, p, v), m.parts))
 
 function _resolve_multiplier(ocp, spec::Tuple)

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -292,6 +292,26 @@ function _resolve_constraint(ocp, spec::Function)
     )
 end
 
+# Combined carrier for a tuple of simultaneous constraints: resolves each element and
+# concatenates their uniform `(t,x,u,v)` values, so the downstream `sum(μ .* g)` pairing
+# computes `Σᵢ μᵢ·gᵢ` with no change to the pseudo-Hamiltonian functors.
+struct _CombinedConstraint{G<:Tuple}
+    parts::G
+end
+(c::_CombinedConstraint)(t, x, u, v) = reduce(vcat, map(g -> g(t, x, u, v), c.parts))
+
+function _resolve_constraint(ocp, spec::Tuple)
+    isempty(spec) && throw(
+        Exceptions.IncorrectArgument(
+            "empty constraint tuple";
+            got="()",
+            expected="a non-empty tuple of constraints",
+            context="Flow(ocp, law; constraint=(…,)) — constraint resolution",
+        ),
+    )
+    return _CombinedConstraint(map(s -> _resolve_constraint(ocp, s), spec))
+end
+
 function _resolve_constraint(::Any, spec)
     return throw(
         Exceptions.IncorrectArgument(
@@ -321,6 +341,25 @@ function _resolve_multiplier(ocp, spec::Function)
     return Data.Multiplier(
         spec; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
     )
+end
+
+# Combined carrier for a tuple of multipliers, paired element-wise with a `_CombinedConstraint`:
+# concatenates the uniform `(t,x,p,v)` values in the same order, so `sum(μ .* g)` = `Σᵢ μᵢ·gᵢ`.
+struct _CombinedMultiplier{M<:Tuple}
+    parts::M
+end
+(m::_CombinedMultiplier)(t, x, p, v) = reduce(vcat, map(μ -> μ(t, x, p, v), m.parts))
+
+function _resolve_multiplier(ocp, spec::Tuple)
+    isempty(spec) && throw(
+        Exceptions.IncorrectArgument(
+            "empty multiplier tuple";
+            got="()",
+            expected="a non-empty tuple of multipliers",
+            context="Flow(ocp, law; multiplier=(…,)) — multiplier resolution",
+        ),
+    )
+    return _CombinedMultiplier(map(s -> _resolve_multiplier(ocp, s), spec))
 end
 
 function _resolve_multiplier(::Any, spec)

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -152,42 +152,74 @@ end
 # =============================================================================
 
 # Piecewise control law: pick the phase by time (flat searchsortedlast — no nested closures),
-# then call that phase's law uniformly. `switches` are the n-1 switching times (sorted).
+# then delegate to that phase's law with the caller's uniform signature. `switches` are the
+# n-1 switching times (sorted); at an exact switch time the *next* phase is chosen (measure
+# zero — irrelevant for plotting and objective integration). Serves both reconstruction paths:
+# `(pl)(t,x,p,v)` for the Hamiltonian/OCP law, `_controlled_u(pl, t, x, v)` for the state law.
 struct _PiecewiseControlLaw{L,S}
     laws::L      # tuple of per-phase Data.ControlLaw
     switches::S  # vector of switching times
 end
-function (pl::_PiecewiseControlLaw)(t, x, p, v)
-    i = clamp(searchsortedlast(pl.switches, t) + 1, 1, length(pl.laws))
-    return pl.laws[i](t, x, p, v)
+function _phase_law(pl::_PiecewiseControlLaw, t)
+    return pl.laws[clamp(searchsortedlast(pl.switches, t) + 1, 1, length(pl.laws))]
+end
+# Hamiltonian/OCP uniform call: (t, x, p, v).
+(pl::_PiecewiseControlLaw)(t, x, p, v) = _phase_law(pl, t)(t, x, p, v)
+# State (controlled) uniform call: dispatched by Trajectories on the phase law's feedback trait.
+function Trajectories._controlled_u(pl::_PiecewiseControlLaw, t, x, v)
+    return Trajectories._controlled_u(_phase_law(pl, t), t, x, v)
 end
 
-# All-OCP phases → rebuild a Solution with piecewise control; plain flows → merged raw
-# trajectory. Runtime branch on the phase types (prototype: avoids alias-vs-nude specificity).
+# All-OCP (Hamiltonian) phases → CTModels Solution; all-controlled (state) phases →
+# ControlledTrajectory; plain flows (no law) → merged raw trajectory. Runtime branch on the
+# phase types (an alias is not more specific than a constrained type — cannot dispatch here).
 function _finalize_multiphase_trajectory(mpf::MultiPhaseFlow, merged, variable)
     phases = get_flows(mpf)
-    if !isempty(phases) && all(p -> p isa Flows.OptimalControlFlow, phases)
+    isempty(phases) && return merged
+    if all(p -> p isa Flows.OptimalControlFlow, phases)
         return _reconstruct_ocp_solution(mpf, merged, variable)
+    end
+    if all(p -> p isa Flows.ControlledFlow, phases)
+        return _reconstruct_controlled_trajectory(mpf, merged, variable)
     end
     return merged
 end
 
-# All-OCP Hamiltonian phases → rebuild a CTModels Solution with a piecewise control.
-function _reconstruct_ocp_solution(mpf, merged, variable)
-    phases = get_flows(mpf)
+# All phases must be built from the same OCP object to reconstruct a single solution
+# (`nothing === nothing` for `Flow(fc, law)` phases, which carry no OCP).
+function _shared_ocp(phases)
     ocp = phases[1].ocp
     all(p -> p.ocp === ocp, phases) || throw(
         Exceptions.IncorrectArgument(
-            "cannot reconstruct a multi-phase OCP solution from flows of different OCPs";
+            "cannot reconstruct a multi-phase solution from flows of different OCPs";
             got="phases carry ≥ 2 distinct ocp objects",
             expected="all phases built from the same ocp",
             context="MultiPhase trajectory reconstruction",
         ),
     )
-    laws = map(p -> p.law, phases)
-    plaw = _PiecewiseControlLaw(laws, get_switching_times(mpf))
+    return ocp
+end
+
+# All-OCP Hamiltonian phases → rebuild a CTModels Solution with a piecewise control.
+function _reconstruct_ocp_solution(mpf, merged, variable)
+    phases = get_flows(mpf)
+    ocp = _shared_ocp(phases)
+    plaw = _PiecewiseControlLaw(map(p -> p.law, phases), get_switching_times(mpf))
     integ = Flows.integrator(phases[1])
     return Flows._build_ocp_solution(ocp, merged, variable, integ, plaw)
+end
+
+# All-controlled (state) phases → rebuild a ControlledTrajectory with a piecewise control,
+# recomputing the objective (Mayer + Lagrange) over the merged trajectory when the phases
+# carry an OCP (`nothing` objective for `Flow(fc, law)` phases).
+function _reconstruct_controlled_trajectory(mpf, merged, variable)
+    phases = get_flows(mpf)
+    ocp = _shared_ocp(phases)
+    plaw = _PiecewiseControlLaw(map(p -> p.law, phases), get_switching_times(mpf))
+    integ = Flows.integrator(phases[1])
+    coerce = Flows._dim_coerce(length(Integrators.final_state(merged)))
+    obj = Flows._controlled_objective(ocp, merged, plaw, variable, integ, coerce)
+    return Trajectories.ControlledTrajectory(merged, plaw, variable, obj, coerce, ocp)
 end
 
 

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -139,8 +139,57 @@ function _evaluate_multiphase(
         end
     end
 
-    return Integrators.merge(results)
+    return _finalize_multiphase_trajectory(mpf, Integrators.merge(results), variable)
 end
+
+# =============================================================================
+# Final reconstruction of a multi-phase trajectory
+#
+# A multi-phase trajectory of OCP-built flows must return the SAME type a single-phase
+# OCP flow returns: a CTModels Solution (via _build_ocp_solution → CTModels build_solution),
+# with a PIECEWISE control reconstructed from the per-phase laws. Plain flows (no law) keep
+# returning the merged raw trajectory.
+# =============================================================================
+
+# Piecewise control law: pick the phase by time (flat searchsortedlast — no nested closures),
+# then call that phase's law uniformly. `switches` are the n-1 switching times (sorted).
+struct _PiecewiseControlLaw{L,S}
+    laws::L      # tuple of per-phase Data.ControlLaw
+    switches::S  # vector of switching times
+end
+function (pl::_PiecewiseControlLaw)(t, x, p, v)
+    i = clamp(searchsortedlast(pl.switches, t) + 1, 1, length(pl.laws))
+    return pl.laws[i](t, x, p, v)
+end
+
+# All-OCP phases → rebuild a Solution with piecewise control; plain flows → merged raw
+# trajectory. Runtime branch on the phase types (prototype: avoids alias-vs-nude specificity).
+function _finalize_multiphase_trajectory(mpf::MultiPhaseFlow, merged, variable)
+    phases = get_flows(mpf)
+    if !isempty(phases) && all(p -> p isa Flows.OptimalControlFlow, phases)
+        return _reconstruct_ocp_solution(mpf, merged, variable)
+    end
+    return merged
+end
+
+# All-OCP Hamiltonian phases → rebuild a CTModels Solution with a piecewise control.
+function _reconstruct_ocp_solution(mpf, merged, variable)
+    phases = get_flows(mpf)
+    ocp = phases[1].ocp
+    all(p -> p.ocp === ocp, phases) || throw(
+        Exceptions.IncorrectArgument(
+            "cannot reconstruct a multi-phase OCP solution from flows of different OCPs";
+            got="phases carry ≥ 2 distinct ocp objects",
+            expected="all phases built from the same ocp",
+            context="MultiPhase trajectory reconstruction",
+        ),
+    )
+    laws = map(p -> p.law, phases)
+    plaw = _PiecewiseControlLaw(laws, get_switching_times(mpf))
+    integ = Flows.integrator(phases[1])
+    return Flows._build_ocp_solution(ocp, merged, variable, integ, plaw)
+end
+
 
 # ==============================================================================
 # Phase Evaluation & Jump Delegation
@@ -165,10 +214,24 @@ Evaluate a single phase for a state flow with point configuration.
 
 See also: [`CTFlows.Flows.StateFlow`](@ref).
 """
+# Dispatch on the abstract dynamics axis, not the concrete Flow type, and
+# unwrap decorator flows (OptimalControlFlow / ControlledFlow) to their raw inner flow so
+# every phase yields a mergeable raw segment. Covers HamiltonianFlow, OptimalControlFlow,
+# StateFlow, ControlledFlow, nested MultiPhaseFlow — one method per axis, no forgotten case.
+_raw_flow(f::Flows.AbstractFlow) = f
+_raw_flow(f::Flows.OptimalControlFlow) = f.flow
+_raw_flow(f::Flows.ControlledFlow) = f.flow
+
 function _evaluate_phase(
-    flow::Flows.StateFlow, t0, tf, x, ::Configs.AbstractEndPointConfig; variable, unsafe
+    flow::Flows.AbstractStateFlow,
+    t0,
+    tf,
+    x,
+    ::Configs.AbstractEndPointConfig;
+    variable,
+    unsafe,
 )
-    return flow(t0, x, tf; variable=variable, unsafe=unsafe)
+    return _raw_flow(flow)(t0, x, tf; variable=variable, unsafe=unsafe)
 end
 
 """
@@ -191,9 +254,15 @@ Evaluate a single phase for a state flow with trajectory configuration.
 See also: [`CTFlows.Flows.StateFlow`](@ref).
 """
 function _evaluate_phase(
-    flow::Flows.StateFlow, t0, tf, x, ::Configs.AbstractTrajectoryConfig; variable, unsafe
+    flow::Flows.AbstractStateFlow,
+    t0,
+    tf,
+    x,
+    ::Configs.AbstractTrajectoryConfig;
+    variable,
+    unsafe,
 )
-    return flow((t0, tf), x; variable=variable, unsafe=unsafe)
+    return _raw_flow(flow)((t0, tf), x; variable=variable, unsafe=unsafe)
 end
 
 """
@@ -216,7 +285,7 @@ Evaluate a single phase for a Hamiltonian flow with point configuration.
 See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
 function _evaluate_phase(
-    flow::Flows.HamiltonianFlow,
+    flow::Flows.AbstractHamiltonianFlow,
     t0,
     tf,
     state_tuple,
@@ -225,7 +294,7 @@ function _evaluate_phase(
     unsafe,
 )
     x, p = state_tuple
-    return flow(t0, x, p, tf; variable=variable, unsafe=unsafe)
+    return _raw_flow(flow)(t0, x, p, tf; variable=variable, unsafe=unsafe)
 end
 
 """
@@ -248,7 +317,7 @@ Evaluate a single phase for a Hamiltonian flow with trajectory configuration.
 See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
 function _evaluate_phase(
-    flow::Flows.HamiltonianFlow,
+    flow::Flows.AbstractHamiltonianFlow,
     t0,
     tf,
     state_tuple,
@@ -257,7 +326,7 @@ function _evaluate_phase(
     unsafe,
 )
     x, p = state_tuple
-    return flow((t0, tf), x, p; variable=variable, unsafe=unsafe)
+    return _raw_flow(flow)((t0, tf), x, p; variable=variable, unsafe=unsafe)
 end
 
 """

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -145,34 +145,118 @@ end
 # =============================================================================
 # Final reconstruction of a multi-phase trajectory
 #
-# A multi-phase trajectory of OCP-built flows must return the SAME type a single-phase
-# OCP flow returns: a CTModels Solution (via _build_ocp_solution → CTModels build_solution),
-# with a PIECEWISE control reconstructed from the per-phase laws. Plain flows (no law) keep
-# returning the merged raw trajectory.
+# A multi-phase trajectory must return the SAME type a single-phase flow returns, with a
+# PIECEWISE control reconstructed from the per-phase laws: all-OptimalControlFlow phases → a
+# CTModels Solution (via _build_ocp_solution), all-ControlledFlow phases → a
+# ControlledTrajectory. Plain flows (no law) keep returning the merged raw trajectory.
 # =============================================================================
 
-# Piecewise control law: pick the phase by time (flat searchsortedlast — no nested closures),
-# then delegate to that phase's law with the caller's uniform signature. `switches` are the
-# n-1 switching times (sorted); at an exact switch time the *next* phase is chosen (measure
-# zero — irrelevant for plotting and objective integration). Serves both reconstruction paths:
-# `(pl)(t,x,p,v)` for the Hamiltonian/OCP law, `_controlled_u(pl, t, x, v)` for the state law.
+"""
+$(TYPEDEF)
+
+Piecewise control law reconstructed from the per-phase laws of a multi-phase flow. It selects
+the phase by time (a flat `searchsortedlast` over the switching times — no nested closures),
+then delegates to that phase's law with the caller's uniform signature. It serves both
+reconstruction paths: `(pl)(t, x, p, v)` for the Hamiltonian/OCP law, and
+`CTFlows.Trajectories._controlled_u(pl, t, x, v)` for the state (controlled) law.
+
+At an exact switching time the *next* phase is selected — a measure-zero choice, irrelevant to
+plotting and to objective integration.
+
+# Type Parameters
+- `L`: type of the tuple of per-phase control laws.
+- `S`: type of the switching-times vector.
+
+# Fields
+- `laws::L`: tuple of the per-phase control laws (each a `CTBase.Data.ControlLaw`).
+- `switches::S`: the `n-1` sorted switching times.
+
+See also: [`CTFlows.MultiPhase._reconstruct_ocp_solution`](@ref),
+[`CTFlows.MultiPhase._reconstruct_controlled_trajectory`](@ref).
+"""
 struct _PiecewiseControlLaw{L,S}
     laws::L      # tuple of per-phase Data.ControlLaw
     switches::S  # vector of switching times
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the phase law active at time `t`: the law of the phase selected by `searchsortedlast`
+over the switching times, clamped to the valid phase range.
+
+# Arguments
+- `pl::_PiecewiseControlLaw`: The piecewise control law.
+- `t`: The time at which to select the active phase.
+
+# Returns
+- The per-phase control law active at time `t`.
+"""
 function _phase_law(pl::_PiecewiseControlLaw, t)
     return pl.laws[clamp(searchsortedlast(pl.switches, t) + 1, 1, length(pl.laws))]
 end
-# Hamiltonian/OCP uniform call: (t, x, p, v).
+
+"""
+$(TYPEDSIGNATURES)
+
+Hamiltonian/OCP uniform call: delegate to the phase law active at time `t`.
+
+# Arguments
+- `pl::_PiecewiseControlLaw`: The piecewise control law.
+- `t`: Time.
+- `x`: State.
+- `p`: Costate.
+- `v`: Variable (or `Core.NotProvided`).
+
+# Returns
+- The control `u = law(t, x, p, v)` of the phase active at `t`.
+"""
 (pl::_PiecewiseControlLaw)(t, x, p, v) = _phase_law(pl, t)(t, x, p, v)
-# State (controlled) uniform call: dispatched by Trajectories on the phase law's feedback trait.
+
+"""
+$(TYPEDSIGNATURES)
+
+State (controlled) uniform call: delegate to the phase law active at time `t`, dispatched by
+`CTFlows.Trajectories` on that law's feedback trait (`OpenLoop`/`ClosedLoop`).
+
+# Arguments
+- `pl::_PiecewiseControlLaw`: The piecewise control law.
+- `t`: Time.
+- `x`: State.
+- `v`: Variable (or `Core.NotProvided`).
+
+# Returns
+- The control of the phase active at `t`, reconstructed by the feedback-dispatched call.
+"""
 function Trajectories._controlled_u(pl::_PiecewiseControlLaw, t, x, v)
     return Trajectories._controlled_u(_phase_law(pl, t), t, x, v)
 end
 
-# All-OCP (Hamiltonian) phases → CTModels Solution; all-controlled (state) phases →
-# ControlledTrajectory; plain flows (no law) → merged raw trajectory. Runtime branch on the
-# phase types (an alias is not more specific than a constrained type — cannot dispatch here).
+"""
+$(TYPEDSIGNATURES)
+
+Finalize a merged multi-phase trajectory into the type a single-phase flow would return.
+
+All-`OptimalControlFlow` phases rebuild a [`CTModels.Solutions.Solution`](@extref) (via
+[`CTFlows.MultiPhase._reconstruct_ocp_solution`](@ref)); all-`ControlledFlow` phases rebuild a
+[`CTFlows.Trajectories.ControlledTrajectory`](@ref) (via
+[`CTFlows.MultiPhase._reconstruct_controlled_trajectory`](@ref)); any other case (plain flows
+carrying no law) returns the merged raw trajectory unchanged.
+
+The branch is a runtime `isa` test on the phase types rather than dispatch: a parametric alias
+(e.g. `MultiPhaseHamiltonianFlow`) is not more specific than the constrained base type, so it
+cannot select a method here.
+
+# Arguments
+- `mpf::MultiPhaseFlow`: The multi-phase flow whose phases carry the per-phase laws.
+- `merged`: The merged trajectory over all phases.
+- `variable`: The variable parameter value (for NonFixed systems).
+
+# Returns
+- A `CTModels.Solution`, a `ControlledTrajectory`, or the merged trajectory (see above).
+
+See also: [`CTFlows.MultiPhase._evaluate_multiphase`](@ref).
+"""
 function _finalize_multiphase_trajectory(mpf::MultiPhaseFlow, merged, variable)
     phases = get_flows(mpf)
     isempty(phases) && return merged
@@ -185,8 +269,22 @@ function _finalize_multiphase_trajectory(mpf::MultiPhaseFlow, merged, variable)
     return merged
 end
 
-# All phases must be built from the same OCP object to reconstruct a single solution
-# (`nothing === nothing` for `Flow(fc, law)` phases, which carry no OCP).
+"""
+$(TYPEDSIGNATURES)
+
+Return the OCP shared by every phase. `Flow(fc, law)` phases carry no OCP (`nothing`), which
+compare equal under `===`.
+
+# Arguments
+- `phases`: The tuple of phase flows (each carrying an `ocp` field).
+
+# Returns
+- The single OCP object (or `nothing`) common to all phases.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): if the phases carry two or more distinct
+  OCP objects.
+"""
 function _shared_ocp(phases)
     ocp = phases[1].ocp
     all(p -> p.ocp === ocp, phases) || throw(
@@ -200,7 +298,23 @@ function _shared_ocp(phases)
     return ocp
 end
 
-# All-OCP Hamiltonian phases → rebuild a CTModels Solution with a piecewise control.
+"""
+$(TYPEDSIGNATURES)
+
+Rebuild a [`CTModels.Solutions.Solution`](@extref) from an all-`OptimalControlFlow` multi-phase
+trajectory, reconstructing the control as a [`CTFlows.MultiPhase._PiecewiseControlLaw`](@ref)
+over the per-phase laws.
+
+# Arguments
+- `mpf`: The multi-phase Hamiltonian flow.
+- `merged`: The merged Hamiltonian trajectory over all phases.
+- `variable`: The variable parameter value (for NonFixed systems).
+
+# Returns
+- A [`CTModels.Solutions.Solution`](@extref) with the piecewise-reconstructed control.
+
+See also: [`CTFlows.MultiPhase._reconstruct_controlled_trajectory`](@ref), `CTFlows.Flows._build_ocp_solution`.
+"""
 function _reconstruct_ocp_solution(mpf, merged, variable)
     phases = get_flows(mpf)
     ocp = _shared_ocp(phases)
@@ -209,9 +323,25 @@ function _reconstruct_ocp_solution(mpf, merged, variable)
     return Flows._build_ocp_solution(ocp, merged, variable, integ, plaw)
 end
 
-# All-controlled (state) phases → rebuild a ControlledTrajectory with a piecewise control,
-# recomputing the objective (Mayer + Lagrange) over the merged trajectory when the phases
-# carry an OCP (`nothing` objective for `Flow(fc, law)` phases).
+"""
+$(TYPEDSIGNATURES)
+
+Rebuild a [`CTFlows.Trajectories.ControlledTrajectory`](@ref) from an all-`ControlledFlow`
+multi-phase trajectory, reconstructing the control as a
+[`CTFlows.MultiPhase._PiecewiseControlLaw`](@ref) and recomputing the objective (Mayer +
+Lagrange) over the merged trajectory when the phases carry an OCP (`nothing` objective for
+`Flow(fc, law)` phases).
+
+# Arguments
+- `mpf`: The multi-phase state flow.
+- `merged`: The merged state trajectory over all phases.
+- `variable`: The variable parameter value (for NonFixed systems).
+
+# Returns
+- A [`CTFlows.Trajectories.ControlledTrajectory`](@ref) with the piecewise-reconstructed control.
+
+See also: [`CTFlows.MultiPhase._reconstruct_ocp_solution`](@ref), `CTFlows.Flows._controlled_objective`.
+"""
 function _reconstruct_controlled_trajectory(mpf, merged, variable)
     phases = get_flows(mpf)
     ocp = _shared_ocp(phases)
@@ -230,10 +360,35 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Evaluate a single phase for a state flow with point configuration.
+Return the raw inner flow of a phase, unwrapping the decorator flows
+([`CTFlows.Flows.OptimalControlFlow`](@ref) / [`CTFlows.Flows.ControlledFlow`](@ref)) to the
+inner `HamiltonianFlow`/`StateFlow` that yields a mergeable raw segment; any other
+[`CTFlows.Flows.AbstractFlow`](@ref) (a plain `HamiltonianFlow`/`StateFlow` or a nested
+`MultiPhaseFlow`) is returned unchanged.
+
+Dispatching on the abstract flow type — one method per decorator plus the fallback — covers
+every phase kind with no forgotten case.
 
 # Arguments
-- `flow::Flows.StateFlow`: The state flow to evaluate.
+- `f::Flows.AbstractFlow`: The phase flow.
+
+# Returns
+- The raw inner flow to integrate for this phase.
+"""
+_raw_flow(f::Flows.AbstractFlow) = f
+_raw_flow(f::Flows.OptimalControlFlow) = f.flow
+_raw_flow(f::Flows.ControlledFlow) = f.flow
+
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate a single phase for a state flow with point configuration.
+
+Dispatches on the abstract dynamics axis (`AbstractStateFlow`) and unwraps decorator flows via
+[`CTFlows.MultiPhase._raw_flow`](@ref) before integrating.
+
+# Arguments
+- `flow::Flows.AbstractStateFlow`: The state (or decorated state) flow to evaluate.
 - `t0`: Start time.
 - `tf`: End time.
 - `x`: Initial state.
@@ -244,16 +399,8 @@ Evaluate a single phase for a state flow with point configuration.
 # Returns
 - Final state at time tf.
 
-See also: [`CTFlows.Flows.StateFlow`](@ref).
+See also: [`CTFlows.MultiPhase._raw_flow`](@ref), [`CTFlows.Flows.StateFlow`](@ref).
 """
-# Dispatch on the abstract dynamics axis, not the concrete Flow type, and
-# unwrap decorator flows (OptimalControlFlow / ControlledFlow) to their raw inner flow so
-# every phase yields a mergeable raw segment. Covers HamiltonianFlow, OptimalControlFlow,
-# StateFlow, ControlledFlow, nested MultiPhaseFlow — one method per axis, no forgotten case.
-_raw_flow(f::Flows.AbstractFlow) = f
-_raw_flow(f::Flows.OptimalControlFlow) = f.flow
-_raw_flow(f::Flows.ControlledFlow) = f.flow
-
 function _evaluate_phase(
     flow::Flows.AbstractStateFlow,
     t0,
@@ -271,8 +418,11 @@ $(TYPEDSIGNATURES)
 
 Evaluate a single phase for a state flow with trajectory configuration.
 
+Dispatches on the abstract dynamics axis (`AbstractStateFlow`) and unwraps decorator flows via
+[`CTFlows.MultiPhase._raw_flow`](@ref) before integrating.
+
 # Arguments
-- `flow::Flows.StateFlow`: The state flow to evaluate.
+- `flow::Flows.AbstractStateFlow`: The state (or decorated state) flow to evaluate.
 - `t0`: Start time.
 - `tf`: End time.
 - `x`: Initial state.
@@ -283,7 +433,7 @@ Evaluate a single phase for a state flow with trajectory configuration.
 # Returns
 - Trajectory solution from t0 to tf.
 
-See also: [`CTFlows.Flows.StateFlow`](@ref).
+See also: [`CTFlows.MultiPhase._raw_flow`](@ref), [`CTFlows.Flows.StateFlow`](@ref).
 """
 function _evaluate_phase(
     flow::Flows.AbstractStateFlow,
@@ -302,8 +452,11 @@ $(TYPEDSIGNATURES)
 
 Evaluate a single phase for a Hamiltonian flow with point configuration.
 
+Dispatches on the abstract dynamics axis (`AbstractHamiltonianFlow`) and unwraps decorator
+flows via [`CTFlows.MultiPhase._raw_flow`](@ref) before integrating.
+
 # Arguments
-- `flow::Flows.HamiltonianFlow`: The Hamiltonian flow to evaluate.
+- `flow::Flows.AbstractHamiltonianFlow`: The Hamiltonian (or decorated Hamiltonian) flow to evaluate.
 - `t0`: Start time.
 - `tf`: End time.
 - `state_tuple`: Tuple of (initial_state, initial_costate).
@@ -314,7 +467,7 @@ Evaluate a single phase for a Hamiltonian flow with point configuration.
 # Returns
 - Tuple of (final_state, final_costate) at time tf.
 
-See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
+See also: [`CTFlows.MultiPhase._raw_flow`](@ref), [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
 function _evaluate_phase(
     flow::Flows.AbstractHamiltonianFlow,
@@ -334,8 +487,11 @@ $(TYPEDSIGNATURES)
 
 Evaluate a single phase for a Hamiltonian flow with trajectory configuration.
 
+Dispatches on the abstract dynamics axis (`AbstractHamiltonianFlow`) and unwraps decorator
+flows via [`CTFlows.MultiPhase._raw_flow`](@ref) before integrating.
+
 # Arguments
-- `flow::Flows.HamiltonianFlow`: The Hamiltonian flow to evaluate.
+- `flow::Flows.AbstractHamiltonianFlow`: The Hamiltonian (or decorated Hamiltonian) flow to evaluate.
 - `t0`: Start time.
 - `tf`: End time.
 - `state_tuple`: Tuple of (initial_state, initial_costate).
@@ -346,7 +502,7 @@ Evaluate a single phase for a Hamiltonian flow with trajectory configuration.
 # Returns
 - Trajectory solution from t0 to tf.
 
-See also: [`CTFlows.Flows.HamiltonianFlow`](@ref).
+See also: [`CTFlows.MultiPhase._raw_flow`](@ref), [`CTFlows.Flows.HamiltonianFlow`](@ref).
 """
 function _evaluate_phase(
     flow::Flows.AbstractHamiltonianFlow,

--- a/src/MultiPhase/concatenation.jl
+++ b/src/MultiPhase/concatenation.jl
@@ -71,13 +71,17 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Concatenate two state flows with a switching time and jump using the `*` operator.
+Concatenate two state flows with a switching time and an additive state jump using the `*`
+operator.
 
-Creates a multi-phase flow with a jump function applied at the switching time.
+Creates a multi-phase flow that adds `jump` to the state at the switching time
+(`x ← x + jump`). The jump follows the "1-D is a scalar" convention: a scalar for a 1-D state,
+a vector for an n-D state — its shape must match the state.
 
 # Arguments
 - `f1::AbstractStateFlow`: First flow (phase 1).
-- `(t_switch, jump, f2)::Tuple{Real, Any, AbstractStateFlow}`: Tuple of switching time, jump function, and second flow (phase 2).
+- `(t_switch, jump, f2)::Tuple{Real, Any, AbstractStateFlow}`: Tuple of switching time, additive
+  state jump, and second flow (phase 2).
 
 # Returns
 - `MultiPhaseStateFlow`: Multi-phase flow with a jump.
@@ -86,8 +90,7 @@ Creates a multi-phase flow with a jump function applied at the switching time.
 \`\`\`julia
 using CTFlows.Flows, CTFlows.MultiPhase
 
-jump = x -> 2 * x
-mpf = flow1 * (1.0, jump, flow2)
+mpf = flow1 * (1.0, [0.1, 0.2], flow2)   # x ← x + [0.1, 0.2] at t = 1.0
 \`\`\`
 
 See also: [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref), [`CTFlows.MultiPhase.get_flows`](@ref).
@@ -140,13 +143,17 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Concatenate two Hamiltonian flows with a switching time and jump using the `*` operator.
+Concatenate two Hamiltonian flows with a switching time and an additive costate jump using the
+`*` operator.
 
-Creates a multi-phase Hamiltonian flow with a jump function applied at the switching time.
+Creates a multi-phase Hamiltonian flow that adds `jump` to the costate at the switching time
+(`p ← p + jump`; the state is unchanged). The jump follows the "1-D is a scalar" convention: a
+scalar for a 1-D costate, a vector for an n-D costate — its shape must match the costate.
 
 # Arguments
 - `f1::AbstractHamiltonianFlow`: First flow (phase 1).
-- `(t_switch, jump, f2)::Tuple{Real, Any, AbstractHamiltonianFlow}`: Tuple of switching time, jump function, and second flow (phase 2).
+- `(t_switch, jump, f2)::Tuple{Real, Any, AbstractHamiltonianFlow}`: Tuple of switching time,
+  additive costate jump, and second flow (phase 2).
 
 # Returns
 - `MultiPhaseHamiltonianFlow`: Multi-phase Hamiltonian flow with a jump.
@@ -155,8 +162,7 @@ Creates a multi-phase Hamiltonian flow with a jump function applied at the switc
 \`\`\`julia
 using CTFlows.Flows, CTFlows.MultiPhase
 
-jump = x -> 2 * x
-mpf = flow1 * (1.0, jump, flow2)
+mpf = flow1 * (1.0, [0.5, 0.0], flow2)   # p ← p + [0.5, 0.0] at t = 1.0
 \`\`\`
 
 See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.MultiPhase.get_flows`](@ref).
@@ -175,13 +181,18 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Concatenate two Hamiltonian flows with a switching time and separate state/costate jumps using the `*` operator.
+Concatenate two Hamiltonian flows with a switching time and separate additive state/costate
+jumps using the `*` operator.
 
-Creates a multi-phase Hamiltonian flow with separate jump functions for state and costate applied at the switching time.
+Creates a multi-phase Hamiltonian flow that adds `jump_x` to the state and `jump_p` to the
+costate at the switching time (`x ← x + jump_x`, `p ← p + jump_p`). Each jump follows the
+"1-D is a scalar" convention: a scalar for a 1-D quantity, a vector for an n-D one — its shape
+must match the state/costate.
 
 # Arguments
 - `f1::AbstractHamiltonianFlow`: First flow (phase 1).
-- `(t_switch, jump_x, jump_p, f2)::Tuple{Real, Any, Any, AbstractHamiltonianFlow}`: Tuple of switching time, state jump, costate jump, and second flow (phase 2).
+- `(t_switch, jump_x, jump_p, f2)::Tuple{Real, Any, Any, AbstractHamiltonianFlow}`: Tuple of
+  switching time, additive state jump, additive costate jump, and second flow (phase 2).
 
 # Returns
 - `MultiPhaseHamiltonianFlow`: Multi-phase Hamiltonian flow with separate jumps.
@@ -190,9 +201,7 @@ Creates a multi-phase Hamiltonian flow with separate jump functions for state an
 \`\`\`julia
 using CTFlows.Flows, CTFlows.MultiPhase
 
-jump_x = x -> 2 * x
-jump_p = p -> 3 * p
-mpf = flow1 * (1.0, jump_x, jump_p, flow2)
+mpf = flow1 * (1.0, [0.1, 0.0], [0.0, 0.5], flow2)   # x ← x + [0.1,0.0], p ← p + [0.0,0.5]
 \`\`\`
 
 See also: [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref), [`CTFlows.MultiPhase.get_flows`](@ref).

--- a/src/Trajectories/Trajectories.jl
+++ b/src/Trajectories/Trajectories.jl
@@ -9,9 +9,10 @@ This module provides:
 - `build_trajectory`: Trajectory building functions for different configuration types
 - `final_state`, `times`, `evaluate_at`: Semantic accessors for integration results
 - `state`, `time_grid`: Semantic accessors for VectorFieldTrajectory
-- `plot`: Plotting functionality for trajectories
+- `Trajectories.plot`: plotting for trajectories via the Plots extension (a `RecipesBase.plot`
+  method; not re-exported — call it qualified or load `Plots`)
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTFlows.Trajectories.VectorFieldTrajectory`](@ref), [`CTFlows.Trajectories.build_trajectory`](@ref), `plot`.
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTFlows.Trajectories.VectorFieldTrajectory`](@ref), [`CTFlows.Trajectories.build_trajectory`](@ref).
 """
 module Trajectories
 
@@ -56,6 +57,5 @@ export state, time_grid
 export costate
 export control, objective
 export build_trajectory
-export plot
 
 end # module Trajectories

--- a/test/suite/flows/test_convenience_arity.jl
+++ b/test/suite/flows/test_convenience_arity.jl
@@ -1,0 +1,231 @@
+"""
+Tests for the arity-checking guard on the OCP convenience constructors:
+`Flow(ocp, u::Function)` and the raw-`Function` `constraint`/`multiplier` specs.
+"""
+
+module TestConvenienceArity
+
+using Test: Test
+import CTBase.Data: Data
+import CTBase.Exceptions: Exceptions
+import CTModels: CTModels
+import CTFlows.Flows: Flows
+using OrdinaryDiffEqTsit5: Tsit5
+using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+_opts() = (; alg=Tsit5(), reltol=1e-10, abstol=1e-10)
+
+# =============================================================================
+# OCP fixtures at module top-level
+# =============================================================================
+
+# scalar LQR: ẋ = -x + u, ℓ = 0.5u², :min  (autonomous, fixed) — expected natural arity 2
+function _build_lqr()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1]=(-x + u); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+# non-autonomous: ẋ = u(1 + tan t), ℓ = 0.5u², :min  (non-autonomous, fixed) — expected arity 3
+function _build_nonauton()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=π / 4)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1]=u * (1 + tan(t)); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+# variable (NonFixed): ẋ = v·(-x) + u, ℓ = 0.5u², :min  (autonomous, non-fixed) — expected arity 3
+function _build_variable()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1]=v * (-x) + u; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+const OCP_LQR = _build_lqr()
+const OCP_NA = _build_nonauton()
+const OCP_VAR = _build_variable()
+
+# Fake function with 2 methods (arity 2 and arity 3): ambiguous, the arity check must skip
+# it entirely (return no issue) even though the extra method would mismatch OCP_LQR.
+_ambiguous_u(x, p) = p
+_ambiguous_u(x, p, v) = p
+
+function test_convenience_arity()
+    Test.@testset "Convenience-constructor arity checking" verbose = VERBOSE showtiming = SHOWTIMING begin
+
+        # ====================================================================
+        # single-issue mismatches
+        # ====================================================================
+
+        Test.@testset "control law arity mismatch alone" begin
+            bad_u = (t, x, p) -> p  # arity 3, OCP_LQR expects 2
+            try
+                Flows.Flow(OCP_LQR, bad_u; _opts()...)
+                Test.@test false  # should not reach here
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                msg = sprint(showerror, err)
+                Test.@test occursin("control law `u`", msg)
+                Test.@test occursin("u(x, p)", msg)
+            end
+        end
+
+        Test.@testset "constraint arity mismatch alone" begin
+            u = (x, p) -> p
+            bad_g = (x, u, v) -> x  # arity 3, OCP_LQR expects 2
+            μ = (x, p) -> 0.7
+            try
+                Flows.Flow(OCP_LQR, u; constraint=bad_g, multiplier=μ, _opts()...)
+                Test.@test false
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                # `got` carries only the collected issues — the full showerror message
+                # also includes the "use explicit constructors" hint, which necessarily
+                # names all three roles regardless of which ones actually mismatched.
+                Test.@test occursin("constraint `g`", err.got)
+                Test.@test occursin("g(x, u)", err.got)
+                Test.@test !occursin("control law", err.got)
+                Test.@test !occursin("multiplier", err.got)
+            end
+        end
+
+        Test.@testset "multiplier arity mismatch alone" begin
+            u = (x, p) -> p
+            g = (x, u) -> x
+            bad_μ = (t, x, p) -> 0.7  # arity 3, OCP_LQR expects 2
+            try
+                Flows.Flow(OCP_LQR, u; constraint=g, multiplier=bad_μ, _opts()...)
+                Test.@test false
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                Test.@test occursin("multiplier `μ`", err.got)
+                Test.@test occursin("μ(x, p)", err.got)
+                Test.@test !occursin("control law", err.got)
+                Test.@test !occursin("constraint `g`", err.got)
+            end
+        end
+
+        # ====================================================================
+        # combined mismatches — one exception, all issues listed
+        # ====================================================================
+
+        Test.@testset "all three mismatched at once — one combined exception" begin
+            bad_u = (x, p, v) -> p    # arity 3, expected 2
+            bad_g = (t, x, u) -> x    # arity 3, expected 2
+            bad_μ = (x, p, v) -> 0.7  # arity 3, expected 2
+            try
+                Flows.Flow(OCP_LQR, bad_u; constraint=bad_g, multiplier=bad_μ, _opts()...)
+                Test.@test false
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                msg = sprint(showerror, err)
+                Test.@test occursin("control law `u`", msg)
+                Test.@test occursin("constraint `g`", msg)
+                Test.@test occursin("multiplier `μ`", msg)
+                Test.@test occursin("3 issue(s)", msg)
+            end
+        end
+
+        Test.@testset "Tuple constraint spec: only the bad element is named" begin
+            u = (x, p) -> p
+            g1 = (x, u) -> x        # correct arity 2
+            g2 = (x, u, v) -> x     # wrong arity 3
+            μ1 = (x, p) -> 0.5
+            μ2 = (x, p) -> 0.5
+            try
+                Flows.Flow(
+                    OCP_LQR, u; constraint=(g1, g2), multiplier=(μ1, μ2), _opts()...
+                )
+                Test.@test false
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                # label includes the tuple index, e.g. "constraint #2 `g2` has arity ..."
+                Test.@test occursin("`g2`", err.got)
+                Test.@test !occursin("`g1`", err.got)
+            end
+        end
+
+        # ====================================================================
+        # positive controls — matching arity never throws
+        # ====================================================================
+
+        Test.@testset "correct arity — no throw, integrates normally" begin
+            u = (x, p) -> p
+            g = (x, u) -> x
+            μ = (x, p) -> 0.7
+            f = Flows.Flow(OCP_LQR, u; constraint=g, multiplier=μ, _opts()...)
+            xf, pf = f(0.0, 1.0, 0.5, 1.0)
+            Test.@test xf isa Number
+            Test.@test pf isa Number
+        end
+
+        Test.@testset "non-autonomous / variable OCPs: matching arity does not throw" begin
+            un = (t, x, p) -> p * (1 + tan(t))
+            fn = Flows.Flow(OCP_NA, un; _opts()...)
+            Test.@test fn isa Flows.OptimalControlFlow
+
+            uv = (x, p, v) -> p
+            fv = Flows.Flow(OCP_VAR, uv; _opts()...)
+            xv, pv = fv(0.0, 1.0, 0.5, 1.0; variable=0.5)
+            Test.@test xv isa Number
+        end
+
+        Test.@testset "ambiguous function (2+ methods) — silently skipped" begin
+            # _ambiguous_u has 2 methods; the check cannot tell which arity the user
+            # means, so it is skipped — Julia's own dispatch picks the (x, p) method at
+            # call time, and the flow integrates normally with no throw.
+            f = Flows.Flow(OCP_LQR, _ambiguous_u; _opts()...)
+            xf, pf = f(0.0, 1.0, 0.5, 1.0)
+            fref = Flows.Flow(OCP_LQR, Data.DynClosedLoop((x, p) -> p); _opts()...)
+            xr, pr = fref(0.0, 1.0, 0.5, 1.0)
+            Test.@test xf ≈ xr atol = 1e-10
+            Test.@test pf ≈ pr atol = 1e-10
+        end
+
+        # ====================================================================
+        # explicit law: only constraint/multiplier are checked, never the law itself
+        # ====================================================================
+
+        Test.@testset "explicit law with divergent traits: law arity itself is not checked" begin
+            # An explicit DynClosedLoop built with is_autonomous=false on an autonomous OCP
+            # is a deliberate trait override — the check only applies to the raw `u` passed
+            # to the Flow(ocp, u::Function) convenience, not to an already-built law.
+            law = Data.DynClosedLoop((t, x, p) -> p; is_autonomous=false)
+            f = Flows.Flow(OCP_LQR, law; _opts()...)
+            Test.@test f isa Flows.OptimalControlFlow
+
+            # but a convenience constraint mismatch alongside it is still caught
+            bad_g = (t, x, u, v) -> x  # arity 4, OCP_LQR expects 2
+            μ = (x, p) -> 0.7
+            try
+                Flows.Flow(OCP_LQR, law; constraint=bad_g, multiplier=μ, _opts()...)
+                Test.@test false
+            catch err
+                Test.@test err isa Exceptions.IncorrectArgument
+                Test.@test occursin("constraint `g`", sprint(showerror, err))
+            end
+        end
+    end
+end
+
+end # module
+
+test_convenience_arity() = TestConvenienceArity.test_convenience_arity()

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -778,6 +778,30 @@ function test_ocp_control()
             Test.@test pvf ≈ _trapz(ts, ys) atol = 1e-3
         end
 
+        Test.@testset "Constrained: :total variable-costate picks up ∂/∂v[H̃+μ·g] (analytic)" begin
+            # Same setup as the :partial test above — v-dependent constraint g(x,v)=x·v,
+            # μ≡c, stationary AND v-independent law u=p ⇒ the chain term ∂H̃/∂u·∂u/∂v
+            # vanishes, so :total's pv coincides with the same frozen-μ analytic formula.
+            # Fills the last cell of the {constraint} × {:total,:partial} × {variable,
+            # variable_costate} matrix (the other three are covered above/below).
+            c = 0.2
+            g = Data.StateConstraint((x, v) -> x * v; is_variable=true)
+            μ = Data.Multiplier((x, p) -> c)
+            law = Data.DynClosedLoop((x, p, v) -> p; is_variable=true)
+            ft = Flows.Flow(
+                OCP_VAR, law; constraint=g, multiplier=μ, hamiltonian_type=:total, _opts()...
+            )
+            t0, tf, x0, p0, v = 0.0, 1.0, 1.0, 0.5, 0.5
+            _, _, pvt = ft(t0, x0, p0, tf; variable=v, variable_costate=true)
+            Test.@test pvt isa Number
+            ts = range(t0, tf; length=201)
+            ys = map(ts) do t
+                x, p = t == t0 ? (x0, p0) : ft(t0, x0, p0, t; variable=v)
+                x * (p - c)                       # ∂/∂v[H̃+μ·g] along the flow's own trajectory
+            end
+            Test.@test pvt ≈ _trapz(ts, ys) atol = 1e-3
+        end
+
         Test.@testset "Constrained :partial: NonFixed smoke (variable at call time)" begin
             c = 0.2
             g = Data.StateConstraint(x -> x)

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -803,6 +803,48 @@ function test_ocp_control()
         end
 
         # ====================================================================
+        # Multiple simultaneous constraints (tuples)
+        # ====================================================================
+
+        Test.@testset "Constrained: tuple of constraints ≡ combined vector (both modes)" begin
+            # A tuple (g₁,g₂)/(μ₁,μ₂) must give the same flow as a single vector-valued
+            # constraint/multiplier — the combined carrier just concatenates.
+            law = Data.DynClosedLoop((x, p) -> p[2])
+            t0, tf, x0, p0 = 0.0, 1.0, [1.0, 2.0], [0.5, 0.5]
+            g1(x, u) = x[1]
+            g2(x, u) = x[2]
+            μ1(x, p) = 0.3
+            μ2(x, p) = 0.7
+            for ht in (:total, :partial)
+                f_tuple = Flows.Flow(
+                    OCP_DI, law; constraint=(g1, g2), multiplier=(μ1, μ2),
+                    hamiltonian_type=ht, _opts()...,
+                )
+                f_vec = Flows.Flow(
+                    OCP_DI, law; constraint=(x, u) -> [x[1], x[2]],
+                    multiplier=(x, p) -> [0.3, 0.7], hamiltonian_type=ht, _opts()...,
+                )
+                xt, pt = f_tuple(t0, x0, p0, tf)
+                xv, pv = f_vec(t0, x0, p0, tf)
+                Test.@test xt ≈ xv atol = ATOL
+                Test.@test pt ≈ pv atol = ATOL
+            end
+        end
+
+        Test.@testset "Constrained: tuple length mismatch / tuple-scalar mix rejected" begin
+            law = Data.DynClosedLoop((x, p) -> p[2])
+            # matched-length requirement: 2 constraints, 1 multiplier
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_DI, law; constraint=((x, u) -> x[1], (x, u) -> x[2]),
+                multiplier=((x, p) -> 0.3,), _opts()...,
+            )
+            # both-must-be-tuples: tuple constraint, scalar multiplier
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                OCP_DI, law; constraint=((x, u) -> x[1],), multiplier=(x, p) -> 0.3, _opts()...,
+            )
+        end
+
+        # ====================================================================
         # ERROR paths
         # ====================================================================
 

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -228,6 +228,69 @@ function test_ocp_control()
         end
 
         # ====================================================================
+        # CONVENIENCE — Flow(ocp, u::Function) ≡ explicit DynClosedLoop, and a raw
+        # function `constraint`/`multiplier` ≡ its wrapped MixedConstraint/Multiplier
+        # ====================================================================
+
+        Test.@testset "Convenience: Flow(ocp, u::Function) ≡ explicit DynClosedLoop" begin
+            # The convenience wraps `u` in a DynClosedLoop with the OCP's time/variable
+            # dependence, so it must reproduce the explicit law exactly.
+
+            # autonomous (x,p): inherits is_autonomous=true, is_variable=false
+            u = (x, p) -> p[2]
+            fconv = Flows.Flow(OCP_DI, u; _opts()...)
+            fexpl = Flows.Flow(OCP_DI, Data.DynClosedLoop(u); _opts()...)
+            Test.@test fconv isa Flows.OptimalControlFlow
+            t0, tf, x0, p0 = 0.0, 1.0, [-1.0, 0.0], [12.0, 6.0]
+            xc, pc = fconv(t0, x0, p0, tf)
+            xe, pe = fexpl(t0, x0, p0, tf)
+            Test.@test xc ≈ xe atol = 1e-10
+            Test.@test pc ≈ pe atol = 1e-10
+
+            # non-autonomous (t,x,p): inherits is_autonomous=false
+            un = (t, x, p) -> p * (1 + tan(t))
+            gconv = Flows.Flow(OCP_NA, un; _opts()...)
+            gexpl = Flows.Flow(OCP_NA, Data.DynClosedLoop(un; is_autonomous=false); _opts()...)
+            xc2, pc2 = gconv(0.0, 0.0, 1.0, π / 4)
+            xe2, pe2 = gexpl(0.0, 0.0, 1.0, π / 4)
+            Test.@test xc2 ≈ xe2 atol = 1e-10
+            Test.@test pc2 ≈ pe2 atol = 1e-10
+
+            # variable (x,p,v): inherits is_variable=true on the NonFixed OCP_VAR
+            uv = (x, p, v) -> p
+            hconv = Flows.Flow(OCP_VAR, uv; _opts()...)
+            hexpl = Flows.Flow(OCP_VAR, Data.DynClosedLoop(uv; is_variable=true); _opts()...)
+            xc3, pc3 = hconv(0.0, 1.0, 0.5, 1.0; variable=0.5)
+            xe3, pe3 = hexpl(0.0, 1.0, 0.5, 1.0; variable=0.5)
+            Test.@test xc3 ≈ xe3 atol = 1e-10
+            Test.@test pc3 ≈ pe3 atol = 1e-10
+        end
+
+        Test.@testset "Convenience: function control + function constraint/multiplier" begin
+            # all three conveniences (u, constraint, multiplier as raw functions) in one call
+            # equal the explicit DynClosedLoop + function constraint/multiplier form
+            u = (x, p) -> p
+            g = (x, u) -> x
+            μ = (x, p) -> 0.7
+            fconv = Flows.Flow(OCP_LQR, u; constraint=g, multiplier=μ, _opts()...)
+            fexpl = Flows.Flow(
+                OCP_LQR, Data.DynClosedLoop(u); constraint=g, multiplier=μ, _opts()...
+            )
+            t0, tf, x0, p0 = 0.0, 1.0, 1.0, 0.5
+            xc, pc = fconv(t0, x0, p0, tf)
+            xe, pe = fexpl(t0, x0, p0, tf)
+            Test.@test xc ≈ xe atol = 1e-10
+            Test.@test pc ≈ pe atol = 1e-10
+
+            # a raw function `constraint` resolves to a mixed-kind PathConstraint (the
+            # `MixedConstraint` constructor), a raw function `multiplier` to a Multiplier
+            resolved = Flows._resolve_constraint(OCP_LQR, g)
+            Test.@test resolved isa Data.PathConstraint
+            Test.@test Traits.is_mixed_constraint(resolved)
+            Test.@test Flows._resolve_multiplier(OCP_LQR, μ) isa Data.Multiplier
+        end
+
+        # ====================================================================
         # INTEGRATION — non-stationary law ⇒ :total ≠ :partial (mandatory)
         # ====================================================================
 

--- a/test/suite/integration/test_double_integrator_state.jl
+++ b/test/suite/integration/test_double_integrator_state.jl
@@ -1,0 +1,122 @@
+module TestDoubleIntegratorState
+
+using Test: Test
+import CTBase.Data
+import CTModels: CTModels
+import CTFlows.Flows
+import CTFlows.Trajectories
+using OrdinaryDiffEqTsit5
+using ForwardDiff: ForwardDiff
+using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# Double integrator, SECOND-ORDER state constraint q ≤ a (position).
+# x = (q, v), ẋ = [v, u], ℓ = 0.5 u², :min ; x0 = (0,1), xf = (0,-1).
+# Boundary-arc case a = 0.1: on the arc u ≡ 0 and μ ≡ 0; costate jumps at both junctions.
+# Ported from OptimalControl docs/src/example-state-constraint.md.
+
+const _T0 = 0.0
+const _TF = 1.0
+const _X0 = [0.0, 1.0]
+const _XF = [0.0, -1.0]
+
+function _build_di(a)
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=_T0, tf=_TF)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= [x[2], u[1]]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u[1]^2)
+    CTModels.Building.constraint!(
+        pre, :path;
+        f=(r, t, x, u, v) -> (r[1] = x[1]; nothing), lb=[-Inf], ub=[a], label=:q,
+    )
+    return CTModels.Building.build(pre)
+end
+
+function test_double_integrator_state()
+    Test.@testset "Double integrator — 2nd-order state constraint (:total/:partial)" verbose=VERBOSE showtiming=SHOWTIMING begin
+        a = 0.1
+        ocp = _build_di(a)
+        g(x) = a - x[1]   # constraint g(x) ≥ 0
+
+        # Analytic boundary-arc solution (see example-state-constraint.md):
+        #   t1 = 3a, t2 = 1-3a, p0 = [-200/9, -60/9], Δpq1 = Δpq2 = 200/9.
+        t1_sol = 3a
+        t2_sol = 1 - 3a
+        p0_sol = [-200 / 9, -60 / 9]
+        Δpq_sol = 200 / 9
+        ξ_sol = [p0_sol..., t1_sol, t2_sol, Δpq_sol, Δpq_sol]
+
+        function _build_flows(ht)
+            fs = Flows.Flow(ocp, (x, p) -> p[2]; hamiltonian_type=ht,
+                            alg=Tsit5(), reltol=1e-12, abstol=1e-12)
+            fc = Flows.Flow(ocp, (x, p) -> 0.0;
+                            constraint=(x, u) -> a - x[1], multiplier=(x, p) -> 0.0,
+                            hamiltonian_type=ht, alg=Tsit5(), reltol=1e-12, abstol=1e-12)
+            return fs, fc
+        end
+
+        function _make_shoot(fs, fc)
+            function shoot!(s, p0, t1, t2, Δpq1, Δpq2)
+                x1, p1 = fs(_T0, _X0, p0, t1)                 # arc 1: interior
+                p1p = [p1[1] + Δpq1, p1[2]]                   # costate jump at t1 (by hand)
+                x2, p2 = fc(t1, x1, p1p, t2)                  # arc 2: boundary
+                p2p = [p2[1] + Δpq2, p2[2]]                   # costate jump at t2 (by hand)
+                xf, _ = fs(t2, x2, p2p, _TF)                  # arc 3: interior
+                s[1:2] = xf - _XF                             # reach target
+                s[3] = g(x1)                                  # q(t1) = a
+                s[4] = x1[2]                                  # v(t1) = 0
+                s[5] = p1p[2]                                 # pv(t1+) = 0
+                s[6] = p1p[1]                                 # pq(t1+) = 0
+                return nothing
+            end
+            return shoot!
+        end
+
+        for ht in (:total, :partial)
+            fs, fc = _build_flows(ht)
+            shoot! = _make_shoot(fs, fc)
+
+            s = zeros(6)
+            shoot!(s, p0_sol, t1_sol, t2_sol, Δpq_sol, Δpq_sol)
+            res_known = sqrt(sum(abs2, s))
+            @info "DI order-2 [$ht] residual at analytic solution" res_known
+
+            ξ0 = [-22.0, -6.7, 0.28, 0.72, 22.0, 22.0]   # perturbed guess
+            shoot_nl!(s, ξ, _) = shoot!(s, ξ[1:2], ξ[3], ξ[4], ξ[5], ξ[6])
+            nl = solve(NonlinearProblem(shoot_nl!, ξ0), SimpleNewtonRaphson();
+                       abstol=1e-10, reltol=1e-10, show_trace=Val(false))
+            sc = zeros(6)
+            shoot!(sc, nl.u[1:2], nl.u[3], nl.u[4], nl.u[5], nl.u[6])
+            res_conv = sqrt(sum(abs2, sc))
+            @info "DI order-2 [$ht] Newton" res_conv t1=nl.u[3] t2=nl.u[4] Δpq1=nl.u[5] Δpq2=nl.u[6]
+
+            Test.@test res_known < 1e-6
+            Test.@test res_conv < 1e-8
+            Test.@test isapprox(nl.u[3], t1_sol; atol=1e-6)   # t1 ≈ 0.3
+            Test.@test isapprox(nl.u[4], t2_sol; atol=1e-6)   # t2 ≈ 0.7
+            Test.@test isapprox(nl.u[5], nl.u[6]; atol=1e-6)  # Δpq1 ≈ Δpq2
+
+            # Final reconstruction via `*` with costate jumps (vector added to costate).
+            # Multi-phase OCP flow → CTModels Solution with piecewise control.
+            φ = fs * (t1_sol, [Δpq_sol, 0.0], fc) * (t2_sol, [Δpq_sol, 0.0], fs)
+            sol = φ((_T0, _TF), _X0, p0_sol)
+            @info "DI order-2 [$ht] reconstruction" typeof(sol)
+            Test.@test sol isa CTModels.Solutions.Solution
+            uu = CTModels.control(sol)
+            _u(t) = uu(t) isa Number ? uu(t) : uu(t)[1]
+            # piecewise control: boundary arc [t1,t2] has u ≡ 0; interior arcs u = p₂ ≠ 0
+            Test.@test abs(_u(0.5 * (t1_sol + t2_sol))) < 1e-6      # boundary midpoint
+            Test.@test abs(_u(0.5 * t1_sol)) > 1e-3                 # interior arc 1
+            Test.@test CTModels.objective(sol) > 0                  # ∫0.5u² > 0
+        end
+    end
+end
+
+end # module
+
+test_double_integrator_state() = TestDoubleIntegratorState.test_double_integrator_state()

--- a/test/suite/integration/test_double_integrator_state.jl
+++ b/test/suite/integration/test_double_integrator_state.jl
@@ -1,3 +1,13 @@
+"""
+End-to-end integration test for the double-integrator OCP with a SECOND-ORDER state
+constraint (position `q ≤ a`), built from a `CTModels.Model`. Boundary-arc case (`a =
+0.1`): three-arc shooting with costate jumps at the two junctions (chained by hand, as
+jumps are not yet threaded through `Flow(ocp, law)`), run in both `:total` and `:partial`
+(order-2 on-arc equivalence, item i: constant boundary control). Ported from
+[example-state-constraint.md](../../../../OptimalControl/docs/src/example-state-constraint.md).
+Also exercises the `*` multi-phase reconstruction with jumps (PR 5 D3): a `CTModels.Solution`
+with piecewise reconstructed control.
+"""
 module TestDoubleIntegratorState
 
 using Test: Test
@@ -84,7 +94,6 @@ function test_double_integrator_state()
             s = zeros(6)
             shoot!(s, p0_sol, t1_sol, t2_sol, Δpq_sol, Δpq_sol)
             res_known = sqrt(sum(abs2, s))
-            @info "DI order-2 [$ht] residual at analytic solution" res_known
 
             ξ0 = [-22.0, -6.7, 0.28, 0.72, 22.0, 22.0]   # perturbed guess
             shoot_nl!(s, ξ, _) = shoot!(s, ξ[1:2], ξ[3], ξ[4], ξ[5], ξ[6])
@@ -93,7 +102,6 @@ function test_double_integrator_state()
             sc = zeros(6)
             shoot!(sc, nl.u[1:2], nl.u[3], nl.u[4], nl.u[5], nl.u[6])
             res_conv = sqrt(sum(abs2, sc))
-            @info "DI order-2 [$ht] Newton" res_conv t1=nl.u[3] t2=nl.u[4] Δpq1=nl.u[5] Δpq2=nl.u[6]
 
             Test.@test res_known < 1e-6
             Test.@test res_conv < 1e-8
@@ -105,7 +113,6 @@ function test_double_integrator_state()
             # Multi-phase OCP flow → CTModels Solution with piecewise control.
             φ = fs * (t1_sol, [Δpq_sol, 0.0], fc) * (t2_sol, [Δpq_sol, 0.0], fs)
             sol = φ((_T0, _TF), _X0, p0_sol)
-            @info "DI order-2 [$ht] reconstruction" typeof(sol)
             Test.@test sol isa CTModels.Solutions.Solution
             uu = CTModels.control(sol)
             _u(t) = uu(t) isa Number ? uu(t) : uu(t)[1]

--- a/test/suite/integration/test_double_integrator_time.jl
+++ b/test/suite/integration/test_double_integrator_time.jl
@@ -1,0 +1,133 @@
+"""
+End-to-end integration test for the double-integrator TIME-OPTIMAL problem (bang-bang, no
+state constraint): `ẋ1 = x2`, `ẋ2 = u`, `u ∈ [-1,1]`, `x(0) = (-1,0)`, `x(tf) = (0,0)`,
+minimise `tf`. Ported from
+[example-double-integrator-time.md](../../../../OptimalControl/docs/src/example-double-integrator-time.md).
+
+Two-phase bang-bang OCP flow (`u=+1` then `u=-1`, free final time, ONE switching time, NO
+jump). Purpose (PR 5 B3): exercise the D3 return-type / piecewise-control reconstruction
+with genuinely DIFFERENT laws per arc, independent of any constraint — the multi-phase `*`
+of two `OptimalControlFlow`s must return a `CTModels.Solution` whose reconstructed `u(t)`
+is `+1` then `-1`.
+"""
+module TestDoubleIntegratorTime
+
+using Test: Test
+import CTModels: CTModels
+import CTFlows.Flows
+using OrdinaryDiffEqTsit5
+using ForwardDiff: ForwardDiff
+using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const _T0 = 0.0
+const _X0 = [-1.0, 0.0]
+const _XF = [0.0, 0.0]
+const _UMAX = 1.0
+const _UMIN = -1.0
+
+function _build_di_time()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.time!(pre; t0=_T0, indf=1)   # free final time = variable[1]
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= [x[2], u[1]]; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> v[1])
+    return CTModels.Building.build(pre)
+end
+
+# pseudo-Hamiltonian H = p1 x2 + p2 u - 1 (normal case, sp0 = -1); u = sign(p2)
+_H(x, p, u) = p[1] * x[2] + p[2] * u - 1
+
+function test_double_integrator_time()
+    Test.@testset "Double integrator — time-optimal bang-bang (:total/:partial)" verbose = VERBOSE showtiming = SHOWTIMING begin
+        ocp = _build_di_time()
+
+        # Closed form (PMP): ṗ1 = 0 ⇒ p1 ≡ 1 (normal case), ṗ2 = -p1 ⇒ p2(t) = 1 - t,
+        # switching at p2(t1) = 0 ⇒ t1 = 1. Phase 1 (u=+1): x2(t) = t, x1(t) = -1 + t²/2.
+        # Phase 2 (u=-1), symmetric return to the origin ⇒ tf = 2 t1 = 2.
+        p0_sol = [1.0, 1.0]
+        t1_sol = 1.0
+        tf_sol = 2.0
+
+        function _build_flows(ht)
+            fmax = Flows.Flow(
+                ocp,
+                (x, p, v) -> _UMAX;
+                hamiltonian_type=ht,
+                alg=Tsit5(),
+                reltol=1e-12,
+                abstol=1e-12,
+            )
+            fmin = Flows.Flow(
+                ocp,
+                (x, p, v) -> _UMIN;
+                hamiltonian_type=ht,
+                alg=Tsit5(),
+                reltol=1e-12,
+                abstol=1e-12,
+            )
+            return fmax, fmin
+        end
+
+        function _make_shoot(fmax, fmin)
+            function shoot!(s, p0, t1, tf)
+                x1, p1v = fmax(_T0, _X0, p0, t1; variable=tf)
+                xf, pf = fmin(t1, x1, p1v, tf; variable=tf)
+                s[1:2] = xf - _XF          # target conditions
+                s[3] = p1v[2]              # switching condition p2(t1) = 0
+                s[4] = _H(xf, pf, _UMIN)   # free final time transversality
+                return nothing
+            end
+            return shoot!
+        end
+
+        for ht in (:total, :partial)
+            fmax, fmin = _build_flows(ht)
+            shoot! = _make_shoot(fmax, fmin)
+
+            # Residual at the KNOWN (closed-form) solution
+            s = zeros(4)
+            shoot!(s, p0_sol, t1_sol, tf_sol)
+            res_known = sqrt(sum(abs2, s))
+
+            # Newton from a perturbed guess
+            ξ0 = [0.8, 0.8, 0.8, 1.8]
+            shoot_nl!(s, ξ, _) = shoot!(s, ξ[1:2], ξ[3], ξ[4])
+            prob = NonlinearProblem(shoot_nl!, ξ0)
+            nl = solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10, show_trace=Val(false))
+            sc = zeros(4)
+            shoot!(sc, nl.u[1:2], nl.u[3], nl.u[4])
+            res_conv = sqrt(sum(abs2, sc))
+
+            # A bang-bang control is constant on each arc, so ∂H̃/∂u ≡ 0 trivially on-arc:
+            # :total and :partial coincide everywhere here — assert strictly for both.
+            Test.@test res_known < 1e-10
+            Test.@test res_conv < 1e-8
+            Test.@test isapprox(nl.u[1:2], p0_sol; atol=1e-6)
+            Test.@test isapprox(nl.u[3], t1_sol; atol=1e-6)
+            Test.@test isapprox(nl.u[4], tf_sol; atol=1e-6)
+
+            if ht === :total
+                Test.@testset "MultiPhase reconstruction: fmax*(t1,fmin) → Solution, piecewise u" begin
+                    φ = fmax * (t1_sol, fmin)
+                    sol = φ((_T0, tf_sol), _X0, p0_sol; variable=tf_sol)
+                    Test.@test sol isa CTModels.Solutions.Solution
+                    uu = CTModels.control(sol)
+                    _u(t) = uu(t) isa Number ? uu(t) : uu(t)[1]
+                    Test.@test _u(0.5 * t1_sol) ≈ _UMAX atol = 1e-6                    # phase 1
+                    Test.@test _u(t1_sol + 0.5 * (tf_sol - t1_sol)) ≈ _UMIN atol = 1e-6 # phase 2
+                    Test.@test CTModels.objective(sol) ≈ tf_sol atol = 1e-3            # tf → min
+                end
+            end
+        end
+    end
+end
+
+end # module
+
+test_double_integrator_time() = TestDoubleIntegratorTime.test_double_integrator_time()

--- a/test/suite/integration/test_goddard_ocp.jl
+++ b/test/suite/integration/test_goddard_ocp.jl
@@ -1,3 +1,13 @@
+"""
+End-to-end integration test for the Goddard optimal control problem, built from a
+`CTModels.Model` (not the hand-built Hamiltonian of `test_goddard.jl`): four arcs
+(boundary-departure, singular, velocity-boundary, off) rebuilt via `Flow(ocp, law)` and
+`Flow(ocp, law; constraint, multiplier)`, and a 7-unknown multi-phase shooting run in both
+`:total` and `:partial` — the hardest end-to-end witness that they converge to the same
+known solution (`on-arc :total ≡ :partial`, see the constrained-flows design note). Also
+exercises the `*` multi-phase reconstruction (a `CTModels.Solution`, PR 5 D3) and the
+1-tuple constraint/multiplier convenience (PR 5 D1) on this problem.
+"""
 module TestGoddardOCP
 
 using Test: Test
@@ -138,7 +148,6 @@ function test_goddard_ocp()
             s = zeros(7)
             shoot!(s, p0_sol, t1_sol, t2_sol, t3_sol, tf_sol)
             res_known = sqrt(sum(abs2, s))
-            @info "Goddard OCP [$ht] residual at known solution" res_known
 
             # Newton from the known solution's neighbourhood
             ξ0 = [3.94, 0.15, 0.05, 0.02, 0.05, 0.10, 0.20]
@@ -149,7 +158,6 @@ function test_goddard_ocp()
             shoot!(sc, nl.u[1:3], nl.u[4], nl.u[5], nl.u[6], nl.u[7])
             res_conv = sqrt(sum(abs2, sc))
             dist_sol = sqrt(sum(abs2, nl.u .- ξ_sol))
-            @info "Goddard OCP [$ht] Newton" res_conv dist_sol ξ=nl.u
 
             # On every Goddard arc the frozen-control :partial dynamics coincides with
             # :total: bang arcs have constant u; on the singular and boundary arcs
@@ -159,6 +167,44 @@ function test_goddard_ocp()
             Test.@test res_known < 1e-5
             Test.@test res_conv < 1e-7
             Test.@test dist_sol < 1e-6
+
+            # Reference arc-by-arc chain at the known solution (same chain as shoot!,
+            # exposed here to cross-check the `*` multi-phase reconstruction below).
+            x1r, p1r = φ1(_GODD_t0, _GODD_x0, p0_sol, t1_sol; variable=tf_sol)
+            x2r, p2r = φs(t1_sol, x1r, p1r, t2_sol; variable=tf_sol)
+            x3r, p3r = φb(t2_sol, x2r, p2r, t3_sol; variable=tf_sol)
+            xfr, pfr = φ0(t3_sol, x3r, p3r, tf_sol; variable=tf_sol)
+
+            if ht === :total
+                Test.@testset "MultiPhase reconstruction: φ1*(t1,φs)*(t2,φb)*(t3,φ0) → Solution" begin
+                    φ = φ1 * (t1_sol, φs) * (t2_sol, φb) * (t3_sol, φ0)
+
+                    # point eval: reproduces the hand-chained arcs, right dimensions (ℝ³)
+                    # (Hamiltonian dynamics returns the flat concatenation [x; p], not a
+                    # (x, p) tuple — see MultiPhase._format_final_output)
+                    res = φ(_GODD_t0, _GODD_x0, p0_sol, tf_sol; variable=tf_sol)
+                    xf_multi, pf_multi = res[1:3], res[4:6]
+                    Test.@test length(xf_multi) == 3
+                    Test.@test length(pf_multi) == 3
+                    Test.@test xf_multi ≈ xfr atol = 1e-8
+                    Test.@test pf_multi ≈ pfr atol = 1e-8
+
+                    # trajectory: same return type as a single-phase OCP flow
+                    sol = φ((_GODD_t0, tf_sol), _GODD_x0, p0_sol; variable=tf_sol)
+                    Test.@test sol isa CTModels.Solutions.Solution
+                    Test.@test CTModels.state(sol)(tf_sol) ≈ xfr atol = 1e-3
+                    Test.@test CTModels.costate(sol)(tf_sol) ≈ pfr atol = 1e-3
+                end
+
+                Test.@testset "1-tuple constraint/multiplier ≡ scalar form (boundary arc)" begin
+                    φb_tuple = Flows.Flow(
+                        ocp, ublaw; constraint=(gc,), multiplier=(μc,), hamiltonian_type=ht
+                    )
+                    x3t, p3t = φb_tuple(t2_sol, x2r, p2r, t3_sol; variable=tf_sol)
+                    Test.@test x3t ≈ x3r atol = 1e-10
+                    Test.@test p3t ≈ p3r atol = 1e-10
+                end
+            end
         end
     end
 end

--- a/test/suite/integration/test_goddard_ocp.jl
+++ b/test/suite/integration/test_goddard_ocp.jl
@@ -1,0 +1,168 @@
+module TestGoddardOCP
+
+using Test: Test
+import CTBase.Data
+import CTBase.Traits
+import CTLie: CTLie
+import CTModels: CTModels
+import CTFlows.Flows
+import CTFlows.Trajectories
+using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff
+using OrdinaryDiffEqTsit5
+using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
+
+import CTBase: CTBase # For generated code by the @Lie macro (CTBase.Traits.*)
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# ==============================================================================
+# Goddard constants + dynamics (module-level), same as test_goddard.jl
+# ==============================================================================
+
+const _GODD_t0 = 0.0
+const _GODD_r0 = 1.0
+const _GODD_v0 = 0.0
+const _GODD_m0 = 1.0
+const _GODD_vmax = 0.1
+const _GODD_mf = 0.6
+const _GODD_x0 = [_GODD_r0, _GODD_v0, _GODD_m0]
+const _GODD_Cd = 310
+const _GODD_Tmax = 3.5
+const _GODD_β = 500
+const _GODD_b = 2
+
+function _godd_F0(x)
+    r, v, m = x
+    D = _GODD_Cd * v^2 * exp(-_GODD_β * (r - 1))
+    return [v, -D / m - 1 / r^2, 0]
+end
+
+function _godd_F1(x)
+    r, v, m = x
+    return [0, _GODD_Tmax / m, -_GODD_b * _GODD_Tmax]
+end
+
+# Goddard OCP: ẋ = F0(x) + u F1(x), free tf (variable), path constraint v ≤ vmax.
+# Mayer-only objective (irrelevant to the pseudo-Hamiltonian flow: no Lagrange term).
+function _build_goddard_ocp()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.state!(pre, 3)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.time!(pre; t0=_GODD_t0, indf=1)   # free final time = variable[1]
+    CTModels.Building.dynamics!(
+        pre, (r, t, x, u, v) -> (r .= _godd_F0(x) .+ u[1] .* _godd_F1(x); nothing)
+    )
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> -xf[3])
+    CTModels.Building.constraint!(
+        pre,
+        :path;
+        f=(r, t, x, u, v) -> (r[1] = x[2]; nothing),
+        lb=[-Inf],
+        ub=[_GODD_vmax],
+        label=:vmax,
+    )
+    return CTModels.Building.build(pre)
+end
+
+# ==============================================================================
+# Test
+# ==============================================================================
+
+function test_goddard_ocp()
+    Test.@testset "Goddard OCP-built flows — :total / :partial" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # Lie brackets / controls / multiplier (same as test_goddard.jl)
+        H0 = CTLie.Lift(_godd_F0)
+        H1 = CTLie.Lift(_godd_F1)
+        H01 = CTLie.@Lie {H0, H1}
+        H001 = CTLie.@Lie {H0, H01}
+        H101 = CTLie.@Lie {H1, H01}
+
+        us(x, p) = -H001(x, p) / H101(x, p)
+        g(x) = _GODD_vmax - x[2]
+        ub(x) = -CTLie.ad(_godd_F0, g)(x) / CTLie.ad(_godd_F1, g)(x)
+        μ(x, p) = H01(x, p) / (CTLie.ad(_godd_F1, g)(x))
+
+        # Known solution
+        p0_sol = [3.945764658689699, 0.15039559623166285, 0.05371271293970429]
+        t1_sol = 0.023509684041887746
+        t2_sol = 0.05973738089985649
+        t3_sol = 0.10157134842431054
+        tf_sol = 0.2020474405709961
+
+        ocp = _build_goddard_ocp()
+
+        # Control laws as (x,p,v) feedbacks; constraint (x,u,v); multiplier (x,p,v).
+        u0law(x, p, v) = 0.0
+        u1law(x, p, v) = 1.0
+        uslaw(x, p, v) = us(x, p)
+        ublaw(x, p, v) = ub(x)
+        gc(x, u, v) = _GODD_vmax - x[2]     # function ⇒ MixedConstraint (∂g/∂u = 0)
+        μc(x, p, v) = μ(x, p)
+
+        function _build_flows(ht)
+            φ0 = Flows.Flow(ocp, u0law; hamiltonian_type=ht)
+            φ1 = Flows.Flow(ocp, u1law; hamiltonian_type=ht)
+            φs = Flows.Flow(ocp, uslaw; hamiltonian_type=ht)
+            φb = Flows.Flow(ocp, ublaw; constraint=gc, multiplier=μc, hamiltonian_type=ht)
+            return φ0, φ1, φs, φb
+        end
+
+        function _make_shoot(φ0, φ1, φs, φb)
+            function shoot!(s, p0, t1, t2, t3, tf)
+                x1, p1 = φ1(_GODD_t0, _GODD_x0, p0, t1; variable=tf)
+                x2, p2 = φs(t1, x1, p1, t2; variable=tf)
+                x3, p3 = φb(t2, x2, p2, t3; variable=tf)
+                xf, pf = φ0(t3, x3, p3, tf; variable=tf)
+                s[1] = xf[3] - _GODD_mf
+                s[2:3] = pf[1:2] - [1, 0]
+                s[4] = H1(x1, p1)
+                s[5] = H01(x1, p1)
+                s[6] = g(x2)
+                s[7] = H0(xf, pf)
+                return nothing
+            end
+            return shoot!
+        end
+
+        ξ_sol = [p0_sol..., t1_sol, t2_sol, t3_sol, tf_sol]
+
+        for ht in (:total, :partial)
+            φ0, φ1, φs, φb = _build_flows(ht)
+            shoot! = _make_shoot(φ0, φ1, φs, φb)
+
+            # Residual at the KNOWN solution
+            s = zeros(7)
+            shoot!(s, p0_sol, t1_sol, t2_sol, t3_sol, tf_sol)
+            res_known = sqrt(sum(abs2, s))
+            @info "Goddard OCP [$ht] residual at known solution" res_known
+
+            # Newton from the known solution's neighbourhood
+            ξ0 = [3.94, 0.15, 0.05, 0.02, 0.05, 0.10, 0.20]
+            shoot_nl!(s, ξ, _) = shoot!(s, ξ[1:3], ξ[4], ξ[5], ξ[6], ξ[7])
+            prob = NonlinearProblem(shoot_nl!, ξ0)
+            nl = solve(prob, SimpleNewtonRaphson(); abstol=1e-10, reltol=1e-10, show_trace=Val(false))
+            sc = zeros(7)
+            shoot!(sc, nl.u[1:3], nl.u[4], nl.u[5], nl.u[6], nl.u[7])
+            res_conv = sqrt(sum(abs2, sc))
+            dist_sol = sqrt(sum(abs2, nl.u .- ξ_sol))
+            @info "Goddard OCP [$ht] Newton" res_conv dist_sol ξ=nl.u
+
+            # On every Goddard arc the frozen-control :partial dynamics coincides with
+            # :total: bang arcs have constant u; on the singular and boundary arcs
+            # ∂H̃/∂u = H1 = 0 (PMP stationarity of the augmented Hamiltonian, ∂g/∂u = 0
+            # for the state constraint); and g ≡ 0 on the boundary arc freezes μ soundly.
+            # So both modes hit the same known solution — assert strictly for both.
+            Test.@test res_known < 1e-5
+            Test.@test res_conv < 1e-7
+            Test.@test dist_sol < 1e-6
+        end
+    end
+end
+
+end # module
+
+test_goddard_ocp() = TestGoddardOCP.test_goddard_ocp()

--- a/test/suite/multiphase/test_controlled_concatenation.jl
+++ b/test/suite/multiphase/test_controlled_concatenation.jl
@@ -1,0 +1,138 @@
+"""
+Integration tests for the concatenation (`*`) of controlled (state) flows: a multi-phase
+`ControlledFlow` must return the SAME type a single-phase controlled flow returns — a
+`ControlledTrajectory` with a PIECEWISE control reconstructed from the per-phase laws
+(and, for OCP-built phases, the objective recomputed over the merged trajectory).
+"""
+
+module TestControlledConcatenation
+
+using Test: Test
+import CTBase.Data: Data
+import CTBase.Exceptions: Exceptions
+import CTModels: CTModels
+import CTFlows.Flows: Flows
+import CTFlows.Trajectories: Trajectories
+import CTFlows.MultiPhase: MultiPhase
+using OrdinaryDiffEqTsit5: Tsit5
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+_opts() = (; alg=Tsit5(), reltol=1e-12, abstol=1e-12)
+
+# ẋ = -x + u, ℓ = 0.5u², :min  (autonomous, fixed, 1-D — scalar convention)
+function _build_ocp()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = (-x + u); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+const OCP = _build_ocp()
+
+function test_controlled_concatenation()
+    Test.@testset "Controlled flow concatenation" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ── ClosedLoop, two phases from the same OCP ─────────────────────────
+        # Phase 1 [0,0.5]: u = -x ⇒ ẋ = -2x ⇒ x = x0 e^{-2t}
+        # Phase 2 [0.5,1]: u =  0 ⇒ ẋ = -x  ⇒ x = x(0.5) e^{-(t-0.5)}
+
+        Test.@testset "ClosedLoop OCP: piecewise control + objective" begin
+            f1 = Flows.Flow(OCP, Data.ClosedLoop(x -> -x); _opts()...)
+            f2 = Flows.Flow(OCP, Data.ClosedLoop(x -> 0.0); _opts()...)
+            Test.@test f1 isa Flows.ControlledFlow
+            φ = f1 * (0.5, f2)
+
+            x0 = 1.0
+            x_half = x0 * exp(-2 * 0.5)
+
+            # point-eval: no costate, returns the final state (exact — no interpolation)
+            xf = φ(0.0, x0, 1.0)
+            Test.@test xf isa Number
+            Test.@test xf ≈ x_half * exp(-(1.0 - 0.5)) atol = 1e-8
+
+            # trajectory: same type as a single-phase controlled flow
+            sol = φ((0.0, 1.0), x0)
+            Test.@test sol isa Trajectories.ControlledTrajectory
+            x = Trajectories.state(sol)
+            u = Trajectories.control(sol)
+
+            # state continuity across the switch (merged trajectory interpolates linearly —
+            # the SciML merge builds a `dense=false` solution — hence a loose tolerance)
+            Test.@test x(0.25) ≈ x0 * exp(-2 * 0.25) atol = 1e-3
+            Test.@test x(0.75) ≈ x_half * exp(-(0.75 - 0.5)) atol = 1e-3
+
+            # piecewise control: phase 1 has u = -x, phase 2 has u ≡ 0
+            Test.@test u(0.25) ≈ -x0 * exp(-2 * 0.25) atol = 1e-3
+            Test.@test abs(u(0.75)) < 1e-8
+
+            # objective = ∫_0^0.5 0.5 u² dt with u = -x = x0 e^{-2t} (phase 2 contributes 0)
+            #           = 0.5 x0² (1 - e^{-2}) / 4
+            Test.@test Trajectories.objective(sol) ≈ 0.5 * x0^2 * (1 - exp(-2)) / 4 atol = 1e-3
+        end
+
+        # ── OpenLoop, two phases (piecewise-constant control) ────────────────
+        # Phase 1 [0,0.5]: u = 1 ⇒ ẋ = -x + 1
+        # Phase 2 [0.5,1]: u = 2 ⇒ ẋ = -x + 2
+
+        Test.@testset "OpenLoop OCP: piecewise-constant control" begin
+            f1 = Flows.Flow(OCP, Data.OpenLoop(() -> 1.0); _opts()...)
+            f2 = Flows.Flow(OCP, Data.OpenLoop(() -> 2.0); _opts()...)
+            φ = f1 * (0.5, f2)
+            sol = φ((0.0, 1.0), 0.0)
+            Test.@test sol isa Trajectories.ControlledTrajectory
+            u = Trajectories.control(sol)
+            Test.@test u(0.25) ≈ 1.0 atol = 1e-8
+            Test.@test u(0.75) ≈ 2.0 atol = 1e-8
+        end
+
+        # ── state jump between phases (additive on the state) ────────────────
+        # A scalar jump keeps the 1-D scalar convention through the point path.
+
+        Test.@testset "ClosedLoop with a state jump" begin
+            f1 = Flows.Flow(OCP, Data.ClosedLoop(x -> -x); _opts()...)
+            f2 = Flows.Flow(OCP, Data.ClosedLoop(x -> -x); _opts()...)
+            x0 = 1.0
+            Δ = 0.3
+            # point-eval reference with the additive jump applied by hand
+            x_half = x0 * exp(-2 * 0.5)
+            xf_ref = (x_half + Δ) * exp(-2 * (1.0 - 0.5))
+            φ = f1 * (0.5, Δ, f2)
+            Test.@test φ(0.0, x0, 1.0) ≈ xf_ref atol = 1e-6
+            sol = φ((0.0, 1.0), x0)
+            Test.@test sol isa Trajectories.ControlledTrajectory
+        end
+
+        # ── Flow(fc, law) phases: no OCP ⇒ no objective (2-D, vector-safe) ────
+
+        Test.@testset "Flow(fc, law) concatenation: no objective" begin
+            fc = Data.ControlledVectorField((x, u) -> -x .+ u)
+            f1 = Flows.Flow(fc, Data.ClosedLoop(x -> -x); _opts()...)
+            f2 = Flows.Flow(fc, Data.ClosedLoop(x -> zero(x)); _opts()...)
+            φ = f1 * (0.5, f2)
+            sol = φ((0.0, 1.0), [1.0, 2.0])
+            Test.@test sol isa Trajectories.ControlledTrajectory
+            # no OCP ⇒ objective getter errors clearly
+            Test.@test_throws Exceptions.PreconditionError Trajectories.objective(sol)
+        end
+
+        # ── different OCP objects ⇒ reconstruction rejects ───────────────────
+
+        Test.@testset "Error: phases from different OCPs" begin
+            ocp2 = _build_ocp()   # structurally identical, distinct object
+            f1 = Flows.Flow(OCP, Data.ClosedLoop(x -> -x); _opts()...)
+            f2 = Flows.Flow(ocp2, Data.ClosedLoop(x -> 0.0); _opts()...)
+            φ = f1 * (0.5, f2)
+            Test.@test_throws Exceptions.IncorrectArgument φ((0.0, 1.0), 1.0)
+        end
+    end
+end
+
+end # module
+
+test_controlled_concatenation() = TestControlledConcatenation.test_controlled_concatenation()

--- a/test/suite/multiphase/test_ocp_concatenation.jl
+++ b/test/suite/multiphase/test_ocp_concatenation.jl
@@ -1,0 +1,146 @@
+"""
+Integration tests for the concatenation (`*`) of OCP Hamiltonian flows (`DynClosedLoop`
+laws): a multi-phase `OptimalControlFlow` must return the SAME type a single-phase OCP flow
+returns — a `CTModels.Solution` with a PIECEWISE control reconstructed from the per-phase
+laws.
+
+The core property exercised here is *split invariance*: cutting a flow at an interior time
+with the SAME law and no jump reproduces the single-phase flow (state, costate, control and
+objective all agree). Complementary testsets cover a genuinely piecewise control (two laws),
+a costate jump between phases, and the same-OCP requirement.
+"""
+
+module TestOCPConcatenation
+
+using Test: Test
+import CTBase.Data: Data
+import CTBase.Exceptions: Exceptions
+import CTModels: CTModels
+import CTFlows.Flows: Flows
+import CTFlows.Trajectories: Trajectories
+import CTFlows.MultiPhase: MultiPhase
+using OrdinaryDiffEqTsit5: Tsit5
+using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+_opts() = (; alg=Tsit5(), reltol=1e-12, abstol=1e-12)
+
+# scalar helper (control may come back as a Number or a 1-vector)
+_uval(u, t) = (val = u(t); val isa Number ? val : val[1])
+
+# LQR: ẋ = -x + u, ℓ = 0.5u², :min (1-D). With DynClosedLoop u(x,p) = p the maximized flow
+# is p(t) = p0 eᵗ and x(t) = (x0 - p0/2)e⁻ᵗ + (p0/2)eᵗ.
+function _build_lqr()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r[1] = (-x + u); nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u^2)
+    return CTModels.Building.build(pre)
+end
+
+const OCP = _build_lqr()
+
+function test_ocp_concatenation()
+    Test.@testset "OCP flow concatenation" verbose=VERBOSE showtiming=SHOWTIMING begin
+        x0, p0, t0, tf, ts = 1.0, 0.5, 0.0, 1.0, 0.5
+
+        # ── split invariance: split a flow at ts with the same law ⇒ single flow ──
+
+        for ht in (:total, :partial)
+            Test.@testset "split invariance [$ht]" begin
+                law = Data.DynClosedLoop((x, p) -> p)
+                f = Flows.Flow(OCP, law; hamiltonian_type=ht, _opts()...)
+                Test.@test f isa Flows.OptimalControlFlow
+                φ = f * (ts, f)   # split at ts, same law, no jump
+
+                # point-eval: the multi-phase result (vector [x; p]) reproduces the single
+                # flow (tuple (x, p)), and matches the analytic solution
+                xf, pf = f(t0, x0, p0, tf)
+                res = φ(t0, x0, p0, tf)
+                Test.@test res[1] ≈ xf atol = 1e-8
+                Test.@test res[end] ≈ pf atol = 1e-8
+                Test.@test pf ≈ p0 * exp(tf) atol = 1e-6
+                Test.@test xf ≈ (x0 - p0 / 2) * exp(-tf) + (p0 / 2) * exp(tf) atol = 1e-6
+
+                # trajectory: same type as a single-phase OCP flow, agreeing with it
+                sol = φ((t0, tf), x0, p0)
+                sol1 = f((t0, tf), x0, p0)
+                Test.@test sol isa CTModels.Solutions.Solution
+                xs, ps, us = CTModels.state(sol), CTModels.costate(sol), CTModels.control(sol)
+                xs1, ps1, us1 = CTModels.state(sol1),
+                CTModels.costate(sol1), CTModels.control(sol1)
+                # merged trajectory interpolates linearly (SciML merge is `dense=false`)
+                for t in (0.2, 0.5, 0.8)
+                    Test.@test xs(t) ≈ xs1(t) atol = 1e-3
+                    Test.@test ps(t) ≈ ps1(t) atol = 1e-3
+                    Test.@test _uval(us, t) ≈ _uval(us1, t) atol = 1e-3
+                end
+                Test.@test CTModels.objective(sol) ≈ CTModels.objective(sol1) atol = 1e-3
+                # objective = ∫₀¹ 0.5 p² dt = 0.25 p0² (e^{2tf} - 1)
+                Test.@test CTModels.objective(sol) ≈ 0.25 * p0^2 * (exp(2tf) - 1) atol = 1e-3
+            end
+        end
+
+        # ── genuinely piecewise control: phase 1 law u = p, phase 2 law u = 0 ─────
+
+        Test.@testset "piecewise control (two laws)" begin
+            f1 = Flows.Flow(
+                OCP, Data.DynClosedLoop((x, p) -> p); hamiltonian_type=:total, _opts()...
+            )
+            f2 = Flows.Flow(
+                OCP, Data.DynClosedLoop((x, p) -> 0.0); hamiltonian_type=:total, _opts()...
+            )
+            φ = f1 * (ts, f2)
+            sol = φ((t0, tf), x0, p0)
+            Test.@test sol isa CTModels.Solutions.Solution
+            u = CTModels.control(sol)
+            Test.@test abs(_uval(u, 0.75)) < 1e-8   # phase 2: u ≡ 0
+            Test.@test abs(_uval(u, 0.25)) > 1e-3   # phase 1: u = p ≠ 0
+        end
+
+        # ── costate jump between phases (additive on the costate) ────────────────
+        # A scalar jump keeps the 1-D scalar convention (state/costate stay scalars through
+        # the point path); the trajectory endpoint is exact (not interpolated).
+
+        Test.@testset "costate jump" begin
+            law = Data.DynClosedLoop((x, p) -> p)
+            f = Flows.Flow(OCP, law; hamiltonian_type=:total, _opts()...)
+            Δp = 0.4
+            # by-hand reference across the two arcs with the jump on the costate
+            p1 = p0 * exp(ts)
+            x1 = (x0 - p0 / 2) * exp(-ts) + (p0 / 2) * exp(ts)
+            p1p = p1 + Δp
+            dt = tf - ts
+            p_ref = p1p * exp(dt)
+            x_ref = (x1 - p1p / 2) * exp(-dt) + (p1p / 2) * exp(dt)
+            φ = f * (ts, Δp, f)
+            res = φ(t0, x0, p0, tf)
+            Test.@test res[1] ≈ x_ref atol = 1e-6
+            Test.@test res[end] ≈ p_ref atol = 1e-6
+            sol = φ((t0, tf), x0, p0)
+            Test.@test sol isa CTModels.Solutions.Solution
+            Test.@test _uval(CTModels.state(sol), tf) ≈ x_ref atol = 1e-6
+            Test.@test _uval(CTModels.costate(sol), tf) ≈ p_ref atol = 1e-6
+        end
+
+        # ── different OCP objects ⇒ reconstruction rejects ───────────────────────
+
+        Test.@testset "Error: phases from different OCPs" begin
+            ocp2 = _build_lqr()   # structurally identical, distinct object
+            law = Data.DynClosedLoop((x, p) -> p)
+            f1 = Flows.Flow(OCP, law; hamiltonian_type=:total, _opts()...)
+            f2 = Flows.Flow(ocp2, law; hamiltonian_type=:total, _opts()...)
+            φ = f1 * (ts, f2)
+            Test.@test_throws Exceptions.IncorrectArgument φ((t0, tf), x0, p0)
+        end
+    end
+end
+
+end # module
+
+test_ocp_concatenation() = TestOCPConcatenation.test_ocp_concatenation()

--- a/test/suite/trajectories/test_trajectories_module.jl
+++ b/test/suite/trajectories/test_trajectories_module.jl
@@ -33,7 +33,9 @@ const EXPORTED_ABSTRACT_TYPES = (
 
 const EXPORTED_CONCRETE_TYPES = (:VectorFieldTrajectory, :HamiltonianVectorFieldTrajectory)
 
-const EXPORTED_FUNCTIONS = (:state, :time_grid, :costate, :build_trajectory, :plot)
+# `plot` is a `RecipesBase.plot` method (an extension overload), not exported — call it
+# qualified (`Trajectories.plot`) or via `Plots.plot`. See test_plots_extension.jl.
+const EXPORTED_FUNCTIONS = (:state, :time_grid, :costate, :build_trajectory)
 
 # Note: Solutions module has no private symbols (after filtering Julia internals)
 # All symbols are exported


### PR DESCRIPTION
**PR 5 of the constrained-flows & duals roadmap** (follows PR 3 `:total` #316 and PR 4 `:partial` #317). Version `0.12.0-beta → 0.13.0-beta`.

## Multiple simultaneous path constraints (tuples)
- `Flow(ocp, law; constraint=(g₁,g₂,…), multiplier=(μ₁,μ₂,…))` with matched-length tuples.
- Resolved via concatenating `_CombinedConstraint`/`_CombinedMultiplier` carriers, so the downstream `sum(μ·g)` computes `Σᵢ μᵢ·gᵢ` **unchanged** in both `:total` and `:partial` (the pseudo-Hamiltonian functors are untouched).
- A single vector-valued constraint (one `:path` label or one vector-returning function) with a vector multiplier already worked; tuples add combining **distinct** constraints.
- `_validate_constraint_pair` enforces both-or-neither and matched tuple lengths.

## Multiphase reconstruction — both axes, full fix
- `_evaluate_phase` dispatches on the **abstract dynamics axis** (`AbstractStateFlow`/`AbstractHamiltonianFlow`) + a `_raw_flow` unwrap, so `*`-concatenated `OptimalControlFlow`/`ControlledFlow` phases **evaluate** (previously `MethodError: no method matching _evaluate_phase(::OptimalControlFlow, …)`).
- A multi-phase **trajectory** of OCP-built flows rebuilds a **`CTModels.Solution`** with a piecewise control (`_PiecewiseControlLaw` + `_reconstruct_ocp_solution`), matching the single-phase return type.
- The symmetric **state-flow** case (`ControlledFlow` concatenation, `OpenLoop`/`ClosedLoop` laws) rebuilds a **`ControlledTrajectory`** with the same piecewise-control mechanism.
- Same OCP required across all phases in both cases (`_shared_ocp`, `IncorrectArgument` otherwise).

## Arity-checking for OCP convenience constructors
- `Flow(ocp, u::Function)` and raw-`Function` `constraint`/`multiplier` specs wrap the user's function with the OCP's own time/variable dependence. When the function has a single method (skipped if ambiguous — multiple dispatch or default args), a mismatched arity is now caught up front: one `IncorrectArgument` naming the real expected syntax for every mismatched item, plus a pointer to the explicit constructors (`DynClosedLoop`/`OpenLoop`/`ClosedLoop`, `MixedConstraint`/`StateConstraint`/`ControlConstraint`, `Multiplier`) as an escape hatch — instead of an opaque `MethodError` deep in AD/integration.

## Integration tests (Goddard order 1, double integrator orders 1 & 2)
- `test_goddard_ocp.jl` — four-arc OCP-built shooting (bang/singular/boundary/off), both `:total`/`:partial` converge to the same known solution (residual `< 1e-7`); `*`-reconstruction to a `Solution`; 1-tuple constraint/multiplier ≡ scalar form.
- `test_double_integrator_state.jl` (**order 2**) — second-order state constraint, three-arc shooting with costate jumps at both junctions, `*`-reconstruction with jumps, piecewise control (`u≡0` on the boundary arc).
- `test_double_integrator_time.jl` (**new, bang-bang time-optimal**) — two genuinely different laws per arc (`u=+1`/`u=-1`), no constraint, no jump: the sharpest test of the piecewise-control reconstruction on its own; closed form derived from the PMP transversality condition.
- `test_ocp_concatenation.jl` / `test_controlled_concatenation.jl` — split-invariance property, piecewise laws, state/costate jumps, cross-OCP rejection, on both the Hamiltonian and state-flow axes.

## NonFixed test matrix (Phase C)
- Completed the `{constraint} × {:total,:partial} × {variable, variable_costate}` matrix — the last untested cell (`:total` + constrained `variable_costate=true` at the flow-call level) is now covered, cross-checked against the same `∂/∂v[H̃+μ·g]` quadrature as its `:partial` counterpart.

## Docs
- New guide chapter **[Constrained flows](docs/src/flows/constrained.md)**: the `constraint`/`multiplier` API, the `g ≥ 0` sign convention (vs. Maurer's `c ≤ 0`, `η ≤ 0` — `g = -c`, `μ = -η`), multiple constraints, and the PMP symplectic-gradient decomposition `H'_c = ∂H/∂z + H₁·u_c' + c·η_c'` explaining *why* `:total` and `:partial` agree on a constrained arc — with two worked examples (Goddard order 1, double integrator order 2). Linked from `overview.md`, `optimal_control.md`, `control_laws.md`.
- Fixed a stale-anchor bug (`{#id}` kramdown syntax → proper Documenter `[Header](@id id)`) and removed a redundant `export plot` in `Trajectories` (re-exporting a foreign `RecipesBase` binding was dragging an unrelated `CTModels.Solution` docstring — with an unresolvable `@ref` in this package — into the generated API page). Docs now build with **zero** `@ref`/`@extref` warnings.
- CHANGELOG entry for the whole PR5 arc; version bumped `0.12.0-beta → 0.13.0-beta`.

## Verification
- Full suite green: **2419/2419** (Aqua included).
- Docs build verified locally: 0 errors, 0 warnings, both `@example` blocks in the new guide chapter execute and match the closed-form values used by the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
