### PR TITLE
feat(flows): add method=:gpu selection + unify flow construction on ad_trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`method=:gpu` device selection on every `Flow(...)` constructor** (GPU roadmap-v4 §5,
+  phase 2): registers the now-parameterized `SciML{P}` (CTSolvers `v0.4.30-beta`) and
+  `DifferentiationInterface{P}` (CTBase `v0.28.1-beta`) strategies with `[CPU, GPU]`. A single
+  `method=:gpu` token resolves `GPU` for both the `:di` and `:sciml` families at once. Default
+  (no `method`) behaviour is byte-identical to before.
+
+### Changed
+
+- **Unified flow construction** onto one resolution mechanism keyed by `Traits.ad_trait`
+  (`WithAD` vs `WithoutAD`), retiring direct `build_integrator` use in favour of a shared
+  `_build_integrator` helper.
+- **BREAKING** — `Flow(vf; ad_backend=…)` on an **AD-free** flow is now rejected as an unknown
+  option instead of being silently ignored (the AD-free plan has no `:di` family).
+
 ## [0.14.0-beta] - 2026-07-17
 
 ### Added

--- a/ext/CTFlowsSciMLFlows/flow_constructors.jl
+++ b/ext/CTFlowsSciMLFlows/flow_constructors.jl
@@ -30,7 +30,7 @@ xf = flow(0.0, [1.0], 1.0; variable=2.0)
 """
 function Flows.Flow(f::SciMLBase.AbstractODEFunction; opts...)
     sys = SciMLFunctionSystem(f)
-    integ = Integrators.build_integrator(; opts...)
+    integ = Flows._build_integrator(opts)
     return build_flow(sys, integ)
 end
 
@@ -63,6 +63,6 @@ xf = Integrators.final_state(result)
 ```
 """
 function Flows.Flow(prob::SciMLBase.AbstractODEProblem; opts...)
-    integ = Integrators.build_integrator(; opts...)
+    integ = Flows._build_integrator(opts)
     return SciMLProblemFlow(prob, integ)
 end

--- a/src/Flows/Flows.jl
+++ b/src/Flows/Flows.jl
@@ -15,6 +15,7 @@ module Flows
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 import CTBase.Core
 import CTBase.Data
+import CTBase.Descriptions
 import CTBase.Differentiation
 import CTBase.Exceptions
 import CTBase.Strategies

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -11,7 +11,11 @@ This constructor builds a complete flow by:
 
 # Arguments
 - `data::CTBase.Data.VectorField`: The vector field defining the system dynamics.
-- `opts...`: Keyword options passed to the integrator's strategy.
+- `opts...`: Keyword options passed to the integrator's strategy. Pass `method=:gpu`
+  (a `Symbol`, or a token tuple) to build the flow for GPU execution — the integrator
+  resolves to `SciML{GPU}`; the default (`method=:cpu`) builds a CPU flow. The `method`
+  selector is accepted by **every** `Flow(...)` constructor and, for AD-dependent flows,
+  also selects the GPU AD backend.
 
 # Returns
 - `CTFlows.Flows.Flow`: The complete flow ready for integration.
@@ -28,8 +32,7 @@ See also: [`CTFlows.Flows.Flow`](@ref), [`CTFlows.Systems.build_system`](@ref), 
 """
 function Flow(data::Data.VectorField; opts...)
     system = Systems.build_system(data)
-    integrator = Integrators.build_integrator(; opts...)
-    return build_flow(system, integrator)
+    return build_flow(system, _build_integrator(opts))
 end
 
 """
@@ -62,8 +65,7 @@ See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_syste
 """
 function Flow(data::Data.HamiltonianVectorField; opts...)
     system = Systems.build_system(data)
-    integrator = Integrators.build_integrator(; opts...)
-    return build_flow(system, integrator)
+    return build_flow(system, _build_integrator(opts))
 end
 
 """
@@ -83,6 +85,9 @@ This constructor builds a complete Hamiltonian flow by:
   Options are automatically routed based on their names:
   - Backend options (e.g., `ad_backend`) → `:di` strategy
   - Integrator options (e.g., `reltol`, `abstol`, `alg`) → `:sciml` strategy
+  Pass `method=:gpu` to build the flow for GPU execution: the AD backend resolves to
+  `DifferentiationInterface{GPU}` (whose default backend is `AutoZygote`) and the integrator
+  to `SciML{GPU}`. The default (`method=:cpu`) keeps `AutoForwardDiff` + `SciML{CPU}`.
 
 # Returns
 - `CTFlows.Flows.HamiltonianFlow`: The complete Hamiltonian flow ready for integration.
@@ -111,8 +116,9 @@ See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Systems.build_syste
 [`CTFlows.Flows._route_flow_options`](@ref), [`CTFlows.Flows._build_flow_components`](@ref)
 """
 function Flow(h::Data.AbstractHamiltonian; kwargs...)
-    routed = _route_flow_options(kwargs)
-    components = _build_flow_components(routed)
+    method, kw = _pop_method(kwargs)
+    routed = _route_flow_options(Traits.WithAD, kw; method=method)
+    components = _build_flow_components(Traits.WithAD, routed; method=method)
     sys = Systems.build_system(h, components.backend)
     return build_flow(sys, components.integrator)
 end
@@ -164,8 +170,9 @@ See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), [`CTFlows.Flows.Flow`](@re
 """
 function _flow_from_ocp(::Type{Traits.ControlFree}, ocp::CTModels.Models.Model; kwargs...)
     _reject_control_free_constraint(kwargs)
-    routed = _route_flow_options(kwargs)
-    components = _build_flow_components(routed)
+    method, kw = _pop_method(kwargs)
+    routed = _route_flow_options(Traits.WithAD, kw; method=method)
+    components = _build_flow_components(Traits.WithAD, routed; method=method)
     h = _ocp_hamiltonian(ocp)
     sys = Systems.build_system(h, components.backend)
     inner = build_flow(sys, components.integrator)
@@ -278,8 +285,9 @@ function _flow_from_pseudo_hamiltonian(
     law::Data.ControlLaw;
     kwargs...,
 )
-    routed = _route_flow_options(kwargs; action_defs=_flow_action_defs())
-    components = _build_flow_components(routed)
+    method, kw = _pop_method(kwargs)
+    routed = _route_flow_options(Traits.WithAD, kw; method=method, action_defs=_flow_action_defs())
+    components = _build_flow_components(Traits.WithAD, routed; method=method)
     ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
     return _build_pseudo_flow(Val(ht), h̃, law, components)
 end
@@ -709,8 +717,9 @@ function _flow_from_ocp_control(
             context="Flow(ocp, law::ControlLaw) — control-dependence check",
         ),
     )
-    routed = _route_flow_options(kwargs; action_defs=_flow_action_defs())
-    components = _build_flow_components(routed)
+    method, kw = _pop_method(kwargs)
+    routed = _route_flow_options(Traits.WithAD, kw; method=method, action_defs=_flow_action_defs())
+    components = _build_flow_components(Traits.WithAD, routed; method=method)
     ht = _unwrap_option(get(routed.action, :hamiltonian_type, nothing), :total)
     cspec = _unwrap_option(get(routed.action, :constraint, nothing), nothing)
     mspec = _unwrap_option(get(routed.action, :multiplier, nothing), nothing)
@@ -854,8 +863,7 @@ function _controlled_flow(
 )
     g = Data.ComposedVectorField(fc, law)
     system = Systems.build_system(g)
-    integrator = Integrators.build_integrator(; kwargs...)
-    return ControlledFlow(build_flow(system, integrator), ocp, law)
+    return ControlledFlow(build_flow(system, _build_integrator(kwargs)), ocp, law)
 end
 
 function Flow(::CTModels.Models.Model, ::Any, args...; kwargs...)

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -512,7 +512,12 @@ function _invoke_flow_variable_costate(
     t0 = Configs.initial_time(config)
     x0 = Configs.initial_state(config)
     p0 = Configs.initial_costate(config)
-    pv0 = Systems._coerce_state(variable)(zeros(eltype(x0), length(variable)))
+    # Preserve x0's array type & eltype for the costate buffer: `similar(x0, …)` keeps it
+    # device-resident when x0 is on GPU. For a scalar x0 (1-D=scalar convention, CPU-only),
+    # fall back to a host `Vector` since `similar` is not defined on a scalar.
+    n_v = length(variable)
+    pv0_zero = x0 isa AbstractArray ? fill!(similar(x0, n_v), 0) : zeros(eltype(x0), n_v)
+    pv0 = Systems._coerce_state(variable)(pv0_zero)
     tf = Configs.final_time(config)
     config_aug = Configs.AugmentedHamiltonianEndPointConfig(t0, x0, p0, pv0, tf)
     return _invoke_flow(flow, config_aug; variable=variable, unsafe=unsafe)

--- a/src/Flows/flow_routing.jl
+++ b/src/Flows/flow_routing.jl
@@ -18,10 +18,78 @@ fam = Flows._flow_families()
 
 See also: [`CTFlows.Flows._route_flow_options`](@ref), [`CTFlows.Flows.flow_registry`](@ref)
 """
-function _flow_families()
+function _flow_families(::Type{Traits.WithAD})
     return (
         backend=Differentiation.AbstractADBackend, integrator=Integrators.AbstractIntegrator
     )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Strategy families for an AD-free flow: only the `:sciml` integrator (no `:di` backend, since
+no scalar Hamiltonian is differentiated).
+"""
+function _flow_families(::Type{Traits.WithoutAD})
+    return (integrator=Integrators.AbstractIntegrator,)
+end
+
+# Back-compat: the full (WithAD) families.
+_flow_families() = _flow_families(Traits.WithAD)
+
+"""
+$(TYPEDSIGNATURES)
+
+Base method description for a flow plan, per AD trait. The device token (`:cpu`) is **explicit**:
+the flow registry is parameterized (`[CPU, GPU]`), so a device token is required —
+[`CTBase.Strategies.extract_global_parameter_from_method`](@extref) throws otherwise. The bare
+`:cpu` reproduces the pre-parameterization CPU behaviour exactly (`SciML{CPU}` metadata ≡ old).
+"""
+_flow_base_description(::Type{Traits.WithAD}) = (:di, :sciml, :cpu)
+_flow_base_description(::Type{Traits.WithoutAD}) = (:sciml, :cpu)
+
+"""
+$(TYPEDSIGNATURES)
+
+Candidate descriptions (the `:cpu`/`:gpu` device variants) against which a user `method` is
+completed via [`CTBase.Descriptions.complete`](@extref).
+"""
+_available_flow_methods(::Type{Traits.WithAD}) = ((:di, :sciml, :cpu), (:di, :sciml, :gpu))
+_available_flow_methods(::Type{Traits.WithoutAD}) = ((:sciml, :cpu), (:sciml, :gpu))
+
+# Normalize a user-supplied `method` into a token tuple (or `nothing` for the default).
+_as_method_tokens(::Nothing) = nothing
+_as_method_tokens(m::Symbol) = (m,)
+_as_method_tokens(m::Tuple{Vararg{Symbol}}) = m
+
+"""
+$(TYPEDSIGNATURES)
+
+Resolve the effective method description for a flow from its AD trait and an optional user
+`method` (a `Symbol` such as `:gpu`, or a token tuple). `method === nothing` yields the base
+(CPU) description; otherwise the tokens are completed against
+[`CTFlows.Flows._available_flow_methods`](@ref).
+"""
+function _flow_description(ad_trait, method)
+    tokens = _as_method_tokens(method)
+    tokens === nothing && return _flow_base_description(ad_trait)
+    return Descriptions.complete(tokens...; descriptions=_available_flow_methods(ad_trait))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Split a flow constructor's keyword arguments into `(method, rest)`: the device selection
+(`method=:gpu`, a `Symbol` or token tuple; `nothing` if absent) and the remaining strategy
+options. `method` rides along in every constructor's `kwargs...` and is popped here, at the
+routing boundary, so it is never mistaken for a strategy option.
+
+See also: [`CTFlows.Flows._flow_description`](@ref), [`CTFlows.Flows._route_flow_options`](@ref).
+"""
+function _pop_method(kwargs)
+    nt = (; kwargs...)
+    method = get(nt, :method, nothing)
+    return method, Base.structdiff(nt, NamedTuple{(:method,)})
 end
 
 """
@@ -42,7 +110,7 @@ This constant identifies the strategy families used in flow construction:
 
 See also: [`CTFlows.Flows._route_flow_options`](@ref), [`CTFlows.Flows._build_flow_components`](@ref), [`CTFlows.Flows._flow_families`](@ref).
 """
-const _FLOW_DESCRIPTION = (:di, :sciml)
+const _FLOW_DESCRIPTION = _flow_base_description(Traits.WithAD)
 
 """
 $(TYPEDSIGNATURES)
@@ -82,16 +150,26 @@ See also: [`CTFlows.Flows._flow_families`](@ref), [`CTFlows.Flows._build_flow_co
 [`CTBase.Orchestration.route_all_options`](@extref)
 """
 function _route_flow_options(
-    kwargs; action_defs::Vector{<:Options.OptionDefinition}=Options.OptionDefinition[]
+    ad_trait,
+    kwargs;
+    method=nothing,
+    action_defs::Vector{<:Options.OptionDefinition}=Options.OptionDefinition[],
 )
     return Orchestration.route_all_options(
-        _FLOW_DESCRIPTION,
-        _flow_families(),
+        _flow_description(ad_trait, method),
+        _flow_families(ad_trait),
         action_defs,
         (; kwargs...),
         flow_registry();
         source_mode=:description,
     )
+end
+
+# Back-compat: default to the WithAD plan (the full `:di`/`:sciml` families).
+function _route_flow_options(
+    kwargs; action_defs::Vector{<:Options.OptionDefinition}=Options.OptionDefinition[]
+)
+    return _route_flow_options(Traits.WithAD, kwargs; action_defs=action_defs)
 end
 
 """
@@ -156,16 +234,20 @@ Each strategy is constructed via
 that were routed to its family by [`CTFlows.Flows._route_flow_options`](@ref).
 
 # Arguments
+- `ad_trait`: `Traits.WithAD` (builds `:di` backend + `:sciml` integrator) or `Traits.WithoutAD`
+  (builds only the `:sciml` integrator).
 - `routed`: Result of [`CTFlows.Flows._route_flow_options`](@ref) containing routed option values.
+- `method`: Optional device selection (`Symbol`/token tuple, e.g. `:gpu`) threaded into the
+  resolved global strategy parameter (`CPU`/`GPU`) for **all** families at once.
 
 # Returns
-- `NamedTuple{(:backend, :integrator)}`: Concrete strategy instances.
+- `NamedTuple`: concrete strategy instances keyed by family — `(integrator,)` for `WithoutAD`,
+  `(backend, integrator)` for `WithAD`.
 
 # Example
 ```julia
-# Build concrete strategies from routed options
-routed = Flows._route_flow_options((; reltol=1e-8))
-components = Flows._build_flow_components(routed)
+routed = Flows._route_flow_options(Traits.WithAD, (; reltol=1e-8))
+components = Flows._build_flow_components(Traits.WithAD, routed)
 # components.backend isa CTBase.Differentiation.DifferentiationInterface
 # components.integrator isa CTFlows.Integrators.SciML
 ```
@@ -173,14 +255,38 @@ components = Flows._build_flow_components(routed)
 See also: [`CTFlows.Flows._route_flow_options`](@ref), [`CTFlows.Flows.flow_registry`](@ref),
 [`CTBase.Orchestration.build_strategy_from_resolved`](@extref)
 """
-function _build_flow_components(routed)
-    families = _flow_families()
-    resolved = Orchestration.resolve_method(_FLOW_DESCRIPTION, families, flow_registry())
-    backend = Orchestration.build_strategy_from_resolved(
-        resolved, :backend, families, flow_registry(); routed.strategies.backend...
+function _build_flow_components(ad_trait, routed; method=nothing)
+    families = _flow_families(ad_trait)
+    resolved = Orchestration.resolve_method(
+        _flow_description(ad_trait, method), families, flow_registry()
     )
-    integrator = Orchestration.build_strategy_from_resolved(
-        resolved, :integrator, families, flow_registry(); routed.strategies.integrator...
-    )
-    return (backend=backend, integrator=integrator)
+    built = map(keys(families)) do family
+        Orchestration.build_strategy_from_resolved(
+            resolved, family, families, flow_registry();
+            getproperty(routed.strategies, family)...,
+        )
+    end
+    return NamedTuple{keys(families)}(built)
+end
+
+# Back-compat: default to the WithAD plan (backend + integrator).
+_build_flow_components(routed) = _build_flow_components(Traits.WithAD, routed)
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the SciML integrator for an **AD-free** flow (`Traits.WithoutAD`) directly from a flow
+constructor's keyword arguments, honouring a `method=:gpu` device selection popped from them.
+
+Shared by the AD-free constructors (`Flow(VectorField)`, `Flow(HamiltonianVectorField)`,
+controlled-vector-field flows, `Flow(ODEFunction)`, `Flow(ODEProblem)`), which build only an
+integrator (no `:di` AD backend). Routing through the `WithoutAD` plan means an `ad_backend`
+option is correctly rejected here as unknown (there is no AD backend to configure).
+
+See also: [`CTFlows.Flows._build_flow_components`](@ref), [`CTFlows.Flows._pop_method`](@ref).
+"""
+function _build_integrator(opts)
+    method, kwargs = _pop_method(opts)
+    routed = _route_flow_options(Traits.WithoutAD, kwargs; method=method)
+    return _build_flow_components(Traits.WithoutAD, routed; method=method).integrator
 end

--- a/src/Flows/registry.jl
+++ b/src/Flows/registry.jl
@@ -19,8 +19,10 @@ types to their concrete implementations for flow construction:
 See also: [`CTFlows.Flows.flow_registry`](@ref), [`CTFlows.Flows._route_flow_options`](@ref), [`CTBase.Strategies.create_registry`](@extref).
 """
 const _FLOW_REGISTRY = Strategies.create_registry(
-    Differentiation.AbstractADBackend => (Differentiation.DifferentiationInterface,),
-    Integrators.AbstractIntegrator => (Integrators.SciML,),
+    Differentiation.AbstractADBackend =>
+        ((Differentiation.DifferentiationInterface, [Strategies.CPU, Strategies.GPU]),),
+    Integrators.AbstractIntegrator =>
+        ((Integrators.SciML, [Strategies.CPU, Strategies.GPU]),),
 )
 
 """

--- a/test/suite/flows/test_flow_routing.jl
+++ b/test/suite/flows/test_flow_routing.jl
@@ -43,7 +43,9 @@ function test_flow_routing()
         end
 
         Test.@testset "Unit: _FLOW_DESCRIPTION" begin
-            Test.@test Flows._FLOW_DESCRIPTION === (:di, :sciml)
+            # The device token (:cpu) is explicit: the registry is now parameterized [CPU, GPU],
+            # so a device token is required; :cpu reproduces the pre-parameterization behaviour.
+            Test.@test Flows._FLOW_DESCRIPTION === (:di, :sciml, :cpu)
         end
 
         Test.@testset "Unit: flow_registry" begin

--- a/test/suite/flows/test_gpu_routing.jl
+++ b/test/suite/flows/test_gpu_routing.jl
@@ -1,0 +1,102 @@
+"""
+Family-A tests: the `method=:gpu` device selection for flow construction. All CPU-runnable —
+building GPU-parameterized strategies needs no functional GPU (the `SciML{GPU}` metadata equals
+`SciML{CPU}`, and the GPU AD default `AutoZygote` is an ADTypes marker), so these assert the
+routing/resolution without executing on a device.
+"""
+
+module TestGPURouting
+
+using Test: Test
+import CTBase.Exceptions
+import CTBase.Strategies
+import CTFlows.Flows
+import CTBase.Data
+import CTBase.Traits
+using ADTypes: ADTypes
+using OrdinaryDiffEqTsit5
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const _TEST_H = Data.Hamiltonian(
+    (t, x, p, v) -> 0.5 * (x[1]^2 + p[1]^2); is_autonomous=true, is_variable=false
+)
+_test_vf() = Data.VectorField(x -> -x; is_autonomous=true, is_variable=false)
+
+function test_gpu_routing()
+    Test.@testset "GPU routing (method=:gpu)" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # method → effective description (device token completion)
+        # ====================================================================
+
+        Test.@testset "method → description" begin
+            # default / :cpu → CPU base; :gpu → GPU variant.
+            Test.@test Flows._flow_description(Traits.WithoutAD, nothing) == (:sciml, :cpu)
+            Test.@test Flows._flow_description(Traits.WithoutAD, :cpu) == (:sciml, :cpu)
+            Test.@test Flows._flow_description(Traits.WithoutAD, :gpu) == (:sciml, :gpu)
+            Test.@test Flows._flow_description(Traits.WithAD, nothing) == (:di, :sciml, :cpu)
+            Test.@test Flows._flow_description(Traits.WithAD, :gpu) == (:di, :sciml, :gpu)
+        end
+
+        # ====================================================================
+        # one global :gpu token resolves GPU on BOTH families at once
+        # ====================================================================
+
+        Test.@testset "components resolve GPU on both families" begin
+            routed = Flows._route_flow_options(Traits.WithoutAD, (;); method=:gpu)
+            comps = Flows._build_flow_components(Traits.WithoutAD, routed; method=:gpu)
+            Test.@test Strategies.parameter(typeof(comps.integrator)) == Strategies.GPU
+            Test.@test !haskey(comps, :backend)  # AD-free plan has no :di backend
+
+            routed_ad = Flows._route_flow_options(Traits.WithAD, (;); method=:gpu)
+            comps_ad = Flows._build_flow_components(Traits.WithAD, routed_ad; method=:gpu)
+            Test.@test Strategies.parameter(typeof(comps_ad.backend)) == Strategies.GPU
+            Test.@test Strategies.parameter(typeof(comps_ad.integrator)) == Strategies.GPU
+        end
+
+        Test.@testset "default / :cpu resolve CPU" begin
+            routed = Flows._route_flow_options(Traits.WithAD, (;))
+            comps = Flows._build_flow_components(Traits.WithAD, routed)
+            Test.@test Strategies.parameter(typeof(comps.backend)) == Strategies.CPU
+            Test.@test Strategies.parameter(typeof(comps.integrator)) == Strategies.CPU
+        end
+
+        # ====================================================================
+        # construction with method=:gpu (host CPU — no functional GPU needed)
+        # ====================================================================
+
+        Test.@testset "construction with method=:gpu" begin
+            f_vf = Flows.Flow(_test_vf(); method=:gpu)                # AD-free
+            Test.@test f_vf isa Flows.AbstractFlow
+            f_h = Flows.Flow(_TEST_H; method=:gpu)                    # AD (AutoZygote default)
+            Test.@test f_h isa Flows.AbstractFlow
+            f_cpu = Flows.Flow(_test_vf(); method=:cpu)               # :cpu ≡ default
+            Test.@test f_cpu isa Flows.AbstractFlow
+        end
+
+        # ====================================================================
+        # behaviour change: ad_backend rejected on an AD-free flow
+        # (the WithoutAD plan has no :di family)
+        # ====================================================================
+
+        Test.@testset "ad_backend rejected on AD-free flow" begin
+            Test.@test_throws Exceptions.IncorrectArgument Flows.Flow(
+                _test_vf(); ad_backend=ADTypes.AutoForwardDiff()
+            )
+        end
+
+        # ====================================================================
+        # unknown device token is rejected
+        # ====================================================================
+
+        Test.@testset "unknown method token rejected" begin
+            Test.@test_throws Exception Flows._flow_description(Traits.WithoutAD, :tpu)
+        end
+    end
+end
+
+end # module
+
+test_gpu_routing() = TestGPURouting.test_gpu_routing()


### PR DESCRIPTION
## What & why

Make GPU reachable from the flow API. This is **phase 2** of the CTFlows GPU roadmap (roadmap-v4 §5, decisions D3 / §4.4). It registers the now-parameterized `SciML{P}` (CTSolvers #178, released as `v0.4.30-beta`) and `DifferentiationInterface{P}` (CTBase #499, released as `v0.28.1-beta`) strategies with `[CPU, GPU]`, adds a user-facing `method=:gpu` selection to every `Flow(...)` constructor, and **unifies** the two flow-construction paths (AD-free vs AD/OCP) onto one resolution mechanism keyed by `Traits.ad_trait`.

`Flow(...)` without `method` is **byte-identical** to before (`SciML{CPU}` / `DifferentiationInterface{CPU}` metadata equals the old non-parameterized metadata).

## How

- **Registry** (`src/Flows/registry.jl`): `(DifferentiationInterface,[CPU,GPU])` + `(SciML,[CPU,GPU])`.
- **Routing** (`src/Flows/flow_routing.jl`): two `(description, families)` plans selected by dispatch on `Traits.ad_trait` — `WithAD` → `(:di, :sciml)`, `WithoutAD` → `(:sciml,)`. Both run through the existing `route_all_options`/`resolve_method`/`build_strategy_from_resolved` pipeline (now exercised at 1 and 2 families). A user `method` is completed via `CTBase.Descriptions.complete` against the `:cpu`/`:gpu` variants. Base descriptions carry an explicit **`:cpu`** token because the parameterized registry *requires* a device token (`extract_global_parameter_from_method` throws otherwise). New helpers `_pop_method` (pops `method` from a constructor's `kwargs` at the routing boundary — so it need not be threaded through ~13 signatures) and `_build_integrator` (shared AD-free integrator build).
- **Constructors** (`src/Flows/building.jl` + `ext/CTFlowsSciMLFlows/flow_constructors.jl`): all five `build_integrator` call sites retired → `_build_integrator` (WithoutAD); `method` threaded through the four Path-B routing sites; it rides through every delegation chain via `kwargs`.
- **Hygiene** (`src/Flows/calling.jl`): the augmented-costate `pv0` buffer now uses `similar(x0, …)` (device-preserving) for array `x0`, with a host-`Vector` fallback for scalar `x0` (1-D=scalar convention).

## Behaviour change (pre-approved, §4.4)

`Flow(vf; ad_backend=…)` on an **AD-free** flow is now **rejected** as an unknown option (the `WithoutAD` plan has no `:di` family), instead of being silently ignored.

## Tests

Full CTFlows suite **green (2568)**, including the new `test/suite/flows/test_gpu_routing.jl` (16, Family-A, CPU-runnable: `method=:gpu` resolves `GPU` on both families) and Aqua (no method ambiguity from the trait-dispatched routing). Validated first locally against `Pkg.develop`'d CTBase/CTSolvers checkouts, then re-confirmed against the released registry betas (`CTBase v0.28.1-beta`, `CTSolvers v0.4.30-beta`).

## Out of scope

AD-dependent GPU *execution* correctness + the augmented host-`v` fix (phase 3); GPU tests on the `kkt` runner (phase 4); the ensemble PoC (4b); the "GPU flows" docs guide (phase 5); deleting CTSolvers `build_integrator` (optional follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
