### PR TITLE
test(gpu): Family-C ensemble GPU PoC (DiffEqGPU) — roadmap-v4 §5 phase 4b

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ CTSolvers = "0.4"
 CUDA = "5, 6"
 CommonSolve = "0.2"
 DiffEqBase = "6, 7"
+DiffEqGPU = "3"
 DifferentiationInterface = "0.7"
 DocStringExtensions = "0.9"
 ForwardDiff = "0.10, 1"
@@ -53,6 +54,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CTLie = "6880e05b-3a7d-4cac-887c-30cb52c5fdde"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -64,4 +66,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "CTLie", "CUDA", "DiffEqBase", "DifferentiationInterface", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test", "Zygote"]
+test = ["Aqua", "CTLie", "CUDA", "DiffEqBase", "DiffEqGPU", "DifferentiationInterface", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test", "Zygote"]

--- a/test/suite/extensions/test_gpu_ensemble.jl
+++ b/test/suite/extensions/test_gpu_ensemble.jl
@@ -71,6 +71,11 @@ function test_gpu_ensemble()
                 Test.@test Array(sol.u[i].u[end]) ≈ _expected(i) atol = 1e-5
             end
 
+            # all N trajectories are present and genuinely distinct — guards that `prob_func` /
+            # `remake` actually varied `u0` per trajectory (a silent "all identical" regression)
+            Test.@test length(sol.u) == _N_ENS
+            Test.@test !isapprox(Array(sol.u[1].u[end]), Array(sol.u[2].u[end]); atol=1e-2)
+
             # cross-check against the CPU EnsembleThreads() reference (same problem, host solve)
             csol = SciMLBase.solve(
                 eprob,
@@ -111,6 +116,32 @@ function test_gpu_ensemble()
             for i in 1:_N_ENS
                 Test.@test Array(sol.u[i].u[end]) ≈ _expected(i) atol = 1e-5
             end
+            Test.@test length(sol.u) == _N_ENS
+            Test.@test !isapprox(Array(sol.u[1].u[end]), Array(sol.u[2].u[end]); atol=1e-2)
+        end
+
+        # ================================================================
+        # Float32 end-to-end (GPUs prefer Float32; check the ensemble path preserves eltype
+        #   and does not silently promote to Float64). Mirrors probe Block 5 in the ensemble.
+        # ================================================================
+        Test.@testset "EnsembleGPUArray Float32, eltype preserved" begin
+            f!(du, u, p, t) = (du .= .-u)
+            prob = SciMLBase.ODEProblem(f!, Float32[1, 2], (0.0f0, 1.0f0))
+            eprob = SciMLBase.EnsembleProblem(
+                prob;
+                prob_func=(p, ctx) ->
+                    SciMLBase.remake(p; u0=Float32[ctx.sim_id, 2 * ctx.sim_id]),
+            )
+            sol = SciMLBase.solve(
+                eprob,
+                OrdinaryDiffEqTsit5.Tsit5(),
+                DiffEqGPU.EnsembleGPUArray(CUDA.CUDABackend());
+                trajectories=_N_ENS,
+                save_everystep=false,
+            )
+            Test.@test eltype(sol.u[1].u[end]) == Float32
+            Test.@test Array(sol.u[1].u[end]) ≈ Float32[1, 2] .* Float32(exp(-1)) atol =
+                1.0f-4
         end
     end
     return nothing

--- a/test/suite/extensions/test_gpu_ensemble.jl
+++ b/test/suite/extensions/test_gpu_ensemble.jl
@@ -1,0 +1,122 @@
+"""
+Family-C GPU **ensemble** tooling PoC: solve N independent small ODEs in parallel on a CUDA
+device with `DiffEqGPU`, and pin — on real hardware — which ensemble algorithm works and what
+shape of RHS each one needs. This is a *tooling spike*, NOT a benchmark and NOT yet wired to
+CTFlows `Flow`s (that batched user API is the real Family-C follow-up, design report §8).
+
+Mirrors `probe/gpu/probe_gpu.jl` Block 6 (H200 runs 8–11, both algorithms green):
+  * `EnsembleGPUArray`  — permissive, in-place RHS `f!(du,u,p,t)`, host arrays moved by the algo;
+  * `EnsembleGPUKernel` — kernel-compiled, needs an out-of-place `SVector` RHS, no host closures.
+
+Each trajectory `i` integrates ẋ = -x from a perturbed x0, so x(1) = x0·e⁻¹ — a clean analytic
+reference. The in-place path is additionally cross-checked against a CPU `EnsembleThreads()` solve.
+
+Self-gates on `is_cuda_on()`: on a machine without a functional device it skips cleanly; the real
+run is the `test-gpu-kkt` job on the `kkt` NVIDIA runner (PR label `run ci gpu`). Everything runs
+under `CUDA.allowscalar(false)`.
+
+Accessor discipline (probe runs 9–10): read a trajectory's final state via the raw `.u` field —
+`sol.u[i].u[end]` — never `sol[i][end]`, which is Cartesian tensor indexing into the
+(component × time) shape and silently returns a scalar, not the final state vector.
+"""
+
+module TestGPUEnsemble
+
+using Test: Test
+import CUDA: CUDA
+import SciMLBase: SciMLBase
+import DiffEqGPU: DiffEqGPU
+import OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5   # Tsit5 for the CPU/EnsembleGPUArray paths
+import StaticArrays: StaticArrays                 # SVector for the EnsembleGPUKernel path
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+is_cuda_on() = CUDA.functional()
+
+# N independent trajectories of ẋ = -x, trajectory i starting at [i, 2i] ⇒ x(1) = [i, 2i]·e⁻¹.
+const _N_ENS = 8
+_u0(i) = [Float64(i), 2.0 * i]
+_expected(i) = _u0(i) .* exp(-1.0)
+
+function test_gpu_ensemble()
+    Test.@testset "GPU ensemble (Family-C, DiffEqGPU tooling PoC)" verbose = VERBOSE showtiming =
+        SHOWTIMING begin
+        if !is_cuda_on()
+            @info "CUDA not functional — GPU ensemble tests skipped (run on the kkt runner)"
+            return nothing
+        end
+
+        CUDA.allowscalar(false)  # every ✓ below is genuinely scalar-index-free
+
+        # ================================================================
+        # EnsembleGPUArray — in-place RHS, host u0 moved to device by the algorithm.
+        #   Most permissive path; closest to how a CTFlows in-place RHS functor would plug in.
+        # ================================================================
+        Test.@testset "EnsembleGPUArray (in-place, N=$_N_ENS)" begin
+            f!(du, u, p, t) = (du .= .-u)
+            prob = SciMLBase.ODEProblem(f!, _u0(1), (0.0, 1.0))
+            eprob = SciMLBase.EnsembleProblem(
+                prob; prob_func=(p, ctx) -> SciMLBase.remake(p; u0=_u0(ctx.sim_id))
+            )
+            sol = SciMLBase.solve(
+                eprob,
+                OrdinaryDiffEqTsit5.Tsit5(),
+                DiffEqGPU.EnsembleGPUArray(CUDA.CUDABackend());
+                trajectories=_N_ENS,
+                save_everystep=false,
+            )
+            # each trajectory matches the analytic endpoint
+            for i in 1:_N_ENS
+                Test.@test Array(sol.u[i].u[end]) ≈ _expected(i) atol = 1e-5
+            end
+
+            # cross-check against the CPU EnsembleThreads() reference (same problem, host solve)
+            csol = SciMLBase.solve(
+                eprob,
+                OrdinaryDiffEqTsit5.Tsit5(),
+                SciMLBase.EnsembleThreads();
+                trajectories=_N_ENS,
+                save_everystep=false,
+            )
+            for i in 1:_N_ENS
+                Test.@test Array(sol.u[i].u[end]) ≈ csol.u[i].u[end] atol = 1e-6
+            end
+        end
+
+        # ================================================================
+        # EnsembleGPUKernel — kernel-compiled path: out-of-place SVector RHS, no host-state
+        #   closures. Pins what a GPU-kernel-ready CTFlows RHS would have to satisfy.
+        # ================================================================
+        Test.@testset "EnsembleGPUKernel (out-of-place SVector, N=$_N_ENS)" begin
+            f_oop(u, p, t) = -u
+            u0 = StaticArrays.SVector{2,Float64}(1.0, 2.0)
+            prob = SciMLBase.ODEProblem(f_oop, u0, (0.0, 1.0))
+            eprob = SciMLBase.EnsembleProblem(
+                prob;
+                prob_func=(p, ctx) -> SciMLBase.remake(
+                    p;
+                    u0=StaticArrays.SVector{2,Float64}(
+                        Float64(ctx.sim_id), 2.0 * ctx.sim_id
+                    ),
+                ),
+            )
+            sol = SciMLBase.solve(
+                eprob,
+                DiffEqGPU.GPUTsit5(),
+                DiffEqGPU.EnsembleGPUKernel(CUDA.CUDABackend());
+                trajectories=_N_ENS,
+                save_everystep=false,
+            )
+            for i in 1:_N_ENS
+                Test.@test Array(sol.u[i].u[end]) ≈ _expected(i) atol = 1e-5
+            end
+        end
+    end
+    return nothing
+end
+
+end # module
+
+# CRITICAL: redefine in the outer scope so the runner can call it
+test_gpu_ensemble() = TestGPUEnsemble.test_gpu_ensemble()


### PR DESCRIPTION
## Phase 4b — Family-C ensemble GPU PoC (GPU roadmap-v4 §5)

Pins the **DiffEqGPU ensemble tooling** on the `kkt` H200 runner over N=8 independent small ODEs (ẋ = -x). A tooling spike to establish *which* ensemble algorithm works and *what RHS shape* each needs — **not** a benchmark, and **not** yet wired to CTFlows `Flow`s (the production batch API is a separate Family-C follow-up, design report §8).

Mirrors `probe/gpu/probe_gpu.jl` **Block 6** (H200 runs 8–11, both algorithms already green).

### What's tested (under `CUDA.allowscalar(false)`)
- **EnsembleGPUArray** — in-place RHS `f!(du,u,p,t)`, host `u0` moved by the algorithm; asserted vs the analytic endpoint `x0·e⁻¹` **and** cross-checked against a CPU `EnsembleThreads()` solve of the same `EnsembleProblem`.
- **EnsembleGPUKernel** — kernel-compiled, out-of-place `SVector` RHS + `GPUTsit5`; asserted vs analytic.
- Accessor discipline: final state read as `sol.u[i].u[end]` (raw `.u` field), never `sol[i][end]`.

### Changes
- **NEW** `test/suite/extensions/test_gpu_ensemble.jl` — module `TestGPUEnsemble`, self-gated on `is_cuda_on()` (skips cleanly off-device), `allowscalar(false)`.
- `Project.toml` — `DiffEqGPU = "3"` added to `[extras]`, `[targets].test`, `[compat]` (StaticArrays already present).

No `runtests.jl` change (glob auto-discovery + the CUDA gate already landed in phase 4).

### Validation
- Local (no device): env resolves with `DiffEqGPU="3"` + CUDA 6, file loads and self-skips; **Aqua clean** (11/11).
- Real GPU: the `test-gpu-kkt` job (this PR carries the `run ci gpu` label).

### Out of scope
Production user-facing batch API; `ext/CTFlowsDiffEqGPU`; wiring ensembles to `Flow` constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)