### PR TITLE
test(objective): assert objective values across Mayer/Lagrange/Bolza

### DIFF
--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -111,6 +111,53 @@ function _build_ocp_nonauton_fixed_mayer()
     return CTModels.Building.build(pre)
 end
 
+# ── objective-coverage fixtures ──────────────────────────────────────────────
+# The Mayer/Lagrange/Bolza trio was covered only for the autonomous / fixed-time / SCALAR-state
+# family. These three extend it to the families that had Mayer only (variable, non-autonomous)
+# plus a vector state, which had no objective coverage at all. Every analytic reference below is
+# derived in closed form AND was reconciled numerically against the flow before being committed.
+
+# autonomous, non-fixed (variable), Lagrange: ẋ = v·x, ℓ = x² ⇒ ∫₀ᵀ x0²e^{2vt}dt
+function _build_ocp_auton_nonfixed_lagrange()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.variable!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, v) -> (r[1]=v[1] * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(_, x, _, _) -> x[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# non-autonomous, fixed, Lagrange: ẋ = t·x, ℓ = t·x².
+# ℓ = x² would give ∫e^{t²}dt — no elementary closed form (erfi). With the t factor,
+# d(x²)/dt = 2t·x², so the integral telescopes to (x(tf)² − x0²)/2 — exact and x-dependent.
+function _build_ocp_nonauton_fixed_lagrange()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=false)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, _, _) -> (r[1]=t * x[1]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, _, _) -> t * x[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# VECTOR state (n = 2), Bolza: ẋ = λx componentwise, mayer = Σxf, ℓ = Σx²
+function _build_ocp_vector_bolza()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.dynamics!(pre, (r, _, x, _, _) -> (r .= λ_TEST .* x; nothing))
+    CTModels.Building.objective!(
+        pre,
+        :min;
+        mayer=(x0, xf, v) -> sum(xf),
+        lagrange=(_, x, _, _) -> sum(abs2, x),
+    )
+    return CTModels.Building.build(pre)
+end
+
 # with-control OCP (control! called) → WithControl trait, unsupported by Flow(ocp)
 function _build_ocp_with_control()
     pre = CTModels.Building.PreModel()
@@ -133,6 +180,9 @@ const OCP_AF_BOLZA = _build_ocp_auton_fixed_bolza()
 const OCP_ANF_MAYER = _build_ocp_auton_nonfixed_mayer()
 const OCP_NAF_MAYER = _build_ocp_nonauton_fixed_mayer()
 const OCP_WITH_CTRL = _build_ocp_with_control()
+const OCP_ANF_LAG = _build_ocp_auton_nonfixed_lagrange()
+const OCP_NAF_LAG = _build_ocp_nonauton_fixed_lagrange()
+const OCP_VEC_BOLZA = _build_ocp_vector_bolza()
 
 # Pre-built flows (all via generic HamiltonianSystem — OCP rides the generic path)
 const FLOW_AF = Flows.build_flow(
@@ -160,6 +210,15 @@ _lag_obj(T, x0) = x0^2 * (exp(2λ_TEST * T) - 1) / (2λ_TEST)
 _may_obj(T, x0) = x0 * exp(λ_TEST * T)
 
 _xna_ref(t, t0, x0) = x0 * exp((t^2 - t0^2) / 2)  # ẋ=t·x
+
+# Objective references for the extended families (each reconciled numerically before committing).
+# variable: ẋ = v·x, ℓ = x²  ⇒  ∫₀ᵀ x0² e^{2vt} dt
+_lag_obj_var(T, x0, v) = x0^2 * (exp(2 * v * T) - 1) / (2 * v)
+# non-autonomous: ẋ = t·x, ℓ = t·x²  ⇒  ½[x²] = (x(tf)² − x0²)/2
+_lag_obj_na(tf, t0, x0) = (_xna_ref(tf, t0, x0)^2 - x0^2) / 2
+# vector state: ẋ = λx, mayer = Σxf, ℓ = Σx²  (Σ over components; both terms scale as the scalar case)
+_may_obj_vec(T, x0) = sum(x0) * exp(λ_TEST * T)
+_lag_obj_vec(T, x0) = sum(abs2, x0) * (exp(2λ_TEST * T) - 1) / (2λ_TEST)
 
 # =============================================================================
 
@@ -397,6 +456,49 @@ function test_optimal_control_flow()
             sol = ocf_bolza((t0, tf), x0, p0)
             expected = _may_obj(tf - t0, x0) + _lag_obj(tf - t0, x0)
             Test.@test CTModels.Components.objective(sol) ≈ expected atol=ATOL
+        end
+
+        # ── objective coverage beyond the autonomous/fixed/scalar family ──────
+        # The trio above pinned only ONE OCP family. The objective path also runs for problems
+        # with a variable, with explicit time dependence, and with a vector state — none of which
+        # were covered. `_ocp_hamiltonian` + `_flow_objective` are shared by all of them, so a
+        # regression in the Lagrange quadrature would previously have been caught in one shape only.
+
+        Test.@testset "Integration: Lagrange objective ≈ analytic — with variable" begin
+            flow = Flows.build_flow(
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_ANF_LAG), DI_BACKEND), INTEG
+            )
+            ocf = Flows.OptimalControlFlow(flow, OCP_ANF_LAG)
+            t0, tf = 0.0, 1.0
+            x0, p0, v = 1.0, 0.5, 1.5
+            sol = ocf((t0, tf), x0, p0; variable=v)
+            Test.@test CTModels.Components.objective(sol) ≈ _lag_obj_var(tf - t0, x0, v) atol =
+                ATOL
+        end
+
+        Test.@testset "Integration: Lagrange objective ≈ analytic — non-autonomous" begin
+            flow = Flows.build_flow(
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_NAF_LAG), DI_BACKEND), INTEG
+            )
+            ocf = Flows.OptimalControlFlow(flow, OCP_NAF_LAG)
+            t0, tf = 0.0, 1.0
+            x0, p0 = 1.0, 0.5
+            sol = ocf((t0, tf), x0, p0)
+            Test.@test CTModels.Components.objective(sol) ≈ _lag_obj_na(tf, t0, x0) atol = ATOL
+        end
+
+        Test.@testset "Integration: Bolza objective ≈ analytic — vector state" begin
+            flow = Flows.build_flow(
+                Systems.build_system(Flows._ocp_hamiltonian(OCP_VEC_BOLZA), DI_BACKEND),
+                INTEG,
+            )
+            ocf = Flows.OptimalControlFlow(flow, OCP_VEC_BOLZA)
+            t0, tf = 0.0, 1.0
+            x0, p0 = [1.0, 2.0], [0.5, 0.25]
+            sol = ocf((t0, tf), x0, p0)
+            expected = _may_obj_vec(tf - t0, x0) + _lag_obj_vec(tf - t0, x0)
+            # the vector Bolza value is ~89, so a relative tolerance is the meaningful check here
+            Test.@test CTModels.Components.objective(sol) ≈ expected rtol = 1e-6
         end
 
         # ── cross-check: OCP flow vs generic HamiltonianSystem ────────────────

--- a/test/suite/integration/test_double_integrator_energy.jl
+++ b/test/suite/integration/test_double_integrator_energy.jl
@@ -74,6 +74,12 @@ function test_double_integrator_energy()
             sol = f((_T0, _TF), _X0, ξ_opt)
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) > 0   # ∫0.5u² > 0
+            # Analytic value, derived from the closed-form costate documented above:
+            # u*(t) = p2(t) = p20 - p10·t = 6 - 12t, so
+            #   J = ½∫₀¹(6-12t)² dt = ½∫₀¹(36 - 144t + 144t²) dt = ½(36 - 72 + 48) = 6.
+            # Cross-checked against CTProblems.jl `DoubleIntegratorEnergy`, which states the
+            # same value as ½(α²T³/3 + β²T - αβT²) with α = 12, β = 6, T = 1.
+            Test.@test CTModels.objective(sol) ≈ 6.0 rtol = 1e-8
         end
     end
 end

--- a/test/suite/integration/test_double_integrator_energy_distance.jl
+++ b/test/suite/integration/test_double_integrator_energy_distance.jl
@@ -74,6 +74,10 @@ function test_double_integrator_energy_distance()
             sol = f((_T0, _TF), _X0, ξ_opt)
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) < 0   # -0.5x₁(tf) + ∫0.5u² < 0
+            # ANALYTIC. CTProblems.jl `DoubleIntegratorEnergyDistance` gives the closed form
+            #   J* = -0.5·x₁(tf) + tf³/24  with  x₁(tf) = tf²/12·(3tf - tf) = 1/6  at tf = 1,
+            # hence J* = -1/12 + 1/24 = -1/24. Matches the integrated value to ~1e-15.
+            Test.@test CTModels.objective(sol) ≈ -1 / 24 rtol = 1e-6
         end
     end
 end

--- a/test/suite/integration/test_double_integrator_state.jl
+++ b/test/suite/integration/test_double_integrator_state.jl
@@ -116,6 +116,10 @@ function test_double_integrator_state()
             _u(t) = uu(t) isa Number ? uu(t) : uu(t)[1]
             # No boundary arc: control is non-zero on both sides of t1
             Test.@test abs(_u(0.25)) > 1e-3
+            # PINNED REFERENCE — regression guard, NOT a derived optimum. CTProblems.jl gives
+            # J* = 4/(9a), but explicitly only for a ≤ 1/6 (the three-arc case); a = 0.2 is the
+            # two-arc touch-point regime, outside that formula (4/(9·0.2) = 2.222 ≠ 2.24).
+            Test.@test CTModels.objective(sol) ≈ 2.24 rtol = 1e-6
             Test.@test abs(_u(0.75)) > 1e-3
             Test.@test CTModels.objective(sol) > 0
         end
@@ -214,6 +218,9 @@ function test_double_integrator_state()
             Test.@test abs(_u(0.5 * (t1_sol + t2_sol))) < 1e-6      # boundary midpoint
             Test.@test abs(_u(0.5 * t1_sol)) > 1e-3                 # interior arc 1
             Test.@test CTModels.objective(sol) > 0                  # ∫0.5u² > 0
+            # ANALYTIC. CTProblems.jl `DoubleIntegratorEnergyStateConstraint` gives J* = 4/(9a)
+            # for the three-arc case a ≤ 1/6; here a = 0.1, so J* = 40/9.
+            Test.@test CTModels.objective(sol) ≈ 4 / (9 * 0.1) rtol = 1e-6
         end
     end
 end

--- a/test/suite/integration/test_double_integrator_state_first_order.jl
+++ b/test/suite/integration/test_double_integrator_state_first_order.jl
@@ -119,6 +119,8 @@ function test_double_integrator_state_first_order()
                 # Interior arc: u = p₂ ≠ 0
                 Test.@test abs(_u(0.5 * t1)) > 1e-3
                 Test.@test CTModels.objective(sol) > 0
+                # PINNED REFERENCE — regression guard, NOT a derived optimum (sits on 7.68 to ~5e-12).
+                Test.@test CTModels.objective(sol) ≈ 7.68 rtol = 1e-6
             end
         end
     end

--- a/test/suite/integration/test_lqr_ricatti.jl
+++ b/test/suite/integration/test_lqr_ricatti.jl
@@ -77,6 +77,10 @@ function test_lqr_ricatti()
             sol = f((_T0, _TF), _X0, ξ_opt)
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) > 0
+            # PINNED REFERENCE — regression guard, NOT a derived optimum. CTProblems.jl also
+            # marks this problem `:numerical` and obtains its objective by integrating the
+            # Riccati ODE, so there is no closed form to check against.
+            Test.@test CTModels.objective(sol) ≈ 0.6739990459 rtol = 1e-6
         end
     end
 end

--- a/test/suite/integration/test_simple_exponential_energy.jl
+++ b/test/suite/integration/test_simple_exponential_energy.jl
@@ -73,6 +73,9 @@ function test_simple_exponential_energy()
             sol = f((_T0, _TF), _X0, ξ_opt[1])
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) > 0   # ∫0.5u² > 0
+            # ANALYTIC. CTProblems.jl `SimpleExponentialEnergy` gives J* = (e² - 1)·p0²/4
+            # with p0 = exp(-tf)/sinh(tf) — the same p0 already asserted above.
+            Test.@test CTModels.objective(sol) ≈ (exp(2.0) - 1) * _P0_SOL^2 / 4 rtol = 1e-6
         end
     end
 end

--- a/test/suite/integration/test_simple_integrator_energy_free_tf.jl
+++ b/test/suite/integration/test_simple_integrator_energy_free_tf.jl
@@ -87,6 +87,9 @@ function test_simple_integrator_energy_free_tf()
             sol = f((_T0, ξ_opt[2]), _X0, ξ_opt[1]; variable=ξ_opt[2])
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) > 0   # ∫0.5u² > 0
+            # ANALYTIC. CTProblems.jl `SimpleIntegratorEnergyFreeTf` gives J* = (tf+10)²/(2tf),
+            # which at the closed-form tf = 10 is 400/20 = 20.
+            Test.@test CTModels.objective(sol) ≈ (_TF_SOL + 10)^2 / (2 * _TF_SOL) rtol = 1e-6
         end
     end
 end

--- a/test/suite/integration/test_simple_integrator_lqr_free_tf.jl
+++ b/test/suite/integration/test_simple_integrator_lqr_free_tf.jl
@@ -81,6 +81,10 @@ function test_simple_integrator_lqr_free_tf()
             sol = f((_T0, ξ_opt[2]), _X0, ξ_opt[1]; variable=ξ_opt[2])
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) > 0   # tf + ∫0.5(u²+x²) > 0
+            # ANALYTIC. CTProblems.jl `SimpleIntegratorLqrFreeTf` gives the Bolza value
+            # J* = tf + 0.5·xf²/tanh(tf), evaluated at the closed-form tf = atanh(1/√3).
+            Test.@test CTModels.objective(sol) ≈ _TF_SOL + 0.5 * _XF^2 / tanh(_TF_SOL) rtol =
+                1e-6
         end
     end
 end

--- a/test/suite/integration/test_simple_integrator_mixed_constraint.jl
+++ b/test/suite/integration/test_simple_integrator_mixed_constraint.jl
@@ -88,6 +88,9 @@ function test_simple_integrator_mixed_constraint()
             sol = f((_T0, _TF), _X0, ξ_opt)
             Test.@test sol isa CTModels.Solutions.Solution
             Test.@test CTModels.objective(sol) < 0   # ∫(-u) = exp(-1) - 1 < 0
+            # The closed form asserted in the comment above, now actually checked:
+            # measured exp(-1) - 1 = -0.6321205588285526 vs analytic -0.6321205588285577.
+            Test.@test CTModels.objective(sol) ≈ exp(-1) - 1 rtol = 1e-8
         end
     end
 end

--- a/test/suite/integration/test_singular_control.jl
+++ b/test/suite/integration/test_singular_control.jl
@@ -123,6 +123,8 @@ function test_singular_control()
                 sol = f((_T0, _TF_SOL), [0.0, 0.0, _TH0_SOL], _P0_SOL; variable=_TF_SOL)
                 Test.@test sol isa CTModels.Solutions.Solution
                 Test.@test CTModels.objective(sol) > 0
+                # PINNED REFERENCE — regression guard, NOT a derived optimum (no closed form used).
+                Test.@test CTModels.objective(sol) ≈ 1.1497308858 rtol = 1e-6
             end
         end
     end


### PR DESCRIPTION
Phase 4d, PR 1 of 2 (roadmap-v4 §5 workstream). **No `src/` change** — that is the point: these assertions must be green *before* the scalar cost-state switch, so PR 2 can prove that switch is value-neutral.

## Why

Auditing the OCP objective path during phase 4c surfaced two gaps:

- **Unit:** the analytic Mayer/Lagrange/Bolza trio covered only the *autonomous / fixed-time / scalar-state* family. Fixtures for the variable and non-autonomous families carried **Mayer only**, and every fixture in the file was `state!(pre, 1)` — no vector-state objective coverage at all.
- **Integration:** of 25 files, 13 assert no objective, **11 asserted only a sign**, 2 were analytic.

## What changed

### Unit — `test/suite/extensions/test_optimal_control_flow.jl`

Three families added: variable, non-autonomous, and vector-state. Every reference was derived and **reconciled numerically against the flow before being written**.

One modelling note: for the non-autonomous family, `ℓ = x²` would integrate to `∫e^{t²}dt` (erfi — no elementary closed form). `ℓ = t·x²` is used instead; it telescopes exactly to `(x(tf)² − x0²)/2`.

### Integration — 7 analytic, 4 pinned

Five closed forms come from [CTProblems.jl](https://github.com/control-toolbox/CTProblems.jl) and are written as **expressions, not literals**, so the formula is visible in the test:

| Test | Closed form | Value |
|---|---|---|
| `simple_exponential_energy` | `(e²−1)·p0²/4` | `0.1565176427496657` |
| `simple_integrator_lqr_free_tf` | `tf + xf²/(2·tanh tf)` | `1.524504352246847` |
| `simple_integrator_energy_free_tf` | `(tf+10)²/(2tf)` | `20.0` |
| `double_integrator_energy_distance` | `−x₁(tf)/2 + tf³/24` | `−1/24` |
| `double_integrator_state` (a=0.1) | `4/(9a)` | `40/9` |

All five match the integrated value to the last digit. `double_integrator_energy` (already analytic) was cross-checked against the same source.

The remaining four stay **pinned regression guards**, each carrying its reason rather than a vague "no closed form":

- `double_integrator_state` **a = 0.2** — the two-arc touch-point regime. CTProblems states `4/(9a)` only for `a ≤ 1/6` (three arcs), and indeed `4/(9·0.2) = 2.222 ≠ 2.24`.
- `lqr_ricatti` — CTProblems marks this problem `:numerical` too, integrating the Riccati ODE.
- `singular_control`, `double_integrator_state_first_order` — no CTProblems counterpart.

Existing sign assertions are kept alongside the new values: still meaningful, still cheap.

## Verification

`suite/extensions` + `suite/integration`: **790/790**.

## Out of scope

The 13 integration files that assert no objective at all — a separate coverage question, deliberately left for a follow-up. CTProblems supplies analytic values for 5 of them; the rest (goddard, the orbital transfers) are numerical there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)