### PR TITLE
test(gpu): Family-B GPU execution tests on kkt (phase 4)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ CTBase = "0.28"
 CTLie = "0.1.1"
 CTModels = "0.15"
 CTSolvers = "0.4"
+CUDA = "5, 6"
 CommonSolve = "0.2"
 DiffEqBase = "6, 7"
 DifferentiationInterface = "0.7"
@@ -44,11 +45,13 @@ RecipesBase = "1"
 SciMLBase = "3"
 StaticArrays = "1"
 Test = "1"
+Zygote = "0.7"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CTLie = "6880e05b-3a7d-4cac-887c-30cb52c5fdde"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -58,6 +61,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "CTLie", "DiffEqBase", "DifferentiationInterface", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test"]
+test = ["Aqua", "CTLie", "CUDA", "DiffEqBase", "DifferentiationInterface", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test", "Zygote"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,17 @@ using Test
 using CTBase
 using CTFlows
 
+# CUDA availability check — GPU execution tests (suite/extensions/test_gpu_flows.jl) self-gate
+# on `is_cuda_on()` and skip cleanly when no functional device is present (e.g. CI CPU runners,
+# dev machines). The real GPU run is the `test-gpu-kkt` job on the kkt NVIDIA runner.
+using CUDA
+is_cuda_on() = CUDA.functional()
+if is_cuda_on()
+    println("✓ CUDA functional, GPU tests enabled")
+else
+    println("⚠️  CUDA not functional, GPU tests will be skipped")
+end
+
 # Trigger loading of optional extensions
 const TestRunner = Base.get_extension(CTBase, :TestRunner)
 

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -1,0 +1,201 @@
+"""
+Family-B GPU **execution** tests: run CTFlows single-flows on a CUDA device and assert values
+against analytic references, under `CUDA.allowscalar(false)` (so every pass is genuinely
+scalar-index-free). Mirrors the green surface pinned by `probe/gpu/probe_gpu.jl` (design report
+§6bis.1, H200 runs 3–6) and exercises the phase-3 augmented / `_safe_only` fixes on-device.
+
+The whole suite self-gates on `is_cuda_on()`: on a machine without a functional device (dev
+laptops, CPU CI runners) it skips cleanly. The real run is the `test-gpu-kkt` job on the `kkt`
+NVIDIA runner (PR label `run ci gpu`).
+
+GPU-friendly test integrands use `sum`/`dot`/broadcasts, never scalar indexing (`v[i]`, `x[i]`)
+— a device scalar read is blocked by `allowscalar(false)` (probe run 4/5).
+
+Out of scope here: `Flow(ocp, …)` on device (phase 4c — OCP host-buffers + CTModels `dynamics!`
+gate) and the ensemble path (phase 4b).
+"""
+
+module TestGPUFlows
+
+using Test: Test
+import CUDA: CUDA
+import CTBase.Data: Data
+import CTFlows.Flows: Flows
+import ADTypes: ADTypes
+import SciMLBase: SciMLBase
+import Zygote: Zygote  # loads the Zygote backend so the AutoZygote GPU AD default can differentiate
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+is_cuda_on() = CUDA.functional()
+
+# Move a host array onto the device. Only ever called inside an `is_cuda_on()` guard.
+_dev(x) = CUDA.CuArray(x)
+
+# Analytic references (tf = 1).
+const _E1 = exp(-1.0)                    # ẋ = -x  ⇒  x(1) = x0·e⁻¹
+const _C1 = cos(1.0)
+const _S1 = sin(1.0)
+# Harmonic oscillator ẋ = p, ṗ = -x with x0 = [1,0], p0 = [0,1]:
+#   x(1) = [cos1,  sin1],  p(1) = [-sin1, cos1]
+const _OSC_X = [_C1, _S1]
+const _OSC_P = [-_S1, _C1]
+
+function test_gpu_flows()
+    Test.@testset "GPU flows (Family-B, device execution)" verbose=VERBOSE showtiming=SHOWTIMING begin
+        if !is_cuda_on()
+            @info "CUDA not functional — GPU flow tests skipped (run on the kkt runner)"
+            return nothing
+        end
+
+        CUDA.allowscalar(false)  # every ✓ below is genuinely scalar-index-free
+
+        # ================================================================
+        # AD-FREE flows (GPU-ready first: no AD gate)
+        # ================================================================
+
+        Test.@testset "Flow(VectorField) point + trajectory" begin
+            f = Flows.Flow(Data.VectorField(x -> -x))          # ẋ = -x
+            x0 = _dev([1.0, 2.0])
+            xf = f(0.0, x0, 1.0)
+            Test.@test xf isa CUDA.CuArray                     # array type preserved
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+            # trajectory construction stays device-clean under allowscalar(false)
+            traj = f((0.0, 1.0), x0)
+            Test.@test traj !== nothing
+        end
+
+        Test.@testset "Flow(HamiltonianVectorField) point vs analytic" begin
+            f = Flows.Flow(Data.HamiltonianVectorField((x, p) -> (p, -x)))   # oscillator
+            xf, pf = f(0.0, _dev([1.0, 0.0]), _dev([0.0, 1.0]), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        Test.@testset "Flow(ODEProblem) device u0, remake point-call" begin
+            prob = SciMLBase.ODEProblem(
+                (du, u, p, t) -> (du .= .-u), _dev([1.0, 2.0]), (0.0, 1.0)
+            )
+            f = Flows.Flow(prob)
+            xf = f(0.0, _dev([1.0, 2.0]), 1.0)                 # returns the final state directly
+            Test.@test xf isa CUDA.CuArray
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+        end
+
+        Test.@testset "Flow(ODEFunction) device u0" begin
+            odef = SciMLBase.ODEFunction((du, u, p, t) -> (du .= .-u))
+            f = Flows.Flow(odef)
+            xf = f(0.0, _dev([1.0, 2.0]), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+        end
+
+        # ================================================================
+        # AD-dependent flows (GPU AD default = AutoZygote, phase 1b/2)
+        # ================================================================
+
+        Test.@testset "Flow(Hamiltonian; method=:gpu) — AutoZygote default" begin
+            h = Data.Hamiltonian((x, p) -> (sum(abs2, x) + sum(abs2, p)) / 2)   # oscillator
+            f = Flows.Flow(h; method=:gpu)
+            xf, pf = f(0.0, _dev([1.0, 0.0]), _dev([0.0, 1.0]), 1.0)
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        Test.@testset "Flow(Hamiltonian; ad_backend=AutoZygote())" begin
+            h = Data.Hamiltonian((x, p) -> (sum(abs2, x) + sum(abs2, p)) / 2)
+            f = Flows.Flow(h; ad_backend=ADTypes.AutoZygote())
+            xf, pf = f(0.0, _dev([1.0, 0.0]), _dev([0.0, 1.0]), 1.0)
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        # The DEFAULT backend (AutoForwardDiff) scalar-indexes on a device array: documents the
+        # gate that makes `method=:gpu` (AutoZygote) necessary (probe B3-3c, expected failure).
+        Test.@testset "Flow(Hamiltonian) default backend fails on device" begin
+            h = Data.Hamiltonian((x, p) -> (sum(abs2, x) + sum(abs2, p)) / 2)
+            f = Flows.Flow(h)                                  # default = AutoForwardDiff
+            Test.@test_throws Exception f(0.0, _dev([1.0, 0.0]), _dev([0.0, 1.0]), 1.0)
+        end
+
+        # ================================================================
+        # Augmented variable_costate on device (phase-3 B4a + _safe_only fixes)
+        #   H = (‖x‖² + ‖p‖²)/2 + sum(v): the ∂H/∂v term does not enter ẋ/ṗ, so (x,p) still
+        #   follow the plain oscillator — a clean analytic reference for all three variants.
+        # ================================================================
+
+        _h_var() = Data.Hamiltonian(
+            (x, p, v) -> (sum(abs2, x) + sum(abs2, p)) / 2 + sum(v); is_variable=true
+        )
+
+        Test.@testset "variable_costate — HOST variable (B4a)" begin
+            f = Flows.Flow(_h_var(); ad_backend=ADTypes.AutoZygote())
+            xf, pf = f(
+                0.0,
+                _dev([1.0, 0.0]),
+                _dev([0.0, 1.0]),
+                1.0;
+                variable=[0.5],
+                variable_costate=true,
+            )
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        Test.@testset "variable_costate — DEVICE variable, length 1 (_safe_only)" begin
+            f = Flows.Flow(_h_var(); ad_backend=ADTypes.AutoZygote())
+            xf, pf = f(
+                0.0,
+                _dev([1.0, 0.0]),
+                _dev([0.0, 1.0]),
+                1.0;
+                variable=_dev([0.5]),
+                variable_costate=true,
+            )
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        Test.@testset "variable_costate — DEVICE variable, length 2" begin
+            f = Flows.Flow(_h_var(); ad_backend=ADTypes.AutoZygote())
+            xf, pf = f(
+                0.0,
+                _dev([1.0, 0.0]),
+                _dev([0.0, 1.0]),
+                1.0;
+                variable=_dev([0.5, 0.5]),
+                variable_costate=true,
+            )
+            Test.@test Array(xf) ≈ _OSC_X atol = 1e-6
+            Test.@test Array(pf) ≈ _OSC_P atol = 1e-6
+        end
+
+        # ================================================================
+        # Float32 end-to-end (GPUs prefer Float32; nothing promotes to Float64)
+        # ================================================================
+
+        Test.@testset "Float32 end-to-end, eltype preserved" begin
+            f = Flows.Flow(Data.VectorField(x -> -x))
+            xf = f(0.0f0, _dev(Float32[1, 2]), 1.0f0)
+            Test.@test eltype(xf) == Float32
+            Test.@test Array(xf) ≈ Float32[1, 2] .* Float32(_E1) atol = 1.0f-5
+        end
+
+        # ================================================================
+        # Multi-phase concatenation on device — probe-unverified; enable after the first
+        # green kkt run confirms the concatenation path is scalar-index-free on device.
+        # ================================================================
+
+        Test.@testset "multi-phase on device (pending kkt confirmation)" begin
+            Test.@test_skip false
+        end
+    end
+    return nothing
+end
+
+end # module
+
+# CRITICAL: redefine in the outer scope so the runner can call it
+test_gpu_flows() = TestGPUFlows.test_gpu_flows()

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -85,9 +85,12 @@ function test_gpu_flows()
         end
 
         Test.@testset "Flow(ODEFunction) device u0" begin
-            odef = SciMLBase.ODEFunction((du, u, p, t) -> (du .= .-u))
+            # An ODEFunction carries a parameter slot `p`, so its flow is NonFixed: `p` is
+            # supplied via `variable=` at call time (here the decay rate, a host scalar that
+            # broadcasts cleanly against the device state).
+            odef = SciMLBase.ODEFunction((du, u, p, t) -> (du .= .-p .* u))
             f = Flows.Flow(odef)
-            xf = f(0.0, _dev([1.0, 2.0]), 1.0)
+            xf = f(0.0, _dev([1.0, 2.0]), 1.0; variable=1.0)   # ẋ = -1·u
             Test.@test xf isa CUDA.CuArray
             Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
         end

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -187,12 +187,30 @@ function test_gpu_flows()
         end
 
         # ================================================================
-        # Multi-phase concatenation on device — probe-unverified; enable after the first
-        # green kkt run confirms the concatenation path is scalar-index-free on device.
+        # Multi-phase concatenation on device (state flow, point config).
+        #   Confirmed scalar-index-free: `_extract_final_state` reads `final_state`
+        #   (no scalar getindex) and jumps are applied as broadcasts `v .+ j`, so a
+        #   state-flow `*` concatenation runs under `allowscalar(false)`.
         # ================================================================
 
-        Test.@testset "multi-phase on device (pending kkt confirmation)" begin
-            Test.@test_skip false
+        Test.@testset "multi-phase concat — no jump == single flow" begin
+            f = Flows.Flow(Data.VectorField(x -> -x))              # ẋ = -x
+            mpf = f * (0.5, f)                                     # split at t = 0.5, no jump
+            xf = mpf(0.0, _dev([1.0, 2.0]), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            # splitting a flow with no jump leaves the endpoint unchanged: x(1) = x0·e⁻¹
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+        end
+
+        Test.@testset "multi-phase concat — scalar additive jump" begin
+            f = Flows.Flow(Data.VectorField(x -> -x))              # ẋ = -x
+            mpf = f * (0.5, 0.1, f)                                # x ← x .+ 0.1 at t = 0.5
+            xf = mpf(0.0, _dev([1.0, 2.0]), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            # phase 1 to 0.5, +0.1, phase 2 to 1.0
+            x_mid = [1.0, 2.0] .* exp(-0.5) .+ 0.1
+            x_ref = x_mid .* exp(-0.5)
+            Test.@test Array(xf) ≈ x_ref atol = 1e-6
         end
     end
     return nothing

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -26,6 +26,20 @@ Base.setindex!(a::FakeGPUArray, v, i::Int...) = (a.data[i...] = v)
 function Base.similar(::FakeGPUArray, ::Type{T}, dims::Dims) where {T}
     return FakeGPUArray(Array{T}(undef, dims))
 end
+# GPUArrays.jl (loaded via CUDA in the test session) overrides copyto!/view/getindex for
+# AbstractGPUArray with device-kernel implementations this CPU stand-in cannot satisfy;
+# delegate them to the backing Array so the fake only exercises CTFlows' AbstractGPUArray
+# dispatch, never GPUArrays' device paths.
+function Base.copyto!(dst::FakeGPUArray{T,N}, src::AbstractArray{T,N}) where {T,N}
+    (copyto!(dst.data, src); dst)
+end
+# resolve the ambiguity with GPUArrays' copyto!(::AnyGPUArray, ::Array)
+function Base.copyto!(dst::FakeGPUArray{T,N}, src::Array{T,N}) where {T,N}
+    (copyto!(dst.data, src); dst)
+end
+Base.view(a::FakeGPUArray, I::Vararg{Any}) = view(a.data, I...)
+Base.getindex(a::FakeGPUArray, I::AbstractUnitRange) = FakeGPUArray(a.data[I])
+Base.getindex(a::FakeGPUArray, I::AbstractUnitRange, ::Colon) = FakeGPUArray(a.data[I, :])
 
 function test_hamiltonian_vector_field_system()
     Test.@testset "Hamiltonian Vector Field System Tests" verbose=VERBOSE showtiming=SHOWTIMING begin

--- a/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
@@ -20,6 +20,20 @@ Base.setindex!(a::FakeGPUArray, v, i::Int...) = (a.data[i...] = v)
 function Base.similar(::FakeGPUArray, ::Type{T}, dims::Dims) where {T}
     return FakeGPUArray(Array{T}(undef, dims))
 end
+# GPUArrays.jl (loaded via CUDA in the test session) overrides copyto!/view/getindex for
+# AbstractGPUArray with device-kernel implementations this CPU stand-in cannot satisfy;
+# delegate them to the backing Array so the fake only exercises CTFlows' AbstractGPUArray
+# dispatch, never GPUArrays' device paths.
+function Base.copyto!(dst::FakeGPUArray{T,N}, src::AbstractArray{T,N}) where {T,N}
+    (copyto!(dst.data, src); dst)
+end
+# resolve the ambiguity with GPUArrays' copyto!(::AnyGPUArray, ::Array)
+function Base.copyto!(dst::FakeGPUArray{T,N}, src::Array{T,N}) where {T,N}
+    (copyto!(dst.data, src); dst)
+end
+Base.view(a::FakeGPUArray, I::Vararg{Any}) = view(a.data, I...)
+Base.getindex(a::FakeGPUArray, I::AbstractUnitRange) = FakeGPUArray(a.data[I])
+Base.getindex(a::FakeGPUArray, I::AbstractUnitRange, ::Colon) = FakeGPUArray(a.data[I, :])
 
 # =============================================================================
 # Fake integration result for testing


### PR DESCRIPTION
GPU roadmap-v4 §5 — **phase 4**. Adds the **first real GPU execution tests** (single-flow, Family-B), asserting the probe's green surface (`probe/gpu/probe_gpu.jl`, design report §6bis.1, H200 runs 3–6) as pass/fail on the `kkt` NVIDIA runner under `CUDA.allowscalar(false)`. This gives phase 3's augmented + coercion fixes their **on-device proof**. Builds on phases 2 (#335) + 3 (#336), both merged.

> **The `run ci gpu` label is set** → the `test-gpu-kkt` job runs the suite on `kkt`. That is the real validation: the assertions cannot run on a machine without a functional CUDA device (the whole file self-gates on `is_cuda_on()` and skips cleanly locally / on CPU CI).

## What changed

| File | Change |
|---|---|
| `test/suite/extensions/test_gpu_flows.jl` | **new** — Family-B GPU execution, `CUDA.allowscalar(false)` for the whole file, every row gated by `is_cuda_on()` |
| `test/runtests.jl` | `is_cuda_on() = CUDA.functional()` gate + `✓/⚠️ CUDA …` status println (mirrors CTSolvers) |
| `Project.toml` | `CUDA = "5, 6"` + `Zygote = "0.7"` as **test-only** deps (`[extras]` / `[targets]` / `[compat]`) |

## Test rows (mirror the probe green surface)

- **AD-free:** `Flow(VectorField)` point + trajectory (x0::CuArray, type preserved), `Flow(HamiltonianVectorField)` vs analytic oscillator, `Flow(ODEProblem)` / `Flow(ODEFunction)` device u0.
- **AD (AutoZygote default):** `Flow(Hamiltonian; method=:gpu)` and explicit `ad_backend=AutoZygote()` vs analytic. Plus a **negative** row: the default `AutoForwardDiff` scalar-indexes on device (`@test_throws`), documenting why `method=:gpu` is needed.
- **Augmented (phase-3 fixes):** `variable_costate` on device — HOST variable (B4a), DEVICE variable length-1 (`_safe_only`), length-2.
- **Float32** end-to-end (eltype preserved).
- **Multi-phase on device:** `@test_skip` placeholder — probe-unverified; enable after the first green `kkt` run.

Integrands use `sum`/`dot`/broadcasts, never `v[i]`/`x[i]` (device scalar reads are blocked by `allowscalar(false)`).

## Zygote dependency

The AD-on-device rows evaluate the **AutoZygote** default/backend, which needs the **Zygote** package *loaded* to differentiate (AutoZygote alone is only an ADTypes marker). Hence CUDA **and** Zygote as test deps (mirrors `probe/gpu/Project.toml`).

## Scope (signed off)

- **`Flow(ocp, law)` on device is deferred to the new phase 4c** (`.reports/gpu/plan.md`): phase 3 deferred the OCP hot-path host buffers, and the real gate is CTModels-generated `dynamics!` GPU-safety.
- Ensemble/Family-C is **phase 4b**.

## Verification

Local suite green (**489/489**, CUDA non-functional → GPU file skips cleanly); Aqua clean (CUDA/Zygote extras + compat validated). CUDA v6.2.1 / Zygote v0.7.11 resolved. Real device pass/fail: the `test-gpu-kkt` run triggered by this PR's label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)