### PR TITLE
ci: stop label-gated workflows from re-triggering on every subsequent label

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   call:
-    if: contains(github.event.pull_request.labels.*.name, 'run breakage')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,15 @@ on:
 jobs:
   # Job pour les runners GitHub hosted (ubuntu, windows, macos)
   test-cpu-github:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci cpu')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci cpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci cpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       runs_on: '["ubuntu-latest", "macos-latest"]'
@@ -22,7 +30,11 @@ jobs:
 
   # Job pour le runner self-hosted kkt (GPU/CUDA)
   test-gpu-kkt:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci gpu')
+    # See the comment on test-cpu-github above.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci gpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci gpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       versions: '["1"]'

--- a/.github/workflows/CPUProbe.yml
+++ b/.github/workflows/CPUProbe.yml
@@ -13,7 +13,15 @@ on:
 jobs:
   cpu-probe:
     # Run manually (workflow_dispatch) or on a PR carrying the 'run probe' label.
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run probe')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run probe') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run probe'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,7 +11,15 @@ on:
   
 jobs:
   call:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run documentation')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (opened/synchronize/reopened), fall
+    # back to checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true

--- a/.github/workflows/GPUProbe.yml
+++ b/.github/workflows/GPUProbe.yml
@@ -13,7 +13,15 @@ on:
 jobs:
   gpu-probe:
     # Run manually (workflow_dispatch) or on a PR carrying the 'run probe' label.
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run probe')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run probe') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run probe'))
     runs-on: ["kkt"]
 
     steps:


### PR DESCRIPTION
## Summary

Fixes the CI double/triple-triggering observed on #363 when several run-gating labels (`run ci cpu`, `run ci gpu`, `run documentation`) were added to a PR in quick succession.

**Root cause**: GitHub fires a separate `pull_request` `labeled` event per label added, and each job's `if` condition is re-evaluated against the PR's *current full label set*, not just the label that triggered this specific event. So adding labels one after another re-runs every already-matching job again on each subsequent label add, not just the newly-matched one — e.g. adding `run ci gpu` after `run ci cpu` was already present re-ran the CPU job too.

**Fix**: for the `labeled` event specifically, check `github.event.label.name` against the job's own label; for every other trigger type (`synchronize`/`reopened`/`opened`/`push`/`workflow_dispatch`), keep the existing full-label-set check. Applied to all 5 label-gated workflows in this repo:
- `CI.yml` (`test-cpu-github` / `run ci cpu`, `test-gpu-kkt` / `run ci gpu`)
- `Documentation.yml` (`run documentation`)
- `Breakage.yml` (`run breakage`)
- `CPUProbe.yml` / `GPUProbe.yml` (`run probe`)

## Test plan

- [x] All 5 YAML files validated with `yaml.safe_load`
- [ ] Add one of the gating labels to this PR and confirm only the matching job runs, and that adding a second label doesn't re-run the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)