### PR TITLE
refactor(objective): integrate the Lagrange cost on a scalar state

### DIFF
--- a/src/Flows/ocp_readouts.jl
+++ b/src/Flows/ocp_readouts.jl
@@ -33,8 +33,10 @@ Compute the objective value (Mayer + Lagrange) of an OCP along a trajectory, giv
 callable state `x(t)` and control `u(t)` and the variable `v`.
 
 The Mayer term is evaluated at the endpoints `x(t0)` and `x(tf)`. The Lagrange term is
-integrated by flowing `ℓ̇(t) = ℓ(t, x(t), u(t), v)` from `t0` to `tf` (a 1-element vector
-gives SciML a mutable in-place buffer). Shared core of both the Hamiltonian
+integrated by flowing `ℓ̇(t) = ℓ(t, x(t), u(t), v)` from `t0` to `tf` on a **scalar** cost
+state: under the "1-D = scalar" convention the out-of-place right-hand side is wrapped in
+an `IPVFOoPRHS`, and that wrapper — not the state — supplies SciML's mutable in-place
+buffer. Shared core of both the Hamiltonian
 (`OptimalControlFlow`) and state (`ControlledFlow`) objective paths; each caller builds
 its own `x`, `u`, `v` and delegates here.
 
@@ -50,10 +52,10 @@ function _flow_objective(ocp, x, u, v, t0, tf, integ)
     if CTModels.Components.has_lagrange_cost(ocp)
         lag = CTModels.Components.lagrange(ocp)
         running = Data.VectorField(
-            (t, ℓ_vec) -> [lag(t, x(t), u(t), v)]; is_autonomous=false, is_variable=false
+            (t, ℓ) -> lag(t, x(t), u(t), v); is_autonomous=false, is_variable=false
         )
         cost_flow = build_flow(Systems.build_system(running), integ)
-        obj += cost_flow(t0, [0.0], tf)[1]
+        obj += cost_flow(t0, 0.0, tf)
     end
     return obj
 end


### PR DESCRIPTION
Phase 4d, PR 2 of 2. Follow-up to #351, which established the objective-value assertions this PR must leave untouched.

## Why

`_flow_objective` integrated the running cost through a 1-element vector — allocating `[lag(...)]` on every RHS call and unwrapping with `[1]` at the end — and the docstring justified it with:

> a 1-element vector gives SciML a mutable in-place buffer

**That justification is obsolete.** Since the "1-D = scalar" refactor (roadmap-v4 §6) a scalar state is native: the out-of-place RHS is wrapped in an `IPVFOoPRHS`, and *that wrapper* — not the state — supplies SciML's mutable buffer.

Correcting the docstring is the main point of this PR. A stale rationale is worse than no rationale: it actively misleads the next reader into thinking the vector is load-bearing.

```diff
-        running = Data.VectorField(
-            (t, ℓ_vec) -> [lag(t, x(t), u(t), v)]; is_autonomous=false, is_variable=false
-        )
+        running = Data.VectorField(
+            (t, ℓ) -> lag(t, x(t), u(t), v); is_autonomous=false, is_variable=false
+        )
         cost_flow = build_flow(Systems.build_system(running), integ)
-        obj += cost_flow(t0, [0.0], tf)[1]
+        obj += cost_flow(t0, 0.0, tf)
```

## Measured, end to end

On the real `_flow_objective` path — OCP solution reconstruction with a Lagrange cost, simple-exponential-energy model:

| | before | after |
|---|---|---|
| objective | `0.15651764274965457` | `0.15651764274965457` — **bit-identical** |
| allocations | 1 078 176 B | 1 056 480 B — **−21 696 B, −2.0 %** |

⚠️ **Correcting an earlier claim of mine.** An isolated cost-flow reproduction suggested −20 %. End to end the ODE solve dominates and the honest figure is **−2.0 %**. The allocation saving is a bonus here, not the argument.

## The proof obligation

Every objective assertion added in #351 stays green **unchanged**. No test file is touched by this PR — that is exactly what makes the switch demonstrably value-neutral, including the tight analytic references (down to `rtol = 1e-8`).

Full CTFlows suite: **2891/2891**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)