### PR TITLE
test(gpu): OCP Hamiltonian flows on device — phase 4f

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ DifferentiationInterface = "0.7"
 DocStringExtensions = "0.9"
 ForwardDiff = "0.10, 1"
 GPUArraysCore = "0.1, 0.2"
+Mooncake = "0.5"
 NonlinearSolve = "4"
 OrdinaryDiffEqTsit5 = "2"
 Plots = "1"
@@ -57,6 +58,7 @@ DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -66,4 +68,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "CTLie", "CUDA", "DiffEqBase", "DiffEqGPU", "DifferentiationInterface", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test", "Zygote"]
+test = ["Aqua", "CTLie", "CUDA", "DiffEqBase", "DiffEqGPU", "DifferentiationInterface", "ForwardDiff", "Mooncake", "NonlinearSolve", "OrdinaryDiffEqTsit5", "Plots", "SciMLBase", "StaticArrays", "Test", "Zygote"]

--- a/src/Systems/defaults.jl
+++ b/src/Systems/defaults.jl
@@ -7,3 +7,16 @@ Returns `false` by default, meaning the getter returns out-of-place vector field
 unless specified otherwise.
 """
 __hvf_inplace()::Bool = false
+
+"""
+$(TYPEDSIGNATURES)
+
+Default AD backend for the `hamiltonian_vector_field(h::Data.AbstractHamiltonian; ...)` getter.
+
+Returns `Differentiation.DifferentiationInterface()`, the CPU-default strategy. Callers that
+need a device-specific backend (e.g. GPU) must build and pass one explicitly — this default is
+not device-aware.
+
+See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTBase.Differentiation.DifferentiationInterface`](@extref).
+"""
+__hvf_ad_backend() = Differentiation.DifferentiationInterface()

--- a/src/Systems/hamiltonian_getter.jl
+++ b/src/Systems/hamiltonian_getter.jl
@@ -181,14 +181,16 @@ call signature matches the Hamiltonian's time and variable dependence traits.
 
 # Arguments
 - `h::Data.AbstractHamiltonian{TD, VD}`: The Hamiltonian with traits `TD` (time dependence) and `VD` (variable dependence).
-- `ad_backend`: AD backend type (default: `Differentiation.__ad_backend()` = `AutoForwardDiff()`) or an `AbstractADBackend` instance.
+- `ad_backend::Differentiation.AbstractADBackend`: The AD backend to use (default: `__hvf_ad_backend()` = `Differentiation.DifferentiationInterface()`, the CPU default).
 - `inplace::Bool`: Whether to return an in-place functor (default: `__hvf_inplace()` = `false`).
 
 # Returns
 - `Data.HamiltonianVectorField`: The Hamiltonian vector field with correct traits matching the input Hamiltonian.
 
 # Notes
-- If `ad_backend` is an `AbstractADBackend` instance, it is used directly; otherwise it is wrapped via `Differentiation.build_ad_backend`.
+- `ad_backend` must already be a fully-built strategy (e.g. from `Flow`'s registry-based routing,
+  or constructed directly as `Differentiation.DifferentiationInterface{Strategies.GPU}(...)`).
+  This function does not build or device-select a backend from a raw `ADTypes.AbstractADType`.
 - The functor call signature depends on the Hamiltonian's traits:
   - Autonomous/Fixed: `(x, p) -> (∂p, -∂x)` or `(dx, dp, x, p) -> nothing` (in-place)
   - NonAutonomous/Fixed: `(t, x, p) -> (∂p, -∂x)` or `(dx, dp, t, x, p) -> nothing` (in-place)
@@ -199,16 +201,10 @@ See also: [`CTFlows.Systems.HamiltonianSystem`](@ref), [`CTFlows.Systems.Hamilto
 """
 function hamiltonian_vector_field(
     h::Data.AbstractHamiltonian{TD,VD};
-    ad_backend=Differentiation.__ad_backend(),
+    ad_backend::Differentiation.AbstractADBackend=__hvf_ad_backend(),
     inplace::Bool=__hvf_inplace(),
 ) where {TD<:Traits.TimeDependence,VD<:Traits.VariableDependence}
-    # If ad_backend is an AbstractADBackend instance, use it directly; otherwise wrap it
-    backend = if ad_backend isa Differentiation.AbstractADBackend
-        ad_backend
-    else
-        Differentiation.build_ad_backend(; ad_backend=ad_backend)
-    end
-    f = inplace ? HVFIpFunctor(h, backend) : HVFOoPFunctor(h, backend)
+    f = inplace ? HVFIpFunctor(h, ad_backend) : HVFOoPFunctor(h, ad_backend)
     return Data.HamiltonianVectorField(
         f;
         is_autonomous=TD <: Traits.Autonomous,
@@ -260,15 +256,16 @@ Hamiltonian overload to compute the vector field via automatic differentiation.
 - `Data.HamiltonianVectorField`: The Hamiltonian vector field with correct traits matching the system's Hamiltonian.
 
 # Notes
-- This overload uses the AD backend stored in `sys.backend` for gradient computation.
+- This overload uses the AD backend returned by `backend(sys)` for gradient computation,
+  passed through as-is (no unwrapping/rewrapping), so a device-specific backend (e.g.
+  `DifferentiationInterface{Strategies.GPU}`) is preserved.
 - The `inplace` parameter controls whether the returned closure writes results in-place.
 - Delegates to [`CTFlows.Systems.hamiltonian_vector_field`](@ref).
 
 See also: [`CTFlows.Systems.HamiltonianSystem`](@ref), [`CTBase.Data.Hamiltonian`](@extref), [`CTBase.Differentiation.AbstractADBackend`](@extref)
 """
 function hamiltonian_vector_field(sys::HamiltonianSystem; inplace::Bool=__hvf_inplace())
-    ad_backend = Differentiation.ad_backend(sys.backend)
-    return hamiltonian_vector_field(sys.h; ad_backend=ad_backend, inplace=inplace)
+    return hamiltonian_vector_field(sys.h; ad_backend=backend(sys), inplace=inplace)
 end
 
 """
@@ -306,9 +303,8 @@ See also: [`CTFlows.Systems.hamiltonian_vector_field`](@ref), [`CTFlows.Systems.
 function _hamiltonian_vector_field_by_ad(
     ::Type{Traits.WithAD}, sys::AbstractHamiltonianSystem; inplace::Bool=__hvf_inplace()
 )
-    ad_backend = Differentiation.ad_backend(backend(sys))
     return hamiltonian_vector_field(
-        hamiltonian(sys); ad_backend=ad_backend, inplace=inplace
+        hamiltonian(sys); ad_backend=backend(sys), inplace=inplace
     )
 end
 

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -11,12 +11,18 @@ NVIDIA runner (PR label `run ci gpu`).
 GPU-friendly test integrands use `sum`/`dot`/broadcasts, never scalar indexing (`v[i]`, `x[i]`)
 — a device scalar read is blocked by `allowscalar(false)` (probe run 4/5).
 
-Phase 4c adds the **AD-free** OCP surface: `Flow(ocp)`'s state flow (no costate) and
-`Flow(ocp, OpenLoop/ClosedLoop)`. The AD-dependent OCP surface (`Flow(ocp)` Hamiltonian,
-`Flow(ocp, DynClosedLoop)`) is **deferred**: those right-hand sides fill a buffer through
-CTModels' in-place `dynamics!`, and Zygote — the `method=:gpu` AD default — cannot
-differentiate array mutation. That gate fails on CPU too, so it is an AD-architecture issue,
-not a GPU one; the negative row below documents it.
+Phase 4c added the **AD-free** OCP surface: `Flow(ocp)`'s state flow (no costate) and
+`Flow(ocp, OpenLoop/ClosedLoop)`. Phase 4f closes the **AD-dependent** half (`Flow(ocp)`
+Hamiltonian, `Flow(ocp, DynClosedLoop)`), which 4c had to defer: those right-hand sides fill a
+buffer through CTModels' in-place `dynamics!`, and `AutoZygote` — the `method=:gpu` AD default at
+the time — cannot differentiate array mutation. That was an AD-architecture gate, not a GPU one
+(it failed on CPU too), so no buffer fix could lift it.
+
+It was lifted by changing the backend, not the code: an H200 probe campaign (phase 4e,
+`probe/gpu/probe_gpu.jl` blocks B7/B8) measured every reverse-mode DI candidate, `AutoMooncake`
+differentiated the mutating right-hand side on device, and CTBase `v0.28.2-beta` made it the GPU
+default. So `method=:gpu` now resolves `AutoMooncake()` and the rows below assert positively where
+a `@test_throws` gate used to sit.
 
 Out of scope here: the ensemble path (phase 4b, `test_gpu_ensemble.jl`).
 """
@@ -31,7 +37,10 @@ import CTFlows.Trajectories: Trajectories
 import CTModels: CTModels
 import ADTypes: ADTypes
 import SciMLBase: SciMLBase
-import Zygote: Zygote  # loads the Zygote backend so the AutoZygote GPU AD default can differentiate
+# Both AD backends are ADTypes *markers*: they construct without their package, but evaluating a
+# gradient needs the package loaded so DI can dispatch.
+import Mooncake: Mooncake  # backs the `method=:gpu` default (AutoMooncake, CTBase 0.28.2-beta)
+import Zygote: Zygote      # backs the rows that pass `ad_backend=AutoZygote()` explicitly
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -49,6 +58,10 @@ const _S1 = sin(1.0)
 #   x(1) = [cos1,  sin1],  p(1) = [-sin1, cos1]
 const _OSC_X = [_C1, _S1]
 const _OSC_P = [-_S1, _C1]
+# AD-dependent OCP rows (phase 4f): a non-zero initial costate, so the costate equation is
+# actually asserted. For the control-free ẋ = -x model, ṗ = p ⇒ p(1) = p0·e⁺¹.
+const _P0_AD = [1.0, -1.0]
+const _EP1 = exp(1.0)
 
 # =============================================================================
 # OCP fixtures (module top-level, per the repo convention)
@@ -148,10 +161,11 @@ function test_gpu_flows()
         end
 
         # ================================================================
-        # AD-dependent flows (GPU AD default = AutoZygote, phase 1b/2)
+        # AD-dependent flows (GPU AD default = AutoMooncake, CTBase 0.28.2-beta;
+        # it was AutoZygote from phase 1b until the 4e probe replaced it)
         # ================================================================
 
-        Test.@testset "Flow(Hamiltonian; method=:gpu) — AutoZygote default" begin
+        Test.@testset "Flow(Hamiltonian; method=:gpu) — AutoMooncake default" begin
             h = Data.Hamiltonian((x, p) -> (sum(abs2, x) + sum(abs2, p)) / 2)   # oscillator
             f = Flows.Flow(h; method=:gpu)
             xf, pf = f(0.0, _dev([1.0, 0.0]), _dev([0.0, 1.0]), 1.0)
@@ -298,17 +312,38 @@ function test_gpu_flows()
             Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
         end
 
-        # The AD-dependent OCP surface is DEFERRED, and the reason is not GPU-specific:
-        # `_ocp_H` fills its buffer through CTModels' in-place `dynamics!`, and Zygote (the
-        # `method=:gpu` AD default, phase 1b) cannot differentiate array mutation — it throws
-        # "Mutating arrays is not supported". This reproduces on CPU; the row records the gate
-        # so a future fix (Enzyme, Zygote.Buffer, or an out-of-place dynamics contract) flips
-        # it deliberately rather than silently.
-        Test.@testset "Flow(ocp) Hamiltonian on device — deferred (AD/mutation gate)" begin
+        # ================================================================
+        # AD-dependent OCP flows on device (phase 4f) — the half 4c deferred.
+        #   These differentiate the OCP (pseudo-)Hamiltonian, whose RHS fills a buffer through
+        #   CTModels' in-place `dynamics!`. That mutation is what AutoZygote could not handle;
+        #   AutoMooncake — the `method=:gpu` default since CTBase 0.28.2-beta — can, so the
+        #   `@test_throws` gate that used to sit here is now a positive assertion.
+        # ================================================================
+
+        Test.@testset "Flow(ocp) Hamiltonian on device (method=:gpu)" begin
+            # OCP_GPU_CF is ẋ = -x, control-free ⇒ H(x,p) = ⟨p, -x⟩, LINEAR in p. Hence
+            #   ẋ =  ∂H/∂p = -x  ⇒ x(1) = x0·e⁻¹
+            #   ṗ = -∂H/∂x =  p  ⇒ p(1) = p0·e⁺¹
+            # p0 is deliberately NON-ZERO: it makes the costate a real assertion and a sign
+            # guard (a flipped sign would give p0·e⁻¹). Both references were cross-checked on
+            # CPU with the ForwardDiff default and match to ~1e-10.
             f = Flows.Flow(OCP_GPU_CF; method=:gpu)
-            Test.@test_throws Exception f(
-                0.0, _dev([1.0, 2.0]), _dev([0.0, 0.0]), 1.0
-            )
+            xf, pf = f(0.0, _dev([1.0, 2.0]), _dev(_P0_AD), 1.0)
+            Test.@test xf isa CUDA.CuArray            # buffer + gradient stayed on device
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+            Test.@test Array(pf) ≈ _P0_AD .* _EP1 atol = 1e-6
+        end
+
+        Test.@testset "Flow(ocp, DynClosedLoop) on device (method=:gpu)" begin
+            # The other AD-dependent OCP shape: a dynamic feedback law makes the flow
+            # differentiate the PSEUDO-Hamiltonian. This is the shape probe B8 validated.
+            # OCP_GPU_CTRL is autonomous + fixed, so the law arity is (x, p).
+            # u ≡ 0 ⇒ ẋ = -x again, so the same analytic reference applies.
+            f = Flows.Flow(OCP_GPU_CTRL, Data.DynClosedLoop((x, p) -> 0.0); method=:gpu)
+            xf, pf = f(0.0, _dev([1.0, 2.0]), _dev(_P0_AD), 1.0)
+            Test.@test xf isa CUDA.CuArray
+            Test.@test Array(xf) ≈ [1.0, 2.0] .* _E1 atol = 1e-6
+            Test.@test Array(pf) ≈ _P0_AD .* _EP1 atol = 1e-6
         end
     end
     return nothing


### PR DESCRIPTION
Closes the **AD-dependent** half of the OCP device surface that phase 4c had to defer — the last gap in the GPU coverage matrix.

## Why it was blocked, and why it no longer is

`_ocp_H`/`_ocp_pseudo_H` fill their buffer through CTModels' in-place `dynamics!`, and `AutoZygote` — the `method=:gpu` default at the time — cannot differentiate array mutation. That was an **AD-architecture** gate, not a GPU one (it reproduced on CPU), so no buffer fix could lift it. A `@test_throws` row pinned it so a fix would flip it deliberately.

It was lifted by **changing the backend, not the code**: phase 4e (#353) measured every reverse-mode DI candidate on an H200, `AutoMooncake` cleared the matrix including probe **B8** (the real `Flow(ocp)` call on a `CuArray`, numerically correct), and CTBase `v0.28.2-beta` made it the GPU default.

## What's in here

**`refactor(systems)`** (first commit) — `hamiltonian_vector_field` now requires an already-built `AbstractADBackend` instead of a raw ADTypes marker, with the default moved to `Systems/defaults.jl` as `__hvf_ad_backend()`. The previous unwrap-and-rebuild round-trip (`Differentiation.ad_backend(...)` → `build_ad_backend`) discarded the strategy's device parameter, so a `DifferentiationInterface{GPU}` came back as CPU.

**`test(gpu)`** (second commit) — test and config only:

- `Project.toml`: `Mooncake` in `[extras]`/`[targets].test`/`[compat]` (`"0.5"`).
- `test_gpu_flows.jl`: import Mooncake; correct the now-false "AutoZygote default" naming; **flip the `@test_throws` gate** into positive assertions for `Flow(ocp; method=:gpu)`; add a `Flow(ocp, DynClosedLoop)` row (the pseudo-Hamiltonian shape B8 proved).

### A latent breakage this also fixes

`Mooncake` was absent from CTFlows **entirely** (`Project.toml` *and* `Manifest`), while `method=:gpu` now resolves the `AutoMooncake()` marker — which DI cannot dispatch without the package loaded. `test_gpu_flows.jl` already had two `method=:gpu` rows, so **the next `run ci gpu` would have failed even with no other change here**.

### The flipped rows assert something

They use a **non-zero** initial costate on purpose. With `p0 = 0` the costate stays identically zero whatever the sign convention, so the assertion would prove nothing. With `p0 = [1,-1]` the control-free model gives `p(1) = p0·e⁺¹`, and a flipped sign would give `p0·e⁻¹`. Both references were cross-checked on CPU against the ForwardDiff default and match to ~1e-10.

## Known, deliberately not addressed here

`AutoMooncake` + a **CPU** `@view` returns a structural `Mooncake.Tangent` rather than an array, so `-∂x` throws (`hamiltonian_rhs_functors.jl:126`, views from `_ham_split`). Probe B8 traversed the same view path **on device** and passed, so `MooncakeCUDAExt` evidently yields a negatable tangent there. Not a CPU regression — the CPU default is still `AutoForwardDiff`. **kkt is the arbiter**; if it reproduces on device, the fix belongs in CTBase's DI extension, not here.

## Verification

Full CPU suite **2891/2891** (unchanged vs `main`), Aqua clean, GPU rows self-skip off-device. `run ci gpu` label set at creation — the `test-gpu-kkt` job is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)