### PR TITLE
feat(gpu): augmented & OCP flows GPU-clean (phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING** — `Flow(vf; ad_backend=…)` on an **AD-free** flow is now rejected as an unknown
   option instead of being silently ignored (the AD-free plan has no `:di` family).
 
+### Fixed
+
+- **Augmented & OCP flows are now GPU-clean** (GPU roadmap-v4 §5, phase 3): the variable-costate
+  RHS `_aug_assign!` device-adapts the host `∂pv` block (`-∂H/∂v`, produced from the host-side
+  `v`) to `du`'s array type before assignment — one localized fix covering all four augmented
+  functors — clearing the `GPUCompiler.KernelError` on `variable_costate` flows. The OCP
+  "1-D = scalar" coercion cluster (`_dim_coerce`, the `OCPControlled`/`OCPStateVectorFieldFunction`
+  field bounds, `_finalize_vf`) and the `_ham_split_solution` scalar branch now route through the
+  GPU-safe `Systems._safe_only` instead of raw `only`, so a length-1 device buffer no longer
+  scalar-indexes. CPU behaviour is byte-identical; on-device assertions land in phase 4.
+
 ## [0.14.0-beta] - 2026-07-17
 
 ### Added

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -560,9 +560,9 @@ struct OCPControlledVectorFieldFunction{
     TD<:Traits.TimeDependence,
     VD<:Traits.VariableDependence,
     DF<:Function,
-    CX<:Union{typeof(only),typeof(identity)},
-    CU<:Union{typeof(only),typeof(identity)},
-    CV<:Union{typeof(only),typeof(identity)},
+    CX<:Union{typeof(Systems._safe_only),typeof(identity)},
+    CU<:Union{typeof(Systems._safe_only),typeof(identity)},
+    CV<:Union{typeof(Systems._safe_only),typeof(identity)},
 } <: Function
     dynamics!::DF
     n::Int
@@ -577,7 +577,7 @@ $(TYPEDSIGNATURES)
 
 Collapse a length-1 result buffer to a scalar (1-D state convention).
 """
-_finalize_vf(r, ::Number) = only(r)
+_finalize_vf(r, ::Number) = Systems._safe_only(r)
 """
 $(TYPEDSIGNATURES)
 
@@ -593,7 +593,7 @@ $(TYPEDSIGNATURES)
 Precomputed coercion from a declared dimension: `only` collapses a 1-D quantity to a
 scalar (accepting both a scalar and a length-1 vector), `identity` leaves n-D untouched.
 """
-_dim_coerce(dim::Int) = dim == 1 ? only : identity
+_dim_coerce(dim::Int) = dim == 1 ? Systems._safe_only : identity
 
 """
 $(TYPEDSIGNATURES)
@@ -711,8 +711,8 @@ struct OCPStateVectorFieldFunction{
     TD<:Traits.TimeDependence,
     VD<:Traits.VariableDependence,
     DF<:Function,
-    CX<:Union{typeof(only),typeof(identity)},
-    CV<:Union{typeof(only),typeof(identity)},
+    CX<:Union{typeof(Systems._safe_only),typeof(identity)},
+    CV<:Union{typeof(Systems._safe_only),typeof(identity)},
 } <: Function
     dynamics!::DF
     n::Int

--- a/src/Systems/coercion.jl
+++ b/src/Systems/coercion.jl
@@ -26,3 +26,28 @@ See also: [`CTFlows.Systems._coerce_state`](@ref).
 """
 _safe_only(x::GPUArraysCore.AbstractGPUArray) = GPUArraysCore.@allowscalar only(x)
 _safe_only(x) = only(x)
+
+"""
+    _device_like(dst, src)
+
+Return `src` in a form that can be broadcast into `dst` without a device/host mismatch.
+
+Augmented Hamiltonian flows split into `[∂p; -∂x; -∂pv]`; on GPU the state blocks
+`∂x`/`∂p` are device-resident (built from a device state) but `∂pv = -∂H/∂v` is **host**
+(the variable `v` transits host-side, per the D4 rule), so broadcasting it into a device
+`du` slice wraps a non-`isbits` host `Vector` in a `Broadcasted` and fails to compile
+(`GPUCompiler.KernelError`). `_device_like` copies **only** that host block onto the device
+matching `dst`; on host, and for already-device blocks, it is the identity (no copy).
+
+Dispatch is on the array actually received at the call site, so CPU behaviour is byte-for-byte
+unchanged and only the degenerate device-`dst`/host-`src` case pays a tiny `O(n_v)` H2D copy.
+Backend-agnostic (`GPUArraysCore.AbstractGPUArray` covers CUDA/AMDGPU/Metal).
+
+See also: [`CTFlows.Systems._aug_assign!`](@ref), [`CTFlows.Systems._safe_only`](@ref).
+"""
+_device_like(::AbstractArray, src) = src
+_device_like(::GPUArraysCore.AbstractGPUArray, src::Number) = src
+_device_like(::GPUArraysCore.AbstractGPUArray, src::GPUArraysCore.AbstractGPUArray) = src
+function _device_like(dst::GPUArraysCore.AbstractGPUArray, src::AbstractArray)
+    return copyto!(similar(dst, eltype(src), size(src)), src)
+end

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -218,12 +218,16 @@ The augmented derivative vector has the form `[dx; dp; dpv]` where:
 See also: [`CTFlows.Systems._aug_split`](@ref), [`CTFlows.Systems.HamIpAugRHS`](@ref).
 """
 function _aug_assign!(du::AbstractVector, dx, dp, dpv, n_x::Int, n_v::Int)
-    return (du[1:n_x].=dx; du[(n_x + 1):(2 * n_x)].=dp; du[(end - n_v + 1):end].=dpv)
+    du[1:n_x] .= _device_like(du, dx)
+    du[(n_x + 1):(2 * n_x)] .= _device_like(du, dp)
+    du[(end - n_v + 1):end] .= _device_like(du, dpv)
+    return nothing
 end
 function _aug_assign!(du::AbstractMatrix, dx, dp, dpv, n_x::Int, n_v::Int)
-    return (
-        du[1:n_x, :].=dx; du[(n_x + 1):(2 * n_x), :].=dp; du[(end - n_v + 1):end, :].=dpv
-    )
+    du[1:n_x, :] .= _device_like(du, dx)
+    du[(n_x + 1):(2 * n_x), :] .= _device_like(du, dp)
+    du[(end - n_v + 1):end, :] .= _device_like(du, dpv)
+    return nothing
 end
 
 # =============================================================================

--- a/src/Trajectories/hamiltonian_vector_field_trajectory.jl
+++ b/src/Trajectories/hamiltonian_vector_field_trajectory.jl
@@ -84,16 +84,19 @@ end
 # =============================================================================
 
 """
-    _ham_split_solution(u::AbstractVector, x0::Number) = (only(u[1:1]), only(u[2:2]))
+    _ham_split_solution(u::AbstractVector, x0::Number) = (_safe_only(u[1:1]), _safe_only(u[2:2]))
     _ham_split_solution(u::AbstractVector, x0::AbstractVector) = (u[1:n], u[n+1:2n])
     _ham_split_solution(u::AbstractMatrix, x0::AbstractMatrix) = (u[1:n, :], u[n+1:2n, :])
 
 Split a combined state vector into state and costate components, preserving the shape of x0.
 
-For scalar x0, extracts single elements and coerces them back to scalars.
+For scalar x0, extracts single elements and coerces them back to scalars (via the GPU-safe
+[`CTFlows.Systems._safe_only`](@ref), consistent with every other 1-D=scalar split path).
 For vector/matrix x0, extracts views of the appropriate size.
 """
-_ham_split_solution(u::AbstractVector, x0::Number) = (only(u[1:1]), only(u[2:2]))
+function _ham_split_solution(u::AbstractVector, x0::Number)
+    (Systems._safe_only(u[1:1]), Systems._safe_only(u[2:2]))
+end
 _ham_split_solution(u::AbstractVector, x0::AbstractVector) =
     let n = length(x0)
         (u[1:n], u[(n + 1):2n])

--- a/test/suite/flows/test_gpu_routing.jl
+++ b/test/suite/flows/test_gpu_routing.jl
@@ -36,8 +36,23 @@ function test_gpu_routing()
             Test.@test Flows._flow_description(Traits.WithoutAD, nothing) == (:sciml, :cpu)
             Test.@test Flows._flow_description(Traits.WithoutAD, :cpu) == (:sciml, :cpu)
             Test.@test Flows._flow_description(Traits.WithoutAD, :gpu) == (:sciml, :gpu)
-            Test.@test Flows._flow_description(Traits.WithAD, nothing) == (:di, :sciml, :cpu)
+            Test.@test Flows._flow_description(Traits.WithAD, nothing) ==
+                (:di, :sciml, :cpu)
             Test.@test Flows._flow_description(Traits.WithAD, :gpu) == (:di, :sciml, :gpu)
+        end
+
+        # `method` accepts a Symbol OR a token tuple (documented API surface); the tuple
+        # form completes against the same candidate set as the Symbol form.
+        Test.@testset "method tuple form" begin
+            Test.@test Flows._flow_description(Traits.WithoutAD, (:gpu,)) == (:sciml, :gpu)
+            Test.@test Flows._flow_description(Traits.WithoutAD, (:sciml, :gpu)) ==
+                (:sciml, :gpu)
+            Test.@test Flows._flow_description(Traits.WithAD, (:gpu,)) ==
+                (:di, :sciml, :gpu)
+            Test.@test Flows._flow_description(Traits.WithAD, (:di, :sciml, :gpu)) ==
+                (:di, :sciml, :gpu)
+            # end-to-end: a tuple method builds a flow just like the Symbol form
+            Test.@test Flows.Flow(_test_vf(); method=(:gpu,)) isa Flows.AbstractFlow
         end
 
         # ====================================================================

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -489,6 +489,24 @@ function test_ocp_control()
             Test.@test useen isa Number   # 1-D control → scalar even when the state is a vector
         end
 
+        # Unit guard for the coercion primitives behind the two contract tests above:
+        # the 1-D collapse routes through the GPU-safe `_safe_only` (not raw `only`).
+        # Regression guard for the phase-3 migration. (The struct field bounds admitting
+        # `typeof(_safe_only)` is exercised indirectly by every scalar-state OCP flow, e.g.
+        # `x0 = 2.0` in test_ocp_basic_flow.jl — a stale `typeof(only)` bound would
+        # TypeError there at construction.)
+        Test.@testset "Unit: OCP coercion routes through _safe_only" begin
+            # _dim_coerce builds cx/cu/cv: 1-D → GPU-safe collapse, ≥2 → identity
+            Test.@test Flows._dim_coerce(1) === Systems._safe_only
+            Test.@test Flows._dim_coerce(2) === identity
+
+            # _finalize_vf: scalar for a 1-D (Number) state, buffer as-is for a vector state
+            Test.@test Flows._finalize_vf([5.0], 0.0) === 5.0
+            Test.@test Flows._finalize_vf([5.0], 0.0) isa Number
+            r = [1.0, 2.0]
+            Test.@test Flows._finalize_vf(r, [1.0, 2.0]) === r
+        end
+
         # ====================================================================
         # CONSTRAINED :total flows — H = H̃ + μ·g
         #
@@ -605,8 +623,8 @@ function test_ocp_control()
 
             # (2) pseudo-Hamiltonian H̃_c(t,x,p,u,v) = p(-x+u) - 0.5u² + c x
             H̃ = Systems.pseudo_hamiltonian(f)
-            Test.@test H̃(0.0, x0, p0, u0, Float64[]) ≈ p0 * (-x0 + u0) - 0.5 * u0^2 + c * x0 atol =
-                1e-10
+            Test.@test H̃(0.0, x0, p0, u0, Float64[]) ≈
+                p0 * (-x0 + u0) - 0.5 * u0^2 + c * x0 atol = 1e-10
             # the +μ·g term is exactly c·x: difference from the unconstrained H̃
             fu = Flows.Flow(OCP_LQR, law; _opts()...)
             H̃u = Systems.pseudo_hamiltonian(fu)

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -8,9 +8,24 @@ import CTFlows.Systems: Systems
 import CTFlows.Configs: Configs
 import CTFlows.Trajectories: Trajectories
 import StaticArrays: SA, StaticArrays
+import GPUArraysCore: GPUArraysCore
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# Top-level fake device array (never inside a test function — world-age).
+# A CPU-backed `AbstractGPUArray` stand-in that lets the `GPUArraysCore` dispatch
+# branches of `_device_like` / `_aug_assign!` be exercised deterministically without a
+# real GPU (the on-device assertions themselves live in phase 4 on the `kkt` runner).
+struct FakeGPUArray{T,N} <: GPUArraysCore.AbstractGPUArray{T,N}
+    data::Array{T,N}
+end
+Base.size(a::FakeGPUArray) = size(a.data)
+Base.getindex(a::FakeGPUArray, i::Int...) = a.data[i...]
+Base.setindex!(a::FakeGPUArray, v, i::Int...) = (a.data[i...] = v)
+function Base.similar(::FakeGPUArray, ::Type{T}, dims::Dims) where {T}
+    return FakeGPUArray(Array{T}(undef, dims))
+end
 
 function test_hamiltonian_vector_field_system()
     Test.@testset "Hamiltonian Vector Field System Tests" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -343,6 +358,82 @@ function test_hamiltonian_vector_field_system()
             dpv_mat = [5.0 10.0]
             Systems._aug_assign!(du_mat, dx_mat, dp_mat, dpv_mat, 2, 1)
             Test.@test du_mat == [1.0 6.0; 2.0 7.0; -3.0 -8.0; -4.0 -9.0; 5.0 10.0]
+        end
+
+        # ====================================================================
+        # UNIT TESTS - _safe_only / _coerce_state (1-D = scalar, GPU-safe)
+        # ====================================================================
+
+        Test.@testset "_safe_only" begin
+            # host: exactly `only`
+            Test.@test Systems._safe_only([7.0]) === 7.0
+            Test.@test Systems._safe_only(fill(3.0)) === 3.0   # 0-D array
+            # device: the single terminal read is permitted via @allowscalar and still
+            # returns a host scalar (never a device 1-vector) — CPU/GPU uniformity.
+            Test.@test Systems._safe_only(FakeGPUArray([7.0])) === 7.0
+        end
+
+        Test.@testset "_coerce_state dispatch" begin
+            # scalar / length-1 collapse to the GPU-safe `only`; ≥2 and matrices stay put
+            Test.@test Systems._coerce_state(1.0) === Systems._safe_only
+            Test.@test Systems._coerce_state([1.0]) === Systems._safe_only
+            Test.@test Systems._coerce_state([1.0, 2.0]) === identity
+            Test.@test Systems._coerce_state([1.0 2.0; 3.0 4.0]) === identity
+            # dispatch is on the array kind, so a device 1-vector also collapses safely
+            Test.@test Systems._coerce_state(FakeGPUArray([1.0])) === Systems._safe_only
+            Test.@test Systems._coerce_state(FakeGPUArray([1.0, 2.0])) === identity
+        end
+
+        # ====================================================================
+        # UNIT TESTS - _device_like (B4a: device-adapt a host block before assign)
+        # ====================================================================
+
+        Test.@testset "_device_like" begin
+            # --- host dst: pure identity, no copy, for every source kind ---
+            Test.@testset "host dst is identity" begin
+                dst = zeros(3)
+                src_vec = [1.0, 2.0]
+                src_mat = [1.0 2.0; 3.0 4.0]
+                Test.@test Systems._device_like(dst, src_vec) === src_vec
+                Test.@test Systems._device_like(dst, src_mat) === src_mat
+                Test.@test Systems._device_like(dst, 5.0) === 5.0
+            end
+
+            # --- device dst: host source is copied ONTO the device (typed like dst),
+            #     device source and scalars pass straight through (no needless copy) ---
+            Test.@testset "device dst adapts only the host block" begin
+                dst = FakeGPUArray(zeros(3))
+                host_src = [1.0, 2.0]
+                dev_src = FakeGPUArray([3.0, 4.0])
+                adapted = Systems._device_like(dst, host_src)
+                Test.@test adapted isa FakeGPUArray          # host → device-typed
+                Test.@test adapted.data == host_src          # values preserved
+                Test.@test Systems._device_like(dst, dev_src) === dev_src   # device: no copy
+                Test.@test Systems._device_like(dst, 5.0) === 5.0           # scalar: no copy
+            end
+        end
+
+        # _aug_assign! on a device `du` with a HOST `dpv` block — the exact B4a scenario
+        # (`variable_costate` RHS: ∂x/∂p device, ∂pv host). Guards that the assembled
+        # `[dp; -dx; -dpv]` is correct and stays device-typed. (Real-CUDA KernelError
+        # reproduction is a phase-4 on-device assertion; this pins the mechanism on CPU.)
+        Test.@testset "_aug_assign! — device du, host pv block" begin
+            du = FakeGPUArray(zeros(5))
+            dx = FakeGPUArray([1.0, 2.0])
+            dp = FakeGPUArray([-3.0, -4.0])
+            dpv = [5.0]                                   # host block
+            Systems._aug_assign!(du, dx, dp, dpv, 2, 1)
+            Test.@test du isa FakeGPUArray
+            Test.@test du.data == [1.0, 2.0, -3.0, -4.0, 5.0]
+
+            # matrix (batch) form, host pv row
+            du_m = FakeGPUArray(zeros(5, 2))
+            dx_m = FakeGPUArray([1.0 6.0; 2.0 7.0])
+            dp_m = FakeGPUArray([-3.0 -8.0; -4.0 -9.0])
+            dpv_m = [5.0 10.0]                            # host row
+            Systems._aug_assign!(du_m, dx_m, dp_m, dpv_m, 2, 1)
+            Test.@test du_m isa FakeGPUArray
+            Test.@test du_m.data == [1.0 6.0; 2.0 7.0; -3.0 -8.0; -4.0 -9.0; 5.0 10.0]
         end
 
         # ====================================================================

--- a/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
@@ -4,9 +4,22 @@ using Test: Test
 import CTFlows.Integrators: Integrators
 import CTFlows.Trajectories: Trajectories
 import CTBase.Exceptions
+import GPUArraysCore: GPUArraysCore
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# Top-level CPU-backed `AbstractGPUArray` stand-in: lets the scalar-x0 split branch be
+# exercised on a "device" array without a GPU (guards its GPU-safe `_safe_only` collapse).
+struct FakeGPUArray{T,N} <: GPUArraysCore.AbstractGPUArray{T,N}
+    data::Array{T,N}
+end
+Base.size(a::FakeGPUArray) = size(a.data)
+Base.getindex(a::FakeGPUArray, i::Int...) = a.data[i...]
+Base.setindex!(a::FakeGPUArray, v, i::Int...) = (a.data[i...] = v)
+function Base.similar(::FakeGPUArray, ::Type{T}, dims::Dims) where {T}
+    return FakeGPUArray(Array{T}(undef, dims))
+end
 
 # =============================================================================
 # Fake integration result for testing
@@ -325,6 +338,15 @@ function test_hamiltonian_vector_field_trajectory()
                 Test.@test size(p) == (2, 2)
                 Test.@test x == [1.0 2.0; 3.0 4.0]
                 Test.@test p == [5.0 6.0; 7.0 8.0]
+            end
+
+            # scalar x0 on a device `u`: the collapse routes through the GPU-safe
+            # `_safe_only` (not raw `only`), consistent with every other split path.
+            Test.@testset "scalar x0, device u (GPU-safe collapse)" begin
+                u = FakeGPUArray([1.0, 2.0])
+                x, p = Trajectories._ham_split_solution(u, 1.0)
+                Test.@test x === 1.0
+                Test.@test p === 2.0
             end
         end
 


### PR DESCRIPTION
GPU roadmap-v4 §5 — **phase 3**. Closes the two residual GPU-readiness gaps the H200 probe pinned (design report §6bis.1, runs 3–6) so **variable-costate (augmented)** and **OCP** flows run device-clean. Builds on phase 2 (#335, merged). All verification here is **CPU** (no regression); on-device assertions land in phase 4.

## What changed

| Area | Change |
|---|---|
| **Systems** | New `_device_like` helper + device-aware `_aug_assign!` (**B4a**): the augmented RHS adapts the host `∂pv` block (`-∂H/∂v`, produced from the host-side `v`) to `du`'s array type before assignment, clearing the `GPUCompiler.KernelError`. One localized fix covers **all four** augmented functors (`HamIpAugRHS`, hvf-aug, `PseudoHamIpAugRHS`, `ConstrainedPseudoHamIpAugRHS`). |
| **Flows** | OCP "1-D = scalar" `only`-cluster → `Systems._safe_only`: `_dim_coerce`, the `OCPControlled`/`OCPStateVectorFieldFunction` field bounds, and `_finalize_vf` — the Flows-layer cluster the D4 sweep missed. |
| **Trajectories** | `_ham_split_solution` scalar branch `only` → `_safe_only` (materialization-audit finding; consistency across **all** 1-D=scalar split paths). |

CPU behaviour is **byte-identical** (`_safe_only(x) === only(x)` on host). No public API change.

## Design decisions (recorded in the phase-3 plan)

- **B4a fix = option (a)** (device-adapt the host block in `_aug_assign!`), not (b) (carry `v` on-device): one function vs. threading a device `v` through `ODEParameters` + all four functors, and it preserves the "v host-side" invariant everywhere else.
- **OCP hot-path host buffers** (`Vector{T}(undef, h.n)`) — **deferred**: full OCP device execution is gated by CTModels-generated `dynamics!` GPU-safety, discovered in phase 4.

## Materialization audit (§5 rule)

Point calls return device arrays (stay on device, `identity` coerce for n≥2); trajectory building passes device arrays through (probe run-6 confirmed device-native, no host round-trip); `CTModels.Solution` CPU-gather is only reachable via the deferred OCP device path. The one missed `only` (in `_ham_split_solution`) is migrated.

## Tests (+29, all CPU-deterministic)

A top-level CPU-backed `FakeGPUArray <: GPUArraysCore.AbstractGPUArray` exercises the device-dispatch branches **without a GPU**:
- `_safe_only` (host + device scalar-collapse), `_coerce_state` dispatch, `_device_like`, and `_aug_assign!` with a device `du` + host `pv` block (the exact B4a scenario) — `test_hamiltonian_vector_field_system.jl` 53 → 70.
- `_dim_coerce`/`_finalize_vf` route through `_safe_only` — `test_ocp_control.jl` 112 → 117.
- `_ham_split_solution` device-`u` scalar collapse — `test_hamiltonian_vector_field_trajectory.jl` 53 → 55.
- **Phase-2 gap**: the documented tuple-`method` form (`method=(:gpu,)`) — `test_gpu_routing.jl` 16 → 21.

## Verification

Full CTFlows suite green (**2600/2600**) against the released registry betas (CTBase `v0.28.1-beta`, CTSolvers `v0.4.30-beta`, CTModels `v0.15.3-beta`). Formatted with JuliaFormatter (blue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)