### PR TITLE
feat(gpu): OCP flows on device — AD-free surface (roadmap-v4 §5 phase 4c)

### DIFF
--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -70,15 +70,15 @@ See also: [`CTFlows.Flows.OCPHamiltonianFunction`](@ref).
 function _ocp_H(h::OCPHamiltonianFunction, t, x, p, v)
     if v === nothing
         T = eltype(x)
-        u = Vector{T}(undef, 0)          # empty control (control-free) and variable (Fixed)
-        r = Vector{T}(undef, h.n)
+        u = Systems._buffer_like(x, T, 0)  # empty control (control-free) and variable (Fixed)
+        r = Systems._buffer_like(x, T, h.n)
         h.dynamics!(r, t, x, u, u)       # x passed as-is (scalar for 1-D per convention)
         val = sum(p .* r)
         h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, u))
     else
         T = Base.promote_op(*, eltype(x), eltype(v))
-        u = Vector{T}(undef, 0)          # empty control (control-free)
-        r = Vector{T}(undef, h.n)
+        u = Systems._buffer_like(x, T, 0)  # empty control (control-free)
+        r = Systems._buffer_like(x, T, h.n)
         h.dynamics!(r, t, x, u, v)       # x, v passed as-is
         val = sum(p .* r)
         h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, v))
@@ -194,12 +194,12 @@ See also: [`CTFlows.Flows.OCPPseudoHamiltonianFunction`](@ref).
 function _ocp_pseudo_H(h::OCPPseudoHamiltonianFunction, t, x, p, u, v)
     if v === nothing
         T = Base.promote_op(*, eltype(x), eltype(u))
-        vv = Vector{T}(undef, 0)   # empty variable for Fixed problems
+        vv = Systems._buffer_like(x, T, 0)   # empty variable for Fixed problems
     else
         T = Base.promote_op(*, Base.promote_op(*, eltype(x), eltype(u)), eltype(v))
         vv = v
     end
-    r = Vector{T}(undef, h.n)      # in-place derivative buffer (always length n_x)
+    r = Systems._buffer_like(x, T, h.n)   # in-place derivative buffer (always length n_x)
     h.dynamics!(r, t, x, u, vv)    # x, u, v passed as-is (scalar for 1-D per convention)
     val = sum(p .* r)             # p·f — sum handles scalar p (1-D) or vector p (n-D)
     h.lagrange === nothing || (val += h.sp0 * h.lagrange(t, x, u, vv))
@@ -609,13 +609,13 @@ function _ocp_controlled_vf(h::OCPControlledVectorFieldFunction, t, x, u, v)
     us = h.cu(u)
     if v === nothing
         T = Base.promote_op(*, eltype(xs), eltype(us))
-        vv = Vector{T}(undef, 0)
+        vv = Systems._buffer_like(xs, T, 0)
     else
         vs = h.cv(v)
         T = Base.promote_op(*, Base.promote_op(*, eltype(xs), eltype(us)), eltype(vs))
         vv = vs
     end
-    r = Vector{T}(undef, h.n)
+    r = Systems._buffer_like(xs, T, h.n)
     h.dynamics!(r, t, xs, us, vv)
     return _finalize_vf(r, xs)
 end
@@ -734,15 +734,15 @@ function _ocp_state_vf(h::OCPStateVectorFieldFunction, t, x, v)
     xs = h.cx(x)
     if v === nothing
         T = eltype(xs)
-        u = Vector{T}(undef, 0)
+        u = Systems._buffer_like(xs, T, 0)
         vv = u
     else
         vs = h.cv(v)
         T = Base.promote_op(*, eltype(xs), eltype(vs))
-        u = Vector{T}(undef, 0)
+        u = Systems._buffer_like(xs, T, 0)
         vv = vs
     end
-    r = Vector{T}(undef, h.n)
+    r = Systems._buffer_like(xs, T, h.n)
     h.dynamics!(r, t, xs, u, vv)
     return _finalize_vf(r, xs)
 end

--- a/src/Systems/coercion.jl
+++ b/src/Systems/coercion.jl
@@ -5,22 +5,28 @@
 # =============================================================================
 
 """
-    _safe_only(x::GPUArraysCore.AbstractGPUArray) = GPUArraysCore.@allowscalar only(x)
-    _safe_only(x) = only(x)
+$(TYPEDSIGNATURES)
 
 Collapse a length-1 array to its single scalar element, GPU-safely.
 
-On host arrays this is exactly `only(x)`. On device arrays (`CuArray` and any other
-`GPUArraysCore.AbstractGPUArray`), `only` would resolve via `iterate → getindex`, which
-`GPUArraysCore` blocks by default (scalar indexing of device memory). Since this is a
-single, deliberate, O(1) terminal extraction — not a scalar loop — it is wrapped in
-`@allowscalar`, which permits exactly this one read. Dispatch is on the **array actually
-received at the call site**, so the "1-D = scalar" convention returns an identical host
-scalar on CPU and GPU (never a device 1-vector), preserving CPU/GPU uniformity.
+# Arguments
+- `x::GPUArraysCore.AbstractGPUArray`: device-resident array whose single element is extracted.
+- `x`: any other length-1 collection (host arrays, etc.).
 
-This is backend-agnostic (`AbstractGPUArray` covers CUDA/AMDGPU/Metal) and, on the RHS hot
-path, only ever runs for the degenerate length-1-on-GPU case (real GPU workloads have
-`length ≥ 2`, where [`CTFlows.Systems._coerce_state`](@ref) returns `identity` at zero cost).
+# Returns
+- The single scalar element of `x` (a host scalar on both CPU and GPU).
+
+# Notes
+- On host arrays this is exactly `only(x)`.
+- On device arrays, `only` would resolve via `iterate → getindex`, which `GPUArraysCore`
+  blocks by default (scalar indexing of device memory). Since this is a single, deliberate,
+  O(1) terminal extraction — not a scalar loop — it is wrapped in `@allowscalar`.
+- Dispatch is on the **array actually received at the call site**, so the "1-D = scalar"
+  convention returns an identical host scalar on CPU and GPU (never a device 1-vector).
+- Backend-agnostic (`AbstractGPUArray` covers CUDA/AMDGPU/Metal).
+- On the RHS hot path, only ever runs for the degenerate length-1-on-GPU case (real GPU
+  workloads have `length ≥ 2`, where [`CTFlows.Systems._coerce_state`](@ref) returns
+  `identity` at zero cost).
 
 See also: [`CTFlows.Systems._coerce_state`](@ref).
 """
@@ -28,20 +34,29 @@ _safe_only(x::GPUArraysCore.AbstractGPUArray) = GPUArraysCore.@allowscalar only(
 _safe_only(x) = only(x)
 
 """
-    _device_like(dst, src)
+$(TYPEDSIGNATURES)
 
 Return `src` in a form that can be broadcast into `dst` without a device/host mismatch.
 
-Augmented Hamiltonian flows split into `[∂p; -∂x; -∂pv]`; on GPU the state blocks
-`∂x`/`∂p` are device-resident (built from a device state) but `∂pv = -∂H/∂v` is **host**
-(the variable `v` transits host-side, per the D4 rule), so broadcasting it into a device
-`du` slice wraps a non-`isbits` host `Vector` in a `Broadcasted` and fails to compile
-(`GPUCompiler.KernelError`). `_device_like` copies **only** that host block onto the device
-matching `dst`; on host, and for already-device blocks, it is the identity (no copy).
+# Arguments
+- `dst`: the destination array whose device determines the required location.
+- `src`: the source block to broadcast into `dst`.
 
-Dispatch is on the array actually received at the call site, so CPU behaviour is byte-for-byte
-unchanged and only the degenerate device-`dst`/host-`src` case pays a tiny `O(n_v)` H2D copy.
-Backend-agnostic (`GPUArraysCore.AbstractGPUArray` covers CUDA/AMDGPU/Metal).
+# Returns
+- `src` itself when it is already compatible with `dst` (host/host, device/device, or scalar).
+- A device-resident copy of `src` when `dst` is a device array and `src` is a host array.
+
+# Notes
+- Augmented Hamiltonian flows split into `[∂p; -∂x; -∂pv]`; on GPU the state blocks
+  `∂x`/`∂p` are device-resident but `∂pv = -∂H/∂v` is **host** (the variable `v` transits
+  host-side), so broadcasting it into a device `du` slice wraps a non-`isbits` host `Vector`
+  in a `Broadcasted` and fails to compile (`GPUCompiler.KernelError`).
+- `_device_like` copies **only** that host block onto the device matching `dst`; on host,
+  and for already-device blocks, it is the identity (no copy).
+- Dispatch is on the array actually received at the call site, so CPU behaviour is
+  byte-for-byte unchanged and only the degenerate device-`dst`/host-`src` case pays a tiny
+  `O(n_v)` H2D copy.
+- Backend-agnostic (`GPUArraysCore.AbstractGPUArray` covers CUDA/AMDGPU/Metal).
 
 See also: [`CTFlows.Systems._aug_assign!`](@ref), [`CTFlows.Systems._safe_only`](@ref).
 """
@@ -51,3 +66,36 @@ _device_like(::GPUArraysCore.AbstractGPUArray, src::GPUArraysCore.AbstractGPUArr
 function _device_like(dst::GPUArraysCore.AbstractGPUArray, src::AbstractArray)
     return copyto!(similar(dst, eltype(src), size(src)), src)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Allocate an uninitialised length-`n` buffer of eltype `T` in `template`'s array type.
+
+# Arguments
+- `template`: an array or scalar whose type determines the buffer's array backend.
+- `T`: the element type of the buffer.
+- `n::Int`: the length of the buffer.
+
+# Returns
+- For `template::AbstractArray`: `similar(template, T, n)` — same array backend as `template`.
+- For any other `template` (e.g. `Number`): `Vector{T}(undef, n)` — a host vector.
+
+# Notes
+- The OCP right-hand sides fill a length-`n_x` buffer through the **in-place** dynamics
+  `dynamics!(r, t, x, u, v)`, plus empty `u`/`v` buffers for control-free / `Fixed` problems.
+  Allocating those as a host `Vector` pins the whole OCP hot path to the CPU; deriving them
+  from the state instead keeps the buffer on whichever device the state already lives on.
+- The `Number` fallback is required, not defensive: under the "1-D = scalar" convention the
+  coerced state is a scalar (via [`CTFlows.Systems._safe_only`](@ref) for a declared dimension
+  of 1), and `similar` is undefined for `Number`. A scalar state is a **host** scalar even on
+  GPU, so a host `Vector` is the correct buffer there.
+- This generalises the same `isa AbstractArray` branch already used for `pv0` in
+  `CTFlows.Flows` augmented initial conditions.
+- Dispatch is on the value actually received at the call site, so CPU behaviour is
+  byte-for-byte unchanged and no run-time type test enters the hot path.
+
+See also: [`CTFlows.Systems._device_like`](@ref), [`CTFlows.Systems._safe_only`](@ref).
+"""
+_buffer_like(template::AbstractArray, ::Type{T}, n::Int) where {T} = similar(template, T, n)
+_buffer_like(::Any, ::Type{T}, n::Int) where {T} = Vector{T}(undef, n)

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -11,8 +11,14 @@ NVIDIA runner (PR label `run ci gpu`).
 GPU-friendly test integrands use `sum`/`dot`/broadcasts, never scalar indexing (`v[i]`, `x[i]`)
 — a device scalar read is blocked by `allowscalar(false)` (probe run 4/5).
 
-Out of scope here: `Flow(ocp, …)` on device (phase 4c — OCP host-buffers + CTModels `dynamics!`
-gate) and the ensemble path (phase 4b).
+Phase 4c adds the **AD-free** OCP surface: `Flow(ocp)`'s state flow (no costate) and
+`Flow(ocp, OpenLoop/ClosedLoop)`. The AD-dependent OCP surface (`Flow(ocp)` Hamiltonian,
+`Flow(ocp, DynClosedLoop)`) is **deferred**: those right-hand sides fill a buffer through
+CTModels' in-place `dynamics!`, and Zygote — the `method=:gpu` AD default — cannot
+differentiate array mutation. That gate fails on CPU too, so it is an AD-architecture issue,
+not a GPU one; the negative row below documents it.
+
+Out of scope here: the ensemble path (phase 4b, `test_gpu_ensemble.jl`).
 """
 
 module TestGPUFlows
@@ -21,6 +27,7 @@ using Test: Test
 import CUDA: CUDA
 import CTBase.Data: Data
 import CTFlows.Flows: Flows
+import CTModels: CTModels
 import ADTypes: ADTypes
 import SciMLBase: SciMLBase
 import Zygote: Zygote  # loads the Zygote backend so the AutoZygote GPU AD default can differentiate
@@ -41,6 +48,44 @@ const _S1 = sin(1.0)
 #   x(1) = [cos1,  sin1],  p(1) = [-sin1, cos1]
 const _OSC_X = [_C1, _S1]
 const _OSC_P = [-_S1, _C1]
+
+# =============================================================================
+# OCP fixtures (module top-level, per the repo convention)
+#
+# GPU-friendly dynamics: the RHS is written as a BROADCAST (`r .= .-x`), never with
+# component-wise scalar writes (`r[1] = x[2]`). CTModels itself is device-clean — it only
+# ever hands the user closure a contiguous `@view` of the buffer — so the whole GPU-safety
+# burden sits in the user's `dynamics!` body. The canonical docs idiom (`r[1] = …`) would
+# scalar-index a device buffer and fail here; this is the contract phase 5 documents.
+# =============================================================================
+
+# control-free, autonomous, fixed, 2-D: ẋ = -x ⇒ x(1) = x0·e⁻¹
+function _build_gpu_cf_ocp()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= .-x; nothing))
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    return CTModels.Building.build(pre)
+end
+
+# with-control, autonomous, fixed, 2-D: ẋ = -x + u. The control dimension is 1, so CTFlows
+# coerces `u` to a SCALAR before calling the dynamics (1-D = scalar), which broadcasts
+# cleanly against a device state. With the ClosedLoop law u ≡ 0 the reference is x0·e⁻¹.
+function _build_gpu_ctrl_ocp()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= .-x .+ u; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.0)
+    return CTModels.Building.build(pre)
+end
+
+const OCP_GPU_CF = _build_gpu_cf_ocp()
+const OCP_GPU_CTRL = _build_gpu_ctrl_ocp()
 
 function test_gpu_flows()
     Test.@testset "GPU flows (Family-B, device execution)" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -211,6 +256,49 @@ function test_gpu_flows()
             x_mid = [1.0, 2.0] .* exp(-0.5) .+ 0.1
             x_ref = x_mid .* exp(-0.5)
             Test.@test Array(xf) ≈ x_ref atol = 1e-6
+        end
+
+        # ================================================================
+        # OCP flows on device (phase 4c) — the AD-FREE surface only.
+        #   Exercises the `_buffer_like` migration: the in-place `dynamics!` buffer is
+        #   now allocated from the state, so a device state yields a device buffer.
+        # ================================================================
+
+        Test.@testset "Flow(ocp) state flow (no costate) on device" begin
+            f = Flows.Flow(OCP_GPU_CF)
+            xf = f(0.0, _dev([1.0, 2.0]), 1.0)          # basic call: no p0
+            Test.@test xf isa CUDA.CuArray               # buffer stayed on device
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+        end
+
+        Test.@testset "Flow(ocp) state trajectory on device" begin
+            # The tspan call returns a StateFlowTrajectory (NOT a CTModels.Solution), so it
+            # does not cross the host-pinned `build_solution` boundary.
+            f = Flows.Flow(OCP_GPU_CF)
+            traj = f((0.0, 1.0), _dev([1.0, 2.0]))
+            Test.@test traj !== nothing
+        end
+
+        Test.@testset "Flow(ocp, ClosedLoop) on device" begin
+            # ClosedLoop ⇒ AD-free controlled state flow through `_ocp_controlled_vf`.
+            # u ≡ 0, so ẋ = -x and the reference is the same exponential decay.
+            f = Flows.Flow(OCP_GPU_CTRL, Data.ClosedLoop(x -> 0.0))
+            xf = f(0.0, _dev([1.0, 2.0]), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+        end
+
+        # The AD-dependent OCP surface is DEFERRED, and the reason is not GPU-specific:
+        # `_ocp_H` fills its buffer through CTModels' in-place `dynamics!`, and Zygote (the
+        # `method=:gpu` AD default, phase 1b) cannot differentiate array mutation — it throws
+        # "Mutating arrays is not supported". This reproduces on CPU; the row records the gate
+        # so a future fix (Enzyme, Zygote.Buffer, or an out-of-place dynamics contract) flips
+        # it deliberately rather than silently.
+        Test.@testset "Flow(ocp) Hamiltonian on device — deferred (AD/mutation gate)" begin
+            f = Flows.Flow(OCP_GPU_CF; method=:gpu)
+            Test.@test_throws Exception f(
+                0.0, _dev([1.0, 2.0]), _dev([0.0, 0.0]), 1.0
+            )
         end
     end
     return nothing

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -27,6 +27,7 @@ using Test: Test
 import CUDA: CUDA
 import CTBase.Data: Data
 import CTFlows.Flows: Flows
+import CTFlows.Trajectories: Trajectories
 import CTModels: CTModels
 import ADTypes: ADTypes
 import SciMLBase: SciMLBase
@@ -60,13 +61,19 @@ const _OSC_P = [-_S1, _C1]
 # =============================================================================
 
 # control-free, autonomous, fixed, 2-D: ẋ = -x ⇒ x(1) = x0·e⁻¹
+#
+# The MAYER term must be device-safe too, not just the dynamics: a trajectory call evaluates
+# it as `may(x(t0), x(tf), v)` (`ocp_readouts.jl:48`) with the flow's own — here device —
+# endpoints. The natural `xf[1]` scalar-indexes a `CuArray` and is rejected under
+# `allowscalar(false)`; `sum` is a reduction and stays on device.
+# ⇒ objective = sum(x(1)) = (1+2)·e⁻¹.
 function _build_gpu_cf_ocp()
     pre = CTModels.Building.PreModel()
     CTModels.Building.time_dependence!(pre; autonomous=true)
     CTModels.Building.time!(pre; t0=0.0, tf=1.0)
     CTModels.Building.state!(pre, 2)
     CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r .= .-x; nothing))
-    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
+    CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> sum(xf))
     return CTModels.Building.build(pre)
 end
 
@@ -273,10 +280,13 @@ function test_gpu_flows()
 
         Test.@testset "Flow(ocp) state trajectory on device" begin
             # The tspan call returns a StateFlowTrajectory (NOT a CTModels.Solution), so it
-            # does not cross the host-pinned `build_solution` boundary.
+            # does not cross the host-pinned `build_solution` boundary. It DOES evaluate the
+            # Mayer objective on the device endpoints, so this row also covers the
+            # `_flow_objective` Mayer path (mayer = sum(xf) ⇒ (1+2)·e⁻¹).
             f = Flows.Flow(OCP_GPU_CF)
             traj = f((0.0, 1.0), _dev([1.0, 2.0]))
             Test.@test traj !== nothing
+            Test.@test Trajectories.objective(traj) ≈ 3.0 * _E1 atol = 1e-6
         end
 
         Test.@testset "Flow(ocp, ClosedLoop) on device" begin

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -451,6 +451,60 @@ function test_hamiltonian_vector_field_system()
         end
 
         # ====================================================================
+        # UNIT TESTS - _buffer_like (phase 4c: device-preserving RHS buffers)
+        #   The OCP right-hand sides allocate their in-place `dynamics!` buffer from the
+        #   state; `_buffer_like` keeps it on whichever device the state lives on, while
+        #   falling back to a host Vector for the 1-D = scalar convention.
+        # ====================================================================
+
+        Test.@testset "_buffer_like" begin
+            Test.@testset "host array template → host Vector" begin
+                b = Systems._buffer_like([1.0, 2.0, 3.0], Float64, 3)
+                Test.@test b isa Vector{Float64}
+                Test.@test length(b) == 3
+                # eltype is the requested one, not the template's (AD promotes it)
+                Test.@test Systems._buffer_like([1.0, 2.0], Float32, 2) isa Vector{Float32}
+                # length 0 is a valid request (empty control / variable buffers)
+                Test.@test isempty(Systems._buffer_like([1.0], Float64, 0))
+            end
+
+            # 1-D = scalar: `cx === _safe_only` yields a Number, for which `similar` is
+            # undefined — the Number fallback must produce a host Vector.
+            Test.@testset "scalar template → host Vector" begin
+                b = Systems._buffer_like(2.5, Float64, 3)
+                Test.@test b isa Vector{Float64}
+                Test.@test length(b) == 3
+                Test.@test isempty(Systems._buffer_like(2.5, Float64, 0))
+            end
+
+            # A view is what the OCP RHS actually receives (the state is a SubArray of the
+            # integrator's augmented buffer): `similar` must still give a plain host Vector,
+            # i.e. allocation-identical to the pre-4c `Vector{T}(undef, n)`.
+            Test.@testset "SubArray template → host Vector" begin
+                v = view([1.0, 2.0, 3.0, 4.0], 2:3)
+                b = Systems._buffer_like(v, Float64, 3)
+                Test.@test b isa Vector{Float64}
+                Test.@test length(b) == 3
+            end
+
+            # device template → device buffer: this is the whole point of the helper, and
+            # what makes `Flow(ocp, …)` runnable on a device state.
+            Test.@testset "device template → device buffer" begin
+                b = Systems._buffer_like(FakeGPUArray([1.0, 2.0]), Float64, 2)
+                Test.@test b isa FakeGPUArray
+                Test.@test length(b) == 2
+                Test.@test eltype(b) == Float64
+                # eltype follows the request (AD duals), not the template
+                Test.@test eltype(Systems._buffer_like(FakeGPUArray([1.0]), Float32, 1)) ==
+                    Float32
+                # the empty control/variable buffers must be device-typed too, otherwise a
+                # host Vector enters a device broadcast (GPUCompiler.KernelError)
+                Test.@test Systems._buffer_like(FakeGPUArray([1.0]), Float64, 0) isa
+                    FakeGPUArray
+            end
+        end
+
+        # ====================================================================
         # UNIT TESTS - get_ip_rhs_augmented (just verify it builds without error)
         # ====================================================================
 


### PR DESCRIPTION
GPU roadmap **phase 4c**. Depends on phases 2 (#335) and 3 (#336), both merged.

## Summary

Phase 3 deferred the OCP hot-path host buffers, so phase 4 dropped its `Flow(ocp, law)` device row. This closes the gap for the **AD-free** half of the OCP surface.

- **New `Systems._buffer_like(template, T, n)`** ([coercion.jl](src/Systems/coercion.jl)) — allocates the in-place `dynamics!` buffer in the state's array type, so a device state yields a device buffer. The array method uses `similar`; the `Number` fallback is *required, not defensive*: under the 1-D = scalar convention the coerced state is a scalar and `similar` is undefined for `Number`. Generalises the existing `calling.jl:519` idiom.
- **11 RHS allocation sites migrated** in [optimal_control_flow.jl](src/Flows/optimal_control_flow.jl) (`_ocp_H`, `_ocp_pseudo_H`, `_ocp_controlled_vf`, `_ocp_state_vf`). The empty control/variable buffers are included: a host `Vector` inside a device broadcast is a `GPUCompiler.KernelError`.
- **Device rows** for `Flow(ocp)` state flow (no costate) and `Flow(ocp, ClosedLoop)` — both AD-free.

## Two findings that revise the master plan

**1. The master plan's second gate is a non-issue — no CTModels PR needed.** CTModels never scalar-indexes the dynamics buffer: `Models.dynamics` (`model.jl:1106`) is a bare field read, and the only buffer touch in the package is `f!(@view(val[rg]), …)` (`Building/dynamics.jl:192`) with `rg` always a contiguous `UnitRange{Int}` — a lazy view, valid on a `CuArray`. The GPU-safety burden is entirely in the **user's** `dynamics!` body, i.e. a phase-5 documentation contract (load-bearing, since the documented idiom `r[1] = x[2]` and the CTParser `@def` path both scalar-index).

**2. The OCP Hamiltonian path is blocked by AD, not GPU — deferred.** `_ocp_H` / `_ocp_pseudo_H` fill their buffer through CTModels' **in-place** `dynamics!`, and Zygote — the `method=:gpu` AD default from phase 1b — cannot differentiate array mutation (`Mutating arrays is not supported`). Verified **on CPU**, so no buffer fix can lift it. A documented `@test_throws` row records the gate so a future fix (Enzyme, `Zygote.Buffer`, or an out-of-place dynamics contract) flips it deliberately rather than silently.

Gate 1 was also larger than stated: 11 sites, not 5, and the suggested `similar(xs, …)` is not a safe drop-in (the `Number` case).

## Performance — no regression

`Flow(ocp, u::Function)` is the DynClosedLoop path, i.e. `_ocp_pseudo_H` in the hot RHS under ForwardDiff — precisely a migrated site. Goddard benchmark (`.extras/bench-ctflows-latest/goddard-latest.jl`, 4-arc concatenated flow with a state constraint), before vs after:

| Metric | before | after |
|---|---|---|
| Trajectory memory | 8.720611572265625 MiB | **identical** |
| Trajectory allocations | 74451 | **74451** |
| State/costate at `tf`, arc-1 endpoints | — | **identical to the last digit** |

Free because the OCP RHS receives the state as a `SubArray` (a view into the integrator's augmented buffer), and `similar(::SubArray, T, n)` allocates the very same plain `Vector{T}` that `Vector{T}(undef, n)` did.

## Test plan

- [x] Full CTFlows suite: **2868/2868**, Aqua included.
- [x] `test_gpu_flows.jl` loads and skips cleanly with CUDA non-functional.
- [x] Goddard perf/memory guard above.
- [ ] **Real GPU:** needs the `run ci gpu` label (user-triggered) → `test-gpu-kkt` on the `kkt` runner, which exercises the new OCP device rows under `CUDA.allowscalar(false)`.

**Public API change:** none — internal correctness/hygiene, CPU byte-for-byte unchanged. Single package, no CTModels changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)