### PR TITLE
Surface real status/successful from the integrator in OCP flow solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1-beta] - 2026-07-16
+
+### Added
+
+- **Real `status`/`successful` on flow-built `CTModels.Solution`s**: `_build_ocp_solution`
+  previously hard-coded `successful=true` and left `status` unset, discarding the actual ODE
+  termination info. It now delegates to `Integrators.status`/`Integrators.successful`
+  (requires CTSolvers v0.4.29-beta, which added these accessors to
+  `AbstractIntegrationResult`), so a degraded or forced-`unsafe=true` integration is reported
+  truthfully on the resulting `CTModels.Solution` — single-phase, control-free, and merged
+  multi-phase alike.
+- **`status`/`successful` delegation on all trajectory wrappers**: added to
+  `HamiltonianVectorFieldTrajectory`, `VectorFieldTrajectory`, and `ControlledTrajectory`
+  (via its inner state trajectory), matching the existing
+  `final_state`/`times`/`evaluate_at`/`merge` delegation already present on all three.
+
+### Changed
+
+- **`CTBase` compat bumped to `0.28`** (pulled in transitively by CTSolvers v0.4.29-beta).
+
 ## [0.13.0-beta] - 2026-07-11
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.13.0-beta"
+version = "0.13.1-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ CTFlowsStaticArrays = ["StaticArrays"]
 [compat]
 ADTypes = "1"
 Aqua = "0.8"
-CTBase = "0.27"
+CTBase = "0.28"
 CTLie = "0.1.1"
 CTModels = "0.15"
 CTSolvers = "0.4"

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -840,11 +840,9 @@ function _build_ocp_solution(
         v,
         p;
         objective=obj,
-        iterations=-1,
-        constraints_violation=-1.0,
         message="Solution computed by CTFlows OCP flow",
-        status=:nostatusmessage,
-        successful=true,
+        status=Integrators.status(sol),
+        successful=Integrators.successful(sol),
         control_interpolation=:linear,
     )
 end

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -35,6 +35,8 @@ using CTSolvers.Integrators:
     final_state,
     times,
     evaluate_at,
+    status,
+    successful,
     merge,
     build_integrator,
     options_point,
@@ -133,7 +135,7 @@ end
 # ==============================================================================
 
 export AbstractIntegrator, SciML
-export AbstractIntegrationResult, final_state, times, evaluate_at, merge
+export AbstractIntegrationResult, final_state, times, evaluate_at, status, successful, merge
 export build_integrator, options_point, options_trajectory
 export build_problem, build_options
 

--- a/src/Trajectories/controlled_trajectory.jl
+++ b/src/Trajectories/controlled_trajectory.jl
@@ -167,6 +167,22 @@ Integrators.final_state(sol::ControlledTrajectory) = Integrators.final_state(sol
 """
 $(TYPEDSIGNATURES)
 
+Return the termination status of a `ControlledTrajectory`, delegating to the underlying
+state trajectory.
+"""
+Integrators.status(sol::ControlledTrajectory) = Integrators.status(sol.traj)
+
+"""
+$(TYPEDSIGNATURES)
+
+Return whether a `ControlledTrajectory` terminated successfully, delegating to the
+underlying state trajectory.
+"""
+Integrators.successful(sol::ControlledTrajectory) = Integrators.successful(sol.traj)
+
+"""
+$(TYPEDSIGNATURES)
+
 Evaluate the state at time `t` (scalar for a 1-D state).
 """
 (sol::ControlledTrajectory)(t::Real) = sol.state_coerce(sol.traj(t))

--- a/src/Trajectories/hamiltonian_vector_field_trajectory.jl
+++ b/src/Trajectories/hamiltonian_vector_field_trajectory.jl
@@ -254,6 +254,40 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Return the termination status of the solution by delegating to the integration result.
+
+# Arguments
+- `sol::HamiltonianVectorFieldTrajectory`: The Hamiltonian vector field solution.
+
+# Returns
+- The termination status (a `Symbol`) from the integration result.
+
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.status`](@extref).
+"""
+function Integrators.status(sol::HamiltonianVectorFieldTrajectory)
+    return Integrators.status(sol.result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return whether the solution terminated successfully by delegating to the integration result.
+
+# Arguments
+- `sol::HamiltonianVectorFieldTrajectory`: The Hamiltonian vector field solution.
+
+# Returns
+- Whether the integration succeeded.
+
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.successful`](@extref).
+"""
+function Integrators.successful(sol::HamiltonianVectorFieldTrajectory)
+    return Integrators.successful(sol.result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Merge a sequence of HamiltonianVectorFieldTrajectory objects into a single HamiltonianVectorFieldTrajectory.
 
 This extracts the internal integration results, merges them, and wraps the result

--- a/src/Trajectories/vector_field_trajectory.jl
+++ b/src/Trajectories/vector_field_trajectory.jl
@@ -196,6 +196,40 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Return the termination status of the solution by delegating to the integration result.
+
+# Arguments
+- `sol::VectorFieldTrajectory`: The vector field solution.
+
+# Returns
+- The termination status (a `Symbol`) from the integration result.
+
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.status`](@extref).
+"""
+function Integrators.status(sol::VectorFieldTrajectory)
+    return Integrators.status(sol.result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return whether the solution terminated successfully by delegating to the integration result.
+
+# Arguments
+- `sol::VectorFieldTrajectory`: The vector field solution.
+
+# Returns
+- Whether the integration succeeded.
+
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.successful`](@extref).
+"""
+function Integrators.successful(sol::VectorFieldTrajectory)
+    return Integrators.successful(sol.result)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Merge a sequence of VectorFieldTrajectory objects into a single VectorFieldTrajectory.
 
 This extracts the internal integration results, merges them, and wraps the result

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -332,6 +332,8 @@ function test_optimal_control_flow()
             x0, p0 = 1.0, 0.5
             sol = OCF_AF_MAYER((t0, tf), x0, p0)
             Test.@test sol isa CTModels.Solutions.Solution
+            Test.@test CTModels.Solutions.successful(sol) == true
+            Test.@test CTModels.Solutions.status(sol) == :Success
         end
 
         Test.@testset "Integration: Mayer objective ≈ analytic" begin

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -327,6 +327,8 @@ function test_ocp_control()
             fp = Flows.Flow(OCP_DI, law; hamiltonian_type=:partial, _opts()...)
             solp = fp((t0, tf), x0, p0)
             Test.@test obj ≈ CTModels.objective(solp) atol = 1e-6
+            Test.@test CTModels.Solutions.successful(sol) == true
+            Test.@test CTModels.Solutions.status(sol) == :Success
         end
 
         # ====================================================================

--- a/test/suite/flows/test_state_control_flows.jl
+++ b/test/suite/flows/test_state_control_flows.jl
@@ -12,6 +12,7 @@ import CTBase.Exceptions: Exceptions
 import CTModels: CTModels
 import CTFlows.Flows: Flows
 import CTFlows.Trajectories: Trajectories
+import CTFlows.Integrators: Integrators
 using OrdinaryDiffEqTsit5: Tsit5
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -67,6 +68,8 @@ function test_state_control_flows()
             Test.@test u(0.5) ≈ -x0 * exp(-2 * 0.5) atol = 1e-6   # u = -x
             # objective ∫0.5u² = ∫0.5 x0² e^{-4t} = 0.5 x0² (1-e^{-4})/4
             Test.@test Trajectories.objective(sol) ≈ 0.5 * (1 - exp(-4)) / 4 atol = 1e-6
+            Test.@test Integrators.successful(sol) == true
+            Test.@test Integrators.status(sol) == :Success
         end
 
         # ── OpenLoop from an OCP: g(x) = -x + 1 ⇒ x(t) = 1 + (x0-1)e^{-t} ──────

--- a/test/suite/multiphase/test_ocp_concatenation.jl
+++ b/test/suite/multiphase/test_ocp_concatenation.jl
@@ -71,6 +71,8 @@ function test_ocp_concatenation()
                 sol = φ((t0, tf), x0, p0)
                 sol1 = f((t0, tf), x0, p0)
                 Test.@test sol isa CTModels.Solutions.Solution
+                Test.@test CTModels.Solutions.successful(sol) == true
+                Test.@test CTModels.Solutions.status(sol) == :Success
                 xs, ps, us = CTModels.state(sol),
                 CTModels.costate(sol),
                 CTModels.control(sol)

--- a/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
@@ -29,6 +29,8 @@ end
 
 Integrators.final_state(r::FakeHamiltonianResult) = r.final_u
 Integrators.times(r::FakeHamiltonianResult) = r.ts
+Integrators.status(r::FakeHamiltonianResult) = :Success
+Integrators.successful(r::FakeHamiltonianResult) = true
 function Integrators.evaluate_at(r::FakeHamiltonianResult, t::Real)
     idx = findfirst(≥(t), r.ts)
     if isnothing(idx)
@@ -140,6 +142,23 @@ function test_hamiltonian_vector_field_trajectory()
             x, p = Integrators.final_state(sol)
             Test.@test x == [1.0, 2.0]
             Test.@test p == [3.0, 4.0]
+        end
+
+        # ====================================================================
+        # UNIT TESTS - status and successful
+        # ====================================================================
+
+        Test.@testset "status and successful" begin
+            result = FakeHamiltonianResult(
+                [1.0, 2.0, 3.0, 4.0],
+                [0.0, 0.5, 1.0],
+                [[1, 2, 3, 4], [1.5, 2.5, 3.5, 4.5], [2, 3, 4, 5]],
+            )
+            x0 = [1.0, 2.0]  # initial state
+            sol = Trajectories.HamiltonianVectorFieldTrajectory(x0, result)
+
+            Test.@test Integrators.status(sol) == :Success
+            Test.@test Integrators.successful(sol) == true
         end
 
         # ====================================================================

--- a/test/suite/trajectories/test_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_vector_field_trajectory.jl
@@ -22,6 +22,8 @@ end
 
 Integrators.times(r::FakeIntegrationResult) = r.t
 Integrators.final_state(r::FakeIntegrationResult) = r.u[end]
+Integrators.status(r::FakeIntegrationResult) = :Success
+Integrators.successful(r::FakeIntegrationResult) = true
 function Integrators.evaluate_at(r::FakeIntegrationResult, t::Real)
     # Simple interpolation for testing
     return r.u[1]
@@ -90,6 +92,13 @@ function test_vector_field_trajectory()
                 tg = Trajectories.time_grid(sol)
                 ts = Integrators.times(sol)
                 Test.@test tg === ts  # Returns same object
+            end
+
+            Test.@testset "delegates status/successful to result" begin
+                result = FakeIntegrationResult([0.0, 0.5, 1.0], [[1.0], [0.5], [0.25]])
+                sol = Trajectories.VectorFieldTrajectory(result)
+                Test.@test Integrators.status(sol) == :Success
+                Test.@test Integrators.successful(sol) == true
             end
         end
 


### PR DESCRIPTION
## Summary
- `_build_ocp_solution` hard-coded `successful=true` and left `status` unset when assembling a `CTModels.Solution` from a flow integration, discarding the real ODE termination info. Now delegates to `Integrators.status(sol)`/`Integrators.successful(sol)`.
- Adds `status`/`successful` delegation to all three trajectory wrapper types that already delegate `final_state`/`times`/`evaluate_at`/`merge`: `HamiltonianVectorFieldTrajectory`, `VectorFieldTrajectory`, and `ControlledTrajectory` (via its inner `traj`) — for consistency, not just the one path needed for `_build_ocp_solution`.
- Fixes CTFlows' own `Integrators` re-export layer (`src/Integrators/Integrators.jl`), which explicitly lists the symbols it re-exports from `CTSolvers.Integrators` and did not yet include `status`/`successful`.
- Depends on CTSolvers v0.4.29-beta ([CTSolvers.jl#176](https://github.com/control-toolbox/CTSolvers.jl/pull/176), released), which added the `status`/`successful` contract methods on `AbstractIntegrationResult`. Bumps `CTBase` compat to `0.28` (pulled in transitively).

## Test plan
- [x] Unit tests (fakes) for the new delegation on `HamiltonianVectorFieldTrajectory`/`VectorFieldTrajectory`
- [x] Integration test for `ControlledTrajectory` (real SciML solve)
- [x] `CTModels.Solutions.successful`/`status` asserted across three `OptimalControlFlow` variants: control-free, control-law (single phase), and merged multi-phase (exercises CTSolvers' `merge` retcode-aggregation fix end to end)
- [x] Full suite green (2451/2451, including Aqua + alias-subtyping meta tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)