### PR TITLE
Review documentation: content and form

### DIFF
--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -113,10 +113,12 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                 joinpath("Flows", "building.jl"),
                 joinpath("Flows", "calling.jl"),
             ),
-            # Flows re-exports `hamiltonian_vector_field` and `vector_field` from Systems;
-            # documenting them here too would duplicate the Systems-page docstring (same
-            # canonical binding).
-            exclude=vcat(EXCLUDE_SYMBOLS, [:hamiltonian_vector_field, :vector_field]),
+            # Flows re-exports `hamiltonian`, `hamiltonian_vector_field`, and `vector_field`
+            # from Systems; documenting them here too would duplicate the Systems-page
+            # docstring (same canonical binding).
+            exclude=vcat(
+                EXCLUDE_SYMBOLS, [:hamiltonian, :hamiltonian_vector_field, :vector_field]
+            ),
         ),
         (
             mod=CTFlows.MultiPhase,

--- a/docs/src/flows/building_a_flow.md
+++ b/docs/src/flows/building_a_flow.md
@@ -22,6 +22,7 @@ using CTFlows.Systems
 using CTFlows.Integrators
 using CTFlows.Flows
 using CTFlows.Trajectories
+using CTFlows.Configs
 import OrdinaryDiffEqTsit5
 ```
 
@@ -33,22 +34,21 @@ The simplest way to build a flow is to pass data directly to `Flows.Flow`:
 
 ```@example flows_building
 # From a VectorField → StateFlow
-vf   = Data.VectorField(x -> -x)
+vf = Data.VectorField(x -> -x)
 flow = Flows.Flow(vf; reltol=1e-8, abstol=1e-8)
 ```
 
 ```@example flows_building
 # From a HamiltonianVectorField → HamiltonianFlow
-hvf  = Data.HamiltonianVectorField((x, p) -> (p, -x))
+hvf = Data.HamiltonianVectorField((x, p) -> (p, -x))
 hflow = Flows.Flow(hvf; reltol=1e-10)
 ```
 
 ```@example flows_building
-using LinearAlgebra
-
 # From a scalar Hamiltonian (AD computes the derivatives) → HamiltonianFlow
 import DifferentiationInterface, ForwardDiff
-h    = Data.Hamiltonian((x, p) -> 0.5 * (dot(x, x) + dot(p, p)))
+using LinearAlgebra
+h = Data.Hamiltonian((x, p) -> 0.5 * (dot(x, x) + dot(p, p)))
 hflow_ad = Flows.Flow(h; reltol=1e-10)
 ```
 
@@ -77,9 +77,23 @@ hsys = Systems.build_system(hvf)
 ```
 
 A system exposes:
-- `Systems.get_ip_rhs(sys, config)` — the in-place ODE right-hand side `(du, u, p, t) -> nothing`
-- `Systems.get_oop_rhs(sys, config)` — the out-of-place variant `(u, p, t) -> du`
-- `Traits.time_dependence(sys)`, `Traits.variable_dependence(sys)` — delegated from the data
+
+```@repl flows_building
+Traits.time_dependence(sys)
+Traits.variable_dependence(sys)
+```
+
+```@example flows_building
+config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
+```
+
+```@example flows_building
+Systems.get_ip_rhs(sys, config)
+```
+
+```@example flows_building
+Systems.get_oop_rhs(sys, config)
+```
 
 ### Step 2 — Build the integrator
 
@@ -115,6 +129,7 @@ typeof(flow_explicit) == typeof(flow)
 | `HamiltonianVectorField` | `HamiltonianFlow` |
 | `Hamiltonian` (with AD) | `HamiltonianFlow` |
 | `PseudoHamiltonian` + `DynClosedLoop` law | `HamiltonianFlow` |
+| `PseudoHamiltonianVectorField` + `DynClosedLoop` law | `HamiltonianFlow` |
 | `ControlledVectorField` + `OpenLoop`/`ClosedLoop` law | `ControlledFlow` |
 | OCP (control-free) | `OptimalControlFlow` |
 | OCP (with control) + `DynClosedLoop` law | `OptimalControlFlow` |
@@ -128,7 +143,7 @@ Both `StateFlow` and `HamiltonianFlow` are concrete subtypes of `AbstractFlow`.
 [Optimal control](optimal_control.md)).
 Their trait parameters mirror the underlying data:
 
-```@example flows_building
+```@repl flows_building
 Traits.time_dependence(flow)      # Autonomous (inherited from vf)
 Traits.variable_dependence(flow)  # Fixed
 ```
@@ -177,50 +192,38 @@ Every flow answers a small, uniform set of getters. Which ones are meaningful de
 on how the flow was built; calling an inapplicable getter raises a clear
 `IncorrectArgument`.
 
-| Getter | Available on | Returns |
-|---|---|---|
-| `system(f)` / `integrator(f)` | all flows | the wrapped `AbstractSystem` / `AbstractIntegrator` |
-| `vector_field(f)` | all flows | the integrated vector field (for a Hamiltonian flow, ``X_H`` — an alias of `hamiltonian_vector_field`) |
-| `hamiltonian_vector_field(f)` | Hamiltonian flows | ``X_H = (\partial_p H, -\partial_x H)`` |
-| `hamiltonian(f)` | Hamiltonian flows | the scalar ``H(t, x, p, v)`` |
-| `hamiltonian_gradient(f)` / `variable_gradient(f)` | Hamiltonian flows | functors ``(\partial_x H, \partial_p H)`` / ``\partial_v H`` |
-| `pseudo_hamiltonian(f)` / `control_law(f)` | flows built with a control law | ``\tilde H(t, x, p, u, v)`` / the feedback ``u`` |
-| `pseudo_hamiltonian_gradient(f)` / `pseudo_variable_gradient(f)` | flows built with a control law | functors of ``\tilde H`` |
+`system`, `integrator`, and `vector_field` are available on all flows (the first two
+are shown in the `AbstractFlow` contract above). For a `StateFlow`, `vector_field`
+returns the underlying `AbstractVectorField` directly:
 
-The Hamiltonian getters are shown executed on [Integrating](integrating.md), the
-pseudo-Hamiltonian ones on [Control laws](control_laws.md). This page covers the
-vector-field getters.
-
-### Vector field
-
-`Systems.vector_field(f)` is the uniform entry point across flow kinds — for a
-`HamiltonianFlow` it returns the (symplectic) Hamiltonian vector field
-``X_H = (\partial_p H, -\partial_x H)``, an alias of `hamiltonian_vector_field(f)`;
-for a state `Flow` it returns the underlying `AbstractVectorField` integrated by
-the flow:
-
-```@example flows_building
-# State flow → the underlying VectorField
+```@repl flows_building
 Flows.vector_field(flow)
 ```
 
-```@example flows_building
-# HamiltonianVectorField-backed flow → X_H (vector_field is an alias)
-hvf_back = Flows.hamiltonian_vector_field(hflow)
-Flows.vector_field(hflow) === hvf_back
+For a `HamiltonianFlow`, `vector_field` is an alias of `hamiltonian_vector_field` and
+returns ``X_H = (\partial_p H, -\partial_x H)``:
+
+```@repl flows_building
+Flows.vector_field(hflow)
+Flows.hamiltonian_vector_field(hflow)
+Flows.vector_field(hflow) === Flows.hamiltonian_vector_field(hflow)
 ```
 
-For an AD-backed flow (built from `Hamiltonian`), the getter materialises the
-vector field on demand:
+For an AD-backed `HamiltonianFlow` (built from a scalar `Hamiltonian`), the Hamiltonian
+itself is also available:
 
-```@example flows_building
-hvf_ad = Flows.hamiltonian_vector_field(hflow_ad)
+```@repl flows_building
+Flows.hamiltonian(hflow_ad)
+Flows.hamiltonian_vector_field(hflow_ad)
 ```
 
 `hamiltonian_vector_field` (and therefore `vector_field`) also covers flows built
 from a pseudo-Hamiltonian or an OCP together with a control law — the Hamiltonian is
 then a `CTBase.Data.ComposedHamiltonian` (`:total` mode) or reconstructed from a
-`PseudoHamiltonianSystem` (`:partial` mode); see [Control laws](control_laws.md).
+`PseudoHamiltonianSystem` (`:partial` mode). The pseudo-Hamiltonian getters
+(`pseudo_hamiltonian`, `control_law`, `pseudo_hamiltonian_gradient`,
+`pseudo_variable_gradient`) and `variable_gradient` are shown on
+[Control laws](control_laws.md) and [Integrating](integrating.md) respectively.
 
 ---
 

--- a/docs/src/flows/integrating.md
+++ b/docs/src/flows/integrating.md
@@ -71,8 +71,13 @@ For a `NonFixed` flow, pass the variable ``v`` via the `variable` keyword:
 
 ```@example flows_integrating
 vf_v = Data.VectorField((x, v) -> -v[1] .* x; is_variable=true)
-flow_v = Flows.Flow(vf_v)
+```
 
+```@example flows_integrating
+flow_v = Flows.Flow(vf_v)
+```
+
+```@example flows_integrating
 xf_v = flow_v(0.0, [1.0, 0.0], 1.0; variable=[2.0])
 ```
 
@@ -90,10 +95,17 @@ augmented adjoint ``\dot{p}_v = -\partial H/\partial v`` (initialized at
 
 ```@example flows_integrating
 h_v = Data.Hamiltonian((x, p, v) -> v[1] * p^2 / 2; is_variable=true)
-hflow_v = Flows.Flow(h_v)
+```
 
-xf, pf, pvf = hflow_v(0.0, 1.0, 0.5, 1.0; variable=[2.0], variable_costate=true)
-(xf, pf, pvf)
+```@example flows_integrating
+hflow_v = Flows.Flow(h_v)
+```
+
+```@repl flows_integrating
+xf, pf, pvf = hflow_v(0.0, 1.0, 0.5, 1.0; variable=[2.0], variable_costate=true);
+xf
+pf
+pvf
 ```
 
 This is only available for point evaluation, and only when `variable` is provided
@@ -134,7 +146,13 @@ from a control law — its pseudo-Hamiltonian, control law, and their gradients:
 
 ```@example flows_integrating
 Systems.hamiltonian(hflow_v)          # the callable H(t, x, p, v)
+```
+
+```@example flows_integrating
 Systems.hamiltonian_gradient(hflow_v) # functor: (t, x, p, v) -> (∂H/∂x, ∂H/∂p)
+```
+
+```@example flows_integrating
 Systems.variable_gradient(hflow_v)    # functor: (t, x, p, v) -> ∂H/∂v
 ```
 
@@ -161,6 +179,9 @@ pass them to `Flows._invoke_flow`:
 
 ```@example flows_integrating
 cfg = Configs.StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
+```
+
+```@example flows_integrating
 Configs.tspan(cfg)
 ```
 

--- a/docs/src/flows/multiphase.md
+++ b/docs/src/flows/multiphase.md
@@ -152,12 +152,14 @@ MultiPhase.n_phases(mpf)                 # number of phases
 MultiPhase.get_flow(mpf, 1)              # flow for phase 1
 MultiPhase.get_switching_time(mpf, 1)    # switching time after phase 1
 MultiPhase.get_jump(mpf, 1)              # jump at that switching time (nothing here)
+nothing # hide
 ```
 
 ```@example flows_multiphase
 MultiPhase.get_flows(mpf)                # tuple of all phase flows
 MultiPhase.get_switching_times(mpf)      # all switching times
 MultiPhase.get_jumps(mpf)                # all jump functions
+nothing # hide
 ```
 
 ---
@@ -168,7 +170,6 @@ The same operators work for Hamiltonian flows:
 
 ```@example flows_multiphase
 hmpf = hflow1 * (1.0, hflow2)
-typeof(hmpf)
 ```
 
 ```@example flows_multiphase

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -22,11 +22,11 @@ from `Data`, the other from integrator options — and only meet when
 
 | Layer | Submodule | What it produces |
 |---|---|---|
-| **Data** | [`CTBase.Data`](@extref CTBase.Data) | Typed function wrappers (`VectorField`, `Hamiltonian`, `HamiltonianVectorField`) |
+| **Data** | [`CTBase.Data`](@extref CTBase.Data) | Typed function wrappers (`VectorField`, `Hamiltonian`, `HamiltonianVectorField`, `PseudoHamiltonian`, `PseudoHamiltonianVectorField`) |
 | **Systems** | [`Systems`](@ref CTFlows.Systems) | ODE right-hand side + traits (`VectorFieldSystem`, `HamiltonianSystem`, …) |
 | **Integrators** | [`Integrators`](@ref CTFlows.Integrators) | ODE solver strategy (`SciML`) |
 | **Flows** | [`Flows`](@ref CTFlows.Flows) | Callable integration object (`StateFlow`, `HamiltonianFlow`, `OptimalControlFlow`, `ControlledFlow`) |
-| **Trajectories** | [`Trajectories`](@ref CTFlows.Trajectories) | Result container with semantic accessors (`state`, `costate`, `control`, `time_grid`) |
+| **Trajectories** | [`Trajectories`](@ref CTFlows.Trajectories) | Result container with semantic accessors (`state`, `costate`, `control`, `time_grid`, `objective`) |
 
 ## Reading order
 
@@ -35,7 +35,7 @@ from `Data`, the other from integrator options — and only meet when
 | [Building a flow](building_a_flow.md) | Assembling the pipeline | `build_system`, `build_flow`, `Flow` |
 | [Integrating](integrating.md) | Calling a flow, configuration objects, integrator options | `StateEndPointConfig`, `StateTrajectoryConfig` |
 | [Trajectories](trajectories.md) | Reading the result | `state`, `costate`, `time_grid`, `plot` |
-| [Multi-phase flows](multiphase.md) | Concatenating flows with switching times | `MultiPhaseStateFlow`, `*` |
+| [Multi-phase flows](multiphase.md) | Concatenating flows with switching times | `MultiPhaseStateFlow`, `MultiPhaseHamiltonianFlow`, `*` |
 | [Optimal control](optimal_control.md) | Flows from optimal control problems | `OptimalControlFlow`, `Flow(ocp)` |
 | [Control laws](control_laws.md) | Flows with control laws | `ControlledFlow`, `Flow(ocp, law)`, `OpenLoop`, `ClosedLoop`, `DynClosedLoop` |
 | [Constrained flows](constrained.md) | Path-constraint terms on `Flow(ocp, law)` | `constraint`, `multiplier`, `hamiltonian_type` |
@@ -43,7 +43,7 @@ from `Data`, the other from integrator options — and only meet when
 | [GPU flows](gpu.md) | Running a flow on a device | `method=:gpu`, `CuArray` states, the GPU contract |
 
 The **data layer** (wrapping functions as `VectorField`, `Hamiltonian`,
-`HamiltonianVectorField`) and the **trait system** (`Autonomous`, `Fixed`,
+`HamiltonianVectorField`, `PseudoHamiltonian`, `PseudoHamiltonianVectorField`) and the **trait system** (`Autonomous`, `Fixed`,
 `InPlace`, …) live in CTBase — see [`CTBase.Data`](@extref CTBase.Data) and
 [`CTBase.Traits`](@extref CTBase.Traits) in the CTBase documentation. Likewise, the
 **ODE solver strategy** (`SciML`) is not implemented in CTFlows: it is provided by
@@ -96,9 +96,9 @@ sol = flow((0.0, 1.0), [1.0, 0.0])
 
 ```@example flows_overview
 # 4. Read the result
-ts = Trajectories.time_grid(sol)   # vector of time points
-x  = Trajectories.state(sol)       # callable: x(t) → state at time t
-x(0.5)                          # interpolate at t = 0.5
+ts = Trajectories.time_grid(sol) # vector of time points
+x  = Trajectories.state(sol)     # callable: x(t) → state at time t
+x(0.5)                           # interpolate at t = 0.5
 ```
 
 The shortcut `Flows.Flow(vf; opts...)` hides steps 2–3 of the pipeline

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -14,8 +14,7 @@ import Pkg
 Pkg.add("CTFlows")
 ```
 
-To integrate anything you also need an ODE solver backend. The default strategy is
-**SciML**, activated by loading an OrdinaryDiffEq solver package:
+To integrate anything you also need an ODE solver backend. The default (and unique) strategy is **SciML**, activated by loading an OrdinaryDiffEq solver package:
 
 ```julia
 Pkg.add("OrdinaryDiffEqTsit5")
@@ -25,15 +24,15 @@ Pkg.add("OrdinaryDiffEqTsit5")
 
 Three ideas explain most of the API:
 
-1. **No top-level exports.** CTFlows exports nothing at the package level. Every
+- **No top-level exports.** CTFlows exports nothing at the package level. Every
    symbol lives in a submodule and is reached via a qualified path
    (`CTFlows.Flows.Flow`) or an explicit `using CTFlows.Flows`. The same holds for
-   the data layer, which lives in CTBase (`CTBase.Data.VectorField`).
-2. **A pipeline of small layers.** Data (your functions, wrapped) → Systems (ODE
+  the data layer, which lives in CTBase (`CTBase.Data.VectorField`).
+- **A pipeline of small layers.** Data (your functions, wrapped) → Systems (ODE
    right-hand side) → Integrators (solver strategy) → Flows (the callable object) →
    Trajectories (the result). The shortcut `Flows.Flow(data; opts...)` runs the
    whole pipeline in one call.
-3. **Extension-backed features.** The actual ODE solving, plotting, and SciML
+- **Extension-backed features.** The actual ODE solving, plotting, and SciML
    interoperability are Julia package extensions: they activate when you load
    `OrdinaryDiffEqTsit5` (or another solver), `Plots`, or `SciMLBase`.
 
@@ -58,7 +57,6 @@ A vector field is any function of the state. Wrapping it as a
 
 ```@example getting_started
 vf = Data.VectorField(x -> -x)   # autonomous, fixed
-nothing # hide
 ```
 
 ### Build the flow
@@ -71,7 +69,7 @@ flow = Flows.Flow(vf; reltol=1e-8, abstol=1e-8)
 
 Point form returns only the final state:
 
-```@repl getting_started
+```@example getting_started
 xf = flow(0.0, [1.0, 0.0], 1.0)
 ```
 
@@ -100,8 +98,10 @@ The same API drives Hamiltonian dynamics on state–costate pairs
 
 ```@example getting_started
 hvf = Data.HamiltonianVectorField((x, p) -> (p, -x))
+```
+
+```@example getting_started
 hflow = Flows.Flow(hvf; reltol=1e-10)
-nothing # hide
 ```
 
 ```@repl getting_started
@@ -132,7 +132,6 @@ CTModels.Building.objective!(pre, :min; mayer=(x0, xf, v) -> xf[1])
 ocp = CTModels.Building.build(pre)
 
 f = Flows.Flow(ocp; reltol=1e-10)
-nothing # hide
 ```
 
 Point evaluation returns the final state–costate pair (Hamiltonian semantics):
@@ -171,6 +170,7 @@ Base.showable(::MIME"image/png", ::Plots.Plot) = false
 ```
 
 ```@example getting_started
+using Plots
 plot(sol)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,7 +27,7 @@ using CTBase.Data, CTFlows.Flows, CTFlows.Trajectories
 import OrdinaryDiffEqTsit5   # activates the SciML integrator extension
 
 # 1. Wrap the dynamics
-vf = Data.VectorField(x -> -x)          # autonomous, fixed, out-of-place
+vf = Data.VectorField(x -> -x)     # autonomous, fixed, out-of-place
 
 # 2. Build the flow
 flow = Flows.Flow(vf; reltol=1e-8)
@@ -38,8 +38,8 @@ xf = flow(0.0, [1.0, 0.0], 1.0)
 # 4. Integrate — trajectory form (full history)
 sol = flow((0.0, 1.0), [1.0, 0.0])
 t   = Trajectories.time_grid(sol)
-x   = Trajectories.state(sol)           # callable: x(t) → state at time t
-x(0.5)                                  # interpolate
+x   = Trajectories.state(sol)      # callable: x(t) → state at time t
+x(0.5)                             # interpolate
 ```
 
 !!! note "Qualified access"
@@ -64,13 +64,13 @@ Data → Systems → Integrators → Flows → Trajectories
 
 | Layer | Submodule | Key types |
 |---|---|---|
-| Data | [`CTBase.Data`](@extref CTBase.Data) | `VectorField`, `Hamiltonian`, `HamiltonianVectorField`, `PseudoHamiltonian`, `ControlledVectorField`, `OpenLoop`, `ClosedLoop`, `DynClosedLoop` |
-| Configs | [`CTFlows.Configs`](@ref CTFlows.Configs) | `StateEndPointConfig`, `HamiltonianTrajectoryConfig`, `AugmentedHamiltonianEndPointConfig` |
-| Systems | [`CTFlows.Systems`](@ref CTFlows.Systems) | `VectorFieldSystem`, `HamiltonianSystem`, `PseudoHamiltonianSystem` |
+| Data | [`CTBase.Data`](@extref CTBase.Data) | `VectorField`, `Hamiltonian`, `HamiltonianVectorField`, `PseudoHamiltonian`, `PseudoHamiltonianVectorField`, `ControlledVectorField`, `OpenLoop`, `ClosedLoop`, `DynClosedLoop` |
+| Configs | [`CTFlows.Configs`](@ref CTFlows.Configs) | `StateEndPointConfig`, `StateTrajectoryConfig`, `HamiltonianEndPointConfig`, `HamiltonianTrajectoryConfig`, `AugmentedHamiltonianEndPointConfig` |
+| Systems | [`CTFlows.Systems`](@ref CTFlows.Systems) | `VectorFieldSystem`, `HamiltonianVectorFieldSystem`, `HamiltonianSystem`, `PseudoHamiltonianSystem`, `PseudoHamiltonianVectorFieldSystem`, `ConstrainedPseudoHamiltonianSystem` |
 | Integrators | [`CTFlows.Integrators`](@ref CTFlows.Integrators) | `SciML` |
 | Flows | [`CTFlows.Flows`](@ref CTFlows.Flows) | `StateFlow`, `HamiltonianFlow`, `OptimalControlFlow`, `ControlledFlow` |
 | Trajectories | [`CTFlows.Trajectories`](@ref CTFlows.Trajectories) | `VectorFieldTrajectory`, `HamiltonianVectorFieldTrajectory`, `StateFlowTrajectory` |
-| Multi-phase | [`CTFlows.MultiPhase`](@ref CTFlows.MultiPhase) | `MultiPhaseStateFlow` |
+| Multi-phase | [`CTFlows.MultiPhase`](@ref CTFlows.MultiPhase) | `MultiPhaseStateFlow`, `MultiPhaseHamiltonianFlow` |
 
 The data layer (`VectorField`, `Hamiltonian`, `HamiltonianVectorField`) lives in [`CTBase.Data`](@extref CTBase.Data); the ODE integrator
 strategy is provided by

--- a/ext/CTFlowsSciMLFlows/problem_flow.jl
+++ b/ext/CTFlowsSciMLFlows/problem_flow.jl
@@ -153,12 +153,15 @@ function Base.show(io::IO, ::MIME"text/plain", f::SciMLProblemFlow)
     Display.print_header(io, "SciMLProblemFlow"; fmt=fmt)
     Display.print_field(io, "tspan", f.prob.tspan; fmt=fmt)
     Display.print_field(io, "u0", f.prob.u0; fmt=fmt)
-    int_str = sprint(
-        f.integrator; context=IOContext(io, :color => get(io, :color, false))
-    ) do io2, i
-        print(io2, fmt.value, nameof(typeof(i)), fmt.reset)
-        return Flows._print_user_options(io2, i)
-    end
+    # Nest the integrator's own (styled, multi-line) text/plain display under the last branch.
+    int_str = chomp(
+        sprint(
+            show,
+            MIME("text/plain"),
+            f.integrator;
+            context=IOContext(io, :color => get(io, :color, false)),
+        ),
+    )
     return Display.print_field(
         io, "integrator", int_str; last=true, fmt=fmt, value_style=""
     )

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -77,10 +77,9 @@ value uses `value_style` (the `value` role by default). Pass `value_style = ""` 
 value unstyled.
 
 When `value` renders on several lines (e.g. a nested object whose own `show` is multi-line),
-continuation lines are aligned under the value column and prefixed with a `│` pipe (blanks
-when `last`), mirroring the multi-line field convention used across the control-toolbox
-ecosystem. `value` is rendered through `print` (so strings/symbols keep their plain form and
-objects use their own `show`), preserving colour from `io`.
+continuation lines are indented under the branch character and prefixed with a `│` pipe
+(blanks when `last`). `value` is rendered through `print` (so strings/symbols keep their
+plain form and objects use their own `show`), preserving colour from `io`.
 """
 function print_field(
     io::IO, label, value; last::Bool=false, fmt=format_codes(io), value_style=nothing
@@ -99,9 +98,8 @@ function print_field(
     print(io, style, lines[1], reset)
     if length(lines) > 1
         cont = last ? "   " : string(fmt.muted, "│", fmt.reset, "  ")
-        pad = isempty(string(label)) ? "" : " "^(length(string(label)) + 2)   # label + ": "
         for l in @view lines[2:end]
-            print(io, "\n", cont, pad, style, l, reset)
+            print(io, "\n", cont, style, l, reset)
         end
     end
     return nothing

--- a/src/Flows/Flows.jl
+++ b/src/Flows/Flows.jl
@@ -31,7 +31,7 @@ import CommonSolve: CommonSolve
 
 import ..Display: Display
 import ..Configs: Configs
-import ..Systems: Systems, hamiltonian_vector_field, vector_field
+import ..Systems: Systems, hamiltonian, hamiltonian_vector_field, vector_field
 import ..Integrators: Integrators
 import ..Trajectories: Trajectories
 
@@ -60,7 +60,7 @@ export AbstractFlow,
 export OptimalControlFlow, ControlledFlow
 export system, integrator
 export build_flow
-export hamiltonian_vector_field, vector_field
+export hamiltonian, hamiltonian_vector_field, vector_field
 export flow_registry
 
 end # module Flows

--- a/src/Flows/abstract_flow.jl
+++ b/src/Flows/abstract_flow.jl
@@ -509,7 +509,8 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Display the flow in tree-style format with proper indentation for multi-line system displays.
+Display the flow in tree-style format with proper indentation for multi-line system and
+integrator displays.
 
 # Example
 ```julia-repl
@@ -518,8 +519,16 @@ julia> using CTFlows.Flows
 julia> flow = Flow(system, integrator)
 StateFlow
 ├─ system: VectorFieldSystem
-│  └─ wraps: VectorField: autonomous, fixed (no variable), out-of-place
-└─ integrator: SciML (abstol = 1e-8, reltol = 1e-6)
+│  ├─ time_dependence: Autonomous
+│  ├─ variable_dependence: Fixed
+│  └─ VectorField: autonomous, fixed (no variable), out-of-place
+│     natural call: f(x)
+│     uniform call: f(t, x, v)
+└─ integrator: SciML (instance, id=:sciml)
+   ├─ alg = Tsit5  [default]
+   ├─ reltol = 1.0e-8  [user]
+   └─ abstol = 1.0e-8  [user]
+   Tip: use describe(SciML) to see all available options.
 ```
 """
 function Base.show(io::IO, ::MIME"text/plain", flow::AbstractFlow)
@@ -532,13 +541,15 @@ function Base.show(io::IO, ::MIME"text/plain", flow::AbstractFlow)
     # Nest the system's own (styled, possibly multi-line) display under the `system` branch.
     Display.print_field(io, "system", sys; fmt=fmt, value_style="")
 
-    # Integrator name followed by user-supplied options, nested under the last branch.
-    int_str = sprint(
-        integ; context=IOContext(io, :color => get(io, :color, false))
-    ) do io2, i
-        print(io2, fmt.value, nameof(typeof(i)), fmt.reset)
-        return _print_user_options(io2, i)
-    end
+    # Nest the integrator's own (styled, multi-line) text/plain display under the last branch.
+    int_str = chomp(
+        sprint(
+            show,
+            MIME("text/plain"),
+            integ;
+            context=IOContext(io, :color => get(io, :color, false)),
+        ),
+    )
     return Display.print_field(
         io, "integrator", int_str; last=true, fmt=fmt, value_style=""
     )
@@ -566,43 +577,5 @@ function Base.show(io::IO, flow::AbstractFlow)
     push!(parts, "system=$(sys)")
     push!(parts, "integrator=$(nameof(typeof(integ)))")
     print(io, join(parts, ", "))
-    return print(io, ")")
-end
-
-# =============================================================================
-# Internal helpers for show
-# =============================================================================
-
-"""
-    _print_user_options(io::IO, integ::Integrators.AbstractIntegrator)
-
-Print user-supplied integrator options inline: `(key = val, …)`.
-Silently does nothing when no user options are set.
-
-# Arguments
-- `io::IO`: The IO stream to write to.
-- `integ::Integrators.AbstractIntegrator`: The integrator to inspect for user options.
-
-# Example
-\`\`\`julia
-# If user options are set: prints " (abstol = 1e-8, reltol = 1e-6)"
-# If no user options: prints nothing
-\`\`\`
-"""
-function _print_user_options(io::IO, integ::Integrators.AbstractIntegrator)
-    opts = Strategies.options(integ)
-    user_opts = sort!(
-        [
-            (k, Options.value(v)) for
-            (k, v) in pairs(opts.options) if Options.is_user(opts, k)
-        ];
-        by=x -> string(x[1]),
-    )
-    isempty(user_opts) && return nothing
-    print(io, " (")
-    for (i, (k, v)) in enumerate(user_opts)
-        i > 1 && print(io, ", ")
-        print(io, k, " = ", v)
-    end
     return print(io, ")")
 end

--- a/src/Flows/abstract_flow.jl
+++ b/src/Flows/abstract_flow.jl
@@ -517,9 +517,9 @@ julia> using CTFlows.Flows
 
 julia> flow = Flow(system, integrator)
 StateFlow
-  system:     VectorFieldSystem
-                wraps: VectorField: autonomous, fixed (no variable), out-of-place
-  integrator: SciML (abstol = 1e-8, reltol = 1e-6)
+├─ system: VectorFieldSystem
+│  └─ wraps: VectorField: autonomous, fixed (no variable), out-of-place
+└─ integrator: SciML (abstol = 1e-8, reltol = 1e-6)
 ```
 """
 function Base.show(io::IO, ::MIME"text/plain", flow::AbstractFlow)

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -324,8 +324,12 @@ end
 $(TYPEDSIGNATURES)
 
 Build the inner Hamiltonian flow for the `:total` mode: compose the pseudo-Hamiltonian
-with the control law into a [`CTBase.Data.ComposedHamiltonian`](@extref) and wrap it in a
-[`CTFlows.Systems.HamiltonianSystem`](@ref) (AD through the law).
+`H̃` with the control law `u(t,x,p,v)` into a [`CTBase.Data.ComposedHamiltonian`](@extref)
+`H(t,x,p,v) = H̃(t,x,p,u(t,x,p,v),v)`, wrap it in a
+[`CTFlows.Systems.HamiltonianSystem`](@ref), and build the flow.
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref), [`CTFlows.Systems.HamiltonianSystem`](@ref),
+[`CTBase.Data.ComposedHamiltonian`](@extref).
 """
 function _build_pseudo_flow(::Val{:total}, h̃, law, components)
     H = Data.ComposedHamiltonian(h̃, law)
@@ -338,12 +342,26 @@ $(TYPEDSIGNATURES)
 
 Build the inner Hamiltonian flow for the `:partial` mode: wrap the pseudo-Hamiltonian
 and control law in a [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref) (AD at fixed `u`).
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref),
+[`CTFlows.Systems.PseudoHamiltonianSystem`](@ref).
 """
 function _build_pseudo_flow(::Val{:partial}, h̃, law, components)
     sys = Systems.build_system(h̃, law, components.backend)
     return build_flow(sys, components.integrator)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Throw an [`CTBase.Exceptions.IncorrectArgument`](@extref) for an unknown
+`hamiltonian_type` value. Only `:total` and `:partial` are supported.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): when `ht` is not `:total` or `:partial`.
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref).
+"""
 function _build_pseudo_flow(::Val{ht}, h̃, law, components) where {ht}
     return throw(
         Exceptions.IncorrectArgument(
@@ -630,22 +648,21 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Collect arity issues from a convenience spec into `issues`, dispatching on the spec's
-shape: skip `nothing`; check a raw `Function` directly; check each `Function` element of a
-`Tuple` (multi-constraint/multiplier case, labelled `label1`, `label2`, …); skip anything
-else (`Symbol`, `CTBase.Data.PathConstraint`, `CTBase.Data.Multiplier` — not raw functions).
+No arity issues for a `nothing` spec — skip the check.
 
-# Arguments
-- `issues::Vector{String}`: accumulator, mutated in place.
-- `ocp::CTModels.Models.Model`: the OCP, used to infer the expected arity.
-- `spec`: the convenience spec (`nothing`, `Function`, `Tuple`, or an already-resolved
-  carrier).
-- `label::AbstractString`, `second::AbstractString`, `kind::AbstractString`: forwarded to
-  [`CTFlows.Flows._arity_issue`](@ref).
-
-See also: [`CTFlows.Flows._check_convenience_arities`](@ref).
+See also: [`CTFlows.Flows._spec_arity_issues!`](@ref).
 """
 _spec_arity_issues!(issues, ocp, ::Nothing, label, second, kind) = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
+Check the arity of a single `Function` spec against the OCP's expected arity and push
+an issue string into `issues` if they differ.
+
+See also: [`CTFlows.Flows._check_convenience_arities`](@ref),
+[`CTFlows.Flows._arity_issue`](@ref).
+"""
 function _spec_arity_issues!(
     issues,
     ocp,
@@ -658,6 +675,16 @@ function _spec_arity_issues!(
     issue === nothing || push!(issues, issue)
     return nothing
 end
+"""
+$(TYPEDSIGNATURES)
+
+Check the arity of each `Function` element in a `Tuple` spec against the OCP's expected
+arity, pushing an issue string per mismatch into `issues`. Non-`Function` elements are
+skipped.
+
+See also: [`CTFlows.Flows._check_convenience_arities`](@ref),
+[`CTFlows.Flows._arity_issue`](@ref).
+"""
 function _spec_arity_issues!(
     issues,
     ocp,
@@ -673,6 +700,14 @@ function _spec_arity_issues!(
     end
     return nothing
 end
+"""
+$(TYPEDSIGNATURES)
+
+Fallback for an already-resolved spec (not a `Function` or `Tuple`): no arity check
+needed.
+
+See also: [`CTFlows.Flows._check_convenience_arities`](@ref).
+"""
 _spec_arity_issues!(issues, ocp, spec, label, second, kind) = nothing
 
 """
@@ -893,6 +928,19 @@ function _build_ocp_pseudo_flow(::Val{:total}, ocp, law, components, cspec, mspe
     return _build_pseudo_flow(Val(:total), h̃, law, components)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Build the inner flow for the `:partial` mode from an OCP pseudo-Hamiltonian and a
+control law. When a constraint spec (`cspec`) is provided, resolve it together with the
+multiplier spec (`mspec`) and build a
+[`CTFlows.Systems.ConstrainedPseudoHamiltonianSystem`](@ref); otherwise delegate to
+[`CTFlows.Flows._build_pseudo_flow`](@ref).
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref),
+[`CTFlows.Systems.ConstrainedPseudoHamiltonianSystem`](@ref),
+[`CTFlows.Flows._resolve_constraint`](@ref), [`CTFlows.Flows._resolve_multiplier`](@ref).
+"""
 function _build_ocp_pseudo_flow(::Val{:partial}, ocp, law, components, cspec, mspec)
     h̃ = _ocp_pseudo_hamiltonian(ocp)
     cspec === nothing && return _build_pseudo_flow(Val(:partial), h̃, law, components)
@@ -902,8 +950,14 @@ function _build_ocp_pseudo_flow(::Val{:partial}, ocp, law, components, cspec, ms
     return build_flow(sys, components.integrator)
 end
 
-# Unknown hamiltonian_type: delegate to the (throwing) unconstrained fallback so the
-# error message and type match `Flow(h̃, law; hamiltonian_type=…)`.
+"""
+$(TYPEDSIGNATURES)
+
+Unknown `hamiltonian_type`: delegate to the (throwing) unconstrained fallback so the
+error message and type match `Flow(h̃, law; hamiltonian_type=…)`.
+
+See also: [`CTFlows.Flows._build_pseudo_flow`](@ref).
+"""
 function _build_ocp_pseudo_flow(::Val{ht}, ocp, law, components, cspec, mspec) where {ht}
     return _build_pseudo_flow(Val(ht), _ocp_pseudo_hamiltonian(ocp), law, components)
 end
@@ -950,6 +1004,18 @@ function _controlled_flow(
     return ControlledFlow(build_flow(system, _build_integrator(kwargs)), ocp, law)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Reject `Flow(ocp, …)` with extra positional arguments beyond the model. Only
+`Flow(ocp; kwargs…)` (control-free) and `Flow(ocp, law; kwargs…)` (with a control law)
+are supported.
+
+# Throws
+- [`CTBase.Exceptions.PreconditionError`](@extref): when extra positional arguments are passed.
+
+See also: [`CTFlows.Flows.Flow`](@ref).
+"""
 function Flow(::CTModels.Models.Model, ::Any, args...; kwargs...)
     return throw(
         Exceptions.PreconditionError(

--- a/src/Flows/controlled_flow.jl
+++ b/src/Flows/controlled_flow.jl
@@ -109,7 +109,17 @@ covers every later application of the returned function, including inside
 [`CTFlows.Trajectories.StateFlowTrajectory`](@ref).
 """
 _flow_state_coerce(ocp, ::AbstractMatrix) = identity
+
+"""
+$(TYPEDSIGNATURES)
+
+State coercion from the OCP's declared state dimension for a non-batched `x0`:
+`only` for a 1-D state, `identity` otherwise.
+
+See also: [`CTFlows.Flows._flow_state_coerce`](@ref), [`CTFlows.Flows._dim_coerce`](@ref).
+"""
 _flow_state_coerce(ocp, x0) = _dim_coerce(CTModels.Models.state_dimension(ocp))
+
 """
 $(TYPEDSIGNATURES)
 
@@ -118,6 +128,15 @@ Precomputed state coercion (`only` for a 1-D state, `identity` otherwise) inferr
 `identity` — see [`CTFlows.Flows._flow_state_coerce`](@ref).
 """
 _flow_state_coerce(::Nothing, ::AbstractMatrix) = identity
+"""
+$(TYPEDSIGNATURES)
+
+Precomputed state coercion (`only` for a 1-D state, `identity` otherwise) inferred from
+`x0` when there is no OCP (`Flow(fc, law)`): a `Matrix` `x0` always yields `identity`
+(see [`CTFlows.Flows._flow_state_coerce`](@ref)).
+
+See also: [`CTFlows.Flows._flow_state_coerce`](@ref), [`CTFlows.Flows._dim_coerce`](@ref).
+"""
 _flow_state_coerce(::Nothing, x0) = _dim_coerce(length(x0))
 
 # =============================================================================

--- a/src/Flows/flow.jl
+++ b/src/Flows/flow.jl
@@ -54,6 +54,20 @@ const StateFlow{TD<:Traits.TimeDependence,VD<:Traits.VariableDependence,S<:Syste
     TD,VD,Traits.StateDynamics,S,I
 }
 
+"""
+$(TYPEDSIGNATURES)
+
+Construct a [`CTFlows.Flows.StateFlow`](@ref) from a state system and an integrator.
+
+# Arguments
+- `system::S`: a state system (`<: AbstractStateSystem`).
+- `integrator::I`: an ODE integrator (`<: AbstractIntegrator`).
+
+# Returns
+- `StateFlow`: a concrete `Flow` with `StateDynamics`.
+
+See also: [`CTFlows.Flows.StateFlow`](@ref), [`CTFlows.Flows.Flow`](@ref).
+"""
 function StateFlow(
     system::S, integrator::I
 ) where {TD,VD,S<:Systems.AbstractStateSystem{TD,VD},I<:Integrators.AbstractIntegrator}
@@ -71,6 +85,21 @@ const HamiltonianFlow{TD<:Traits.TimeDependence,VD<:Traits.VariableDependence,S<
     TD,VD,Traits.HamiltonianDynamics,S,I
 }
 
+"""
+$(TYPEDSIGNATURES)
+
+Construct a [`CTFlows.Flows.HamiltonianFlow`](@ref) from a Hamiltonian system and an
+integrator.
+
+# Arguments
+- `system::S`: a Hamiltonian system (`<: AbstractHamiltonianSystem`).
+- `integrator::I`: an ODE integrator (`<: AbstractIntegrator`).
+
+# Returns
+- `HamiltonianFlow`: a concrete `Flow` with `HamiltonianDynamics`.
+
+See also: [`CTFlows.Flows.HamiltonianFlow`](@ref), [`CTFlows.Flows.Flow`](@ref).
+"""
 function HamiltonianFlow(
     system::S, integrator::I
 ) where {

--- a/src/Flows/flow_routing.jl
+++ b/src/Flows/flow_routing.jl
@@ -34,7 +34,13 @@ function _flow_families(::Type{Traits.WithoutAD})
     return (integrator=Integrators.AbstractIntegrator,)
 end
 
-# Back-compat: the full (WithAD) families.
+"""
+$(TYPEDSIGNATURES)
+
+Back-compat alias: return the full (`WithAD`) strategy families — backend + integrator.
+
+See also: [`CTFlows.Flows._flow_families`](@ref).
+"""
 _flow_families() = _flow_families(Traits.WithAD)
 
 """
@@ -44,8 +50,18 @@ Base method description for a flow plan, per AD trait. The device token (`:cpu`)
 the flow registry is parameterized (`[CPU, GPU]`), so a device token is required —
 [`CTBase.Strategies.extract_global_parameter_from_method`](@extref) throws otherwise. The bare
 `:cpu` reproduces the pre-parameterization CPU behaviour exactly (`SciML{CPU}` metadata ≡ old).
+
+See also: [`CTFlows.Flows._flow_base_description`](@ref), [`CTFlows.Flows._available_flow_methods`](@ref).
 """
 _flow_base_description(::Type{Traits.WithAD}) = (:di, :sciml, :cpu)
+"""
+$(TYPEDSIGNATURES)
+
+Base method description for an AD-free flow plan: no `:di` backend token (no scalar
+Hamiltonian is differentiated), only the `:sciml` integrator and `:cpu` device.
+
+See also: [`CTFlows.Flows._flow_base_description`](@ref), [`CTFlows.Flows._available_flow_methods`](@ref).
+"""
 _flow_base_description(::Type{Traits.WithoutAD}) = (:sciml, :cpu)
 
 """
@@ -55,6 +71,14 @@ Candidate descriptions (the `:cpu`/`:gpu` device variants) against which a user 
 completed via [`CTBase.Descriptions.complete`](@extref).
 """
 _available_flow_methods(::Type{Traits.WithAD}) = ((:di, :sciml, :cpu), (:di, :sciml, :gpu))
+"""
+$(TYPEDSIGNATURES)
+
+Candidate descriptions for an AD-free flow: only the `:sciml` integrator with `:cpu`/`:gpu`
+device variants (no `:di` backend).
+
+See also: [`CTFlows.Flows._available_flow_methods`](@ref), [`CTBase.Descriptions.complete`](@extref).
+"""
 _available_flow_methods(::Type{Traits.WithoutAD}) = ((:sciml, :cpu), (:sciml, :gpu))
 
 """
@@ -67,7 +91,21 @@ single-element tuple; a tuple of `Symbol`s is returned as-is.
 See also: [`CTFlows.Flows._flow_description`](@ref)
 """
 _as_method_tokens(::Nothing) = nothing
+"""
+$(TYPEDSIGNATURES)
+
+Wrap a bare `Symbol` (e.g. `:gpu`) into a single-element tuple.
+
+See also: [`CTFlows.Flows._as_method_tokens`](@ref), [`CTFlows.Flows._flow_description`](@ref).
+"""
 _as_method_tokens(m::Symbol) = (m,)
+"""
+$(TYPEDSIGNATURES)
+
+Return a tuple of `Symbol`s as-is — already in the normalized form.
+
+See also: [`CTFlows.Flows._as_method_tokens`](@ref), [`CTFlows.Flows._flow_description`](@ref).
+"""
 _as_method_tokens(m::Tuple{Vararg{Symbol}}) = m
 
 """
@@ -173,7 +211,13 @@ function _route_flow_options(
     )
 end
 
-# Back-compat: default to the WithAD plan (the full `:di`/`:sciml` families).
+"""
+$(TYPEDSIGNATURES)
+
+Back-compat alias: route options using the `WithAD` plan (the full `:di`/`:sciml` families).
+
+See also: [`CTFlows.Flows._route_flow_options`](@ref).
+"""
 function _route_flow_options(
     kwargs; action_defs::Vector{<:Options.OptionDefinition}=Options.OptionDefinition[]
 )
@@ -230,6 +274,13 @@ Read an action option value from a routed `action` NamedTuple entry: unwrap an
 See also: [`CTFlows.Flows._flow_action_defs`](@ref), [`CTFlows.Flows._route_flow_options`](@ref).
 """
 _unwrap_option(opt::Options.OptionValue, fallback) = opt.value
+"""
+$(TYPEDSIGNATURES)
+
+Return `opt` directly when it is not `nothing`, or `fallback` otherwise.
+
+See also: [`CTFlows.Flows._unwrap_option`](@ref), [`CTFlows.Flows._route_flow_options`](@ref).
+"""
 _unwrap_option(opt, fallback) = opt === nothing ? fallback : opt
 
 """
@@ -280,7 +331,13 @@ function _build_flow_components(ad_trait, routed; method=nothing)
     return NamedTuple{keys(families)}(built)
 end
 
-# Back-compat: default to the WithAD plan (backend + integrator).
+"""
+$(TYPEDSIGNATURES)
+
+Back-compat alias: build flow components using the `WithAD` plan (backend + integrator).
+
+See also: [`CTFlows.Flows._build_flow_components`](@ref).
+"""
 _build_flow_components(routed) = _build_flow_components(Traits.WithAD, routed)
 
 """

--- a/src/Flows/ocp_readouts.jl
+++ b/src/Flows/ocp_readouts.jl
@@ -22,8 +22,33 @@ Dispatched on the control law and the available data:
 See also: `CTFlows.Flows._flow_objective`, [`CTFlows.Trajectories._controlled_u`](@ref).
 """
 _control_of(::Nothing, x, v) = (_ -> Float64[])
+
+"""
+$(TYPEDSIGNATURES)
+
+Control-free OCP with costate projection: returns `t -> Float64[]` (no control to reconstruct).
+
+See also: [`CTFlows.Flows._control_of`](@ref).
+"""
 _control_of(::Nothing, x, p, v) = (_ -> Float64[])
+
+"""
+$(TYPEDSIGNATURES)
+
+DynClosedLoop law with costate: returns `t -> law(t, x(t), p(t), v)` (Hamiltonian path).
+
+See also: [`CTFlows.Flows._control_of`](@ref).
+"""
 _control_of(law, x, p, v) = (t -> law(t, x(t), p(t), v))
+
+"""
+$(TYPEDSIGNATURES)
+
+OpenLoop/ClosedLoop law with state only: returns `t -> u(t)` via
+[`CTFlows.Trajectories._controlled_u`](@ref) (state path, no costate).
+
+See also: [`CTFlows.Flows._control_of`](@ref), [`CTFlows.Trajectories._controlled_u`](@ref).
+"""
 _control_of(law, x, v) = (t -> Trajectories._controlled_u(law, t, x(t), v))
 
 """

--- a/src/Flows/optimal_control_flow.jl
+++ b/src/Flows/optimal_control_flow.jl
@@ -50,7 +50,10 @@ struct OCPHamiltonianFunction{
     n::Int
 end
 
-# Aliases to keep method signatures concise
+"""
+Const aliases for `CTModels.Components.Autonomous` / `NonAutonomous`, keeping method
+signatures concise in the call-operator dispatch below.
+"""
 const _CTM_Auton = CTModels.Components.Autonomous
 const _CTM_NonAuton = CTModels.Components.NonAutonomous
 
@@ -86,21 +89,39 @@ function _ocp_H(h::OCPHamiltonianFunction, t, x, p, v)
     return val
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Call operators for [`CTFlows.Flows.OCPHamiltonianFunction`](@ref), dispatching on the
+`(TD, VD)` trait pair for the correct arity:
+
+| `TD` / `VD` | Call signature | Effective call |
+|---|---|---|
+| `Auton` / `Fixed` | `H(x, p)` | `_ocp_H(h, 0, x, p, ∅)` |
+| `NonAuton` / `Fixed` | `H(t, x, p)` | `_ocp_H(h, t, x, p, ∅)` |
+| `Auton` / `NonFixed` | `H(x, p, v)` | `_ocp_H(h, 0, x, p, v)` |
+| `NonAuton` / `NonFixed` | `H(t, x, p, v)` | `_ocp_H(h, t, x, p, v)` |
+
+See also: [`CTFlows.Flows.OCPHamiltonianFunction`](@ref), [`CTFlows.Flows._ocp_H`](@ref).
+"""
 function (h::OCPHamiltonianFunction{_CTM_Auton,Traits.Fixed,DF,LF})(
     x, p
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_H(h, 0.0, x, p, nothing)
 end
+
 function (h::OCPHamiltonianFunction{_CTM_NonAuton,Traits.Fixed,DF,LF})(
     t, x, p
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_H(h, t, x, p, nothing)
 end
+
 function (h::OCPHamiltonianFunction{_CTM_Auton,Traits.NonFixed,DF,LF})(
     x, p, v
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_H(h, 0.0, x, p, v)
 end
+
 function (h::OCPHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed,DF,LF})(
     t, x, p, v
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
@@ -206,21 +227,40 @@ function _ocp_pseudo_H(h::OCPPseudoHamiltonianFunction, t, x, p, u, v)
     return val
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Call operators for [`CTFlows.Flows.OCPPseudoHamiltonianFunction`](@ref), dispatching on
+the `(TD, VD)` trait pair for the correct arity:
+
+| `TD` / `VD` | Call signature | Effective call |
+|---|---|---|
+| `Auton` / `Fixed` | `H̃(x, p, u)` | `_ocp_pseudo_H(h, 0, x, p, u, ∅)` |
+| `NonAuton` / `Fixed` | `H̃(t, x, p, u)` | `_ocp_pseudo_H(h, t, x, p, u, ∅)` |
+| `Auton` / `NonFixed` | `H̃(x, p, u, v)` | `_ocp_pseudo_H(h, 0, x, p, u, v)` |
+| `NonAuton` / `NonFixed` | `H̃(t, x, p, u, v)` | `_ocp_pseudo_H(h, t, x, p, u, v)` |
+
+See also: [`CTFlows.Flows.OCPPseudoHamiltonianFunction`](@ref),
+[`CTFlows.Flows._ocp_pseudo_H`](@ref).
+"""
 function (h::OCPPseudoHamiltonianFunction{_CTM_Auton,Traits.Fixed,DF,LF})(
     x, p, u
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_pseudo_H(h, 0.0, x, p, u, nothing)
 end
+
 function (h::OCPPseudoHamiltonianFunction{_CTM_NonAuton,Traits.Fixed,DF,LF})(
     t, x, p, u
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_pseudo_H(h, t, x, p, u, nothing)
 end
+
 function (h::OCPPseudoHamiltonianFunction{_CTM_Auton,Traits.NonFixed,DF,LF})(
     x, p, u, v
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
     return _ocp_pseudo_H(h, 0.0, x, p, u, v)
 end
+
 function (h::OCPPseudoHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed,DF,LF})(
     t, x, p, u, v
 ) where {DF<:Function,LF<:Union{Function,Nothing}}
@@ -299,8 +339,24 @@ function _resolve_constraint(ocp, spec::Symbol)
     return Data.MixedConstraint(g_oop; is_autonomous=false, is_variable=true)
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a `PathConstraint` spec as-is — it is already a resolved
+[`CTBase.Data.PathConstraint`](@extref).
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref), [`CTBase.Data.PathConstraint`](@extref).
+"""
 _resolve_constraint(::Any, spec::Data.PathConstraint) = spec
 
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `Function` constraint spec into a [`CTBase.Data.MixedConstraint`](@extref),
+inferring autonomy and variable-dependence from the OCP.
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref), [`CTBase.Data.MixedConstraint`](@extref).
+"""
 function _resolve_constraint(ocp, spec::Function)
     return Data.MixedConstraint(
         spec; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
@@ -334,6 +390,18 @@ Uniform call: concatenate (`vcat`) the per-constraint values `gᵢ(t,x,u,v)` in 
 """
 (c::_CombinedConstraint)(t, x, u, v) = reduce(vcat, map(g -> g(t, x, u, v), c.parts))
 
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `Tuple` of constraint specs into a [`CTFlows.Flows._CombinedConstraint`](@ref),
+rejecting an empty tuple with [`CTBase.Exceptions.IncorrectArgument`](@extref).
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): when `spec` is an empty tuple.
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref),
+[`CTFlows.Flows._CombinedConstraint`](@ref).
+"""
 function _resolve_constraint(ocp, spec::Tuple)
     isempty(spec) && throw(
         Exceptions.IncorrectArgument(
@@ -346,6 +414,18 @@ function _resolve_constraint(ocp, spec::Tuple)
     return _CombinedConstraint(map(s -> _resolve_constraint(ocp, s), spec))
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Throw an [`CTBase.Exceptions.IncorrectArgument`](@extref) for an unsupported constraint
+spec type. Only `Symbol` (path label), `Function`, `Tuple`, and
+[`CTBase.Data.PathConstraint`](@extref) are accepted.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): when `spec` is not a supported type.
+
+See also: [`CTFlows.Flows._resolve_constraint`](@ref).
+"""
 function _resolve_constraint(::Any, spec)
     return throw(
         Exceptions.IncorrectArgument(
@@ -374,6 +454,14 @@ See also: [`CTFlows.Flows._resolve_constraint`](@ref), `CTFlows.Flows._ocp_const
 """
 _resolve_multiplier(::Any, spec::Data.Multiplier) = spec
 
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `Function` multiplier spec into a [`CTBase.Data.Multiplier`](@extref),
+inferring autonomy and variable-dependence from the OCP.
+
+See also: [`CTFlows.Flows._resolve_multiplier`](@ref), [`CTBase.Data.Multiplier`](@extref).
+"""
 function _resolve_multiplier(ocp, spec::Function)
     return Data.Multiplier(
         spec; is_autonomous=Traits.is_autonomous(ocp), is_variable=Traits.is_variable(ocp)
@@ -406,6 +494,18 @@ Uniform call: concatenate (`vcat`) the per-multiplier values `μᵢ(t,x,p,v)` in
 """
 (m::_CombinedMultiplier)(t, x, p, v) = reduce(vcat, map(μ -> μ(t, x, p, v), m.parts))
 
+"""
+$(TYPEDSIGNATURES)
+
+Resolve a `Tuple` of multiplier specs into a [`CTFlows.Flows._CombinedMultiplier`](@ref),
+rejecting an empty tuple with [`CTBase.Exceptions.IncorrectArgument`](@extref).
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): when `spec` is an empty tuple.
+
+See also: [`CTFlows.Flows._resolve_multiplier`](@ref),
+[`CTFlows.Flows._CombinedMultiplier`](@ref).
+"""
 function _resolve_multiplier(ocp, spec::Tuple)
     isempty(spec) && throw(
         Exceptions.IncorrectArgument(
@@ -418,6 +518,17 @@ function _resolve_multiplier(ocp, spec::Tuple)
     return _CombinedMultiplier(map(s -> _resolve_multiplier(ocp, s), spec))
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Throw an [`CTBase.Exceptions.IncorrectArgument`](@extref) for an unsupported multiplier
+spec type. Only `Function`, `Tuple`, and [`CTBase.Data.Multiplier`](@extref) are accepted.
+
+# Throws
+- [`CTBase.Exceptions.IncorrectArgument`](@extref): when `spec` is not a supported type.
+
+See also: [`CTFlows.Flows._resolve_multiplier`](@ref).
+"""
 function _resolve_multiplier(::Any, spec)
     return throw(
         Exceptions.IncorrectArgument(
@@ -485,15 +596,34 @@ function _constrained_pseudo_H(h::ConstrainedPseudoHamiltonianFunction, t, x, p,
     return base + sum(h.μ(t, x, p, vv) .* h.g(t, x, u, vv))
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Call operators for [`CTFlows.Flows.ConstrainedPseudoHamiltonianFunction`](@ref),
+dispatching on the `(TD, VD)` trait pair for the correct arity:
+
+| `TD` / `VD` | Call signature | Effective call |
+|---|---|---|
+| `Auton` / `Fixed` | `H(x, p, u)` | `_constrained_pseudo_H(h, 0, x, p, u, ∅)` |
+| `NonAuton` / `Fixed` | `H(t, x, p, u)` | `_constrained_pseudo_H(h, t, x, p, u, ∅)` |
+| `Auton` / `NonFixed` | `H(x, p, u, v)` | `_constrained_pseudo_H(h, 0, x, p, u, v)` |
+| `NonAuton` / `NonFixed` | `H(t, x, p, u, v)` | `_constrained_pseudo_H(h, t, x, p, u, v)` |
+
+See also: [`CTFlows.Flows.ConstrainedPseudoHamiltonianFunction`](@ref),
+[`CTFlows.Flows._constrained_pseudo_H`](@ref).
+"""
 function (h::ConstrainedPseudoHamiltonianFunction{_CTM_Auton,Traits.Fixed})(x, p, u)
     return _constrained_pseudo_H(h, 0.0, x, p, u, nothing)
 end
+
 function (h::ConstrainedPseudoHamiltonianFunction{_CTM_NonAuton,Traits.Fixed})(t, x, p, u)
     return _constrained_pseudo_H(h, t, x, p, u, nothing)
 end
+
 function (h::ConstrainedPseudoHamiltonianFunction{_CTM_Auton,Traits.NonFixed})(x, p, u, v)
     return _constrained_pseudo_H(h, 0.0, x, p, u, v)
 end
+
 function (h::ConstrainedPseudoHamiltonianFunction{_CTM_NonAuton,Traits.NonFixed})(
     t, x, p, u, v
 )
@@ -636,6 +766,15 @@ This guard is the runtime check that closes that gap, mirroring
 See also: [`CTFlows.Flows._dim_coerce`](@ref).
 """
 _apply_dim_coerce(coerce, x::AbstractMatrix) = x
+
+"""
+$(TYPEDSIGNATURES)
+
+Apply a precomputed per-dimension coercion to a non-batched value: returns `coerce(x)`
+(`only` for 1-D, `identity` otherwise).
+
+See also: [`CTFlows.Flows._apply_dim_coerce`](@ref), [`CTFlows.Flows._dim_coerce`](@ref).
+"""
 _apply_dim_coerce(coerce, x) = coerce(x)
 
 """
@@ -666,6 +805,8 @@ function _ocp_controlled_vf(h::OCPControlledVectorFieldFunction, t, x, u, v)
 end
 
 """
+$(TYPEDSIGNATURES)
+
 Call operators for [`CTFlows.Flows.OCPControlledVectorFieldFunction`](@ref), dispatching on the
 `(TD, VD)` trait pair for the correct arity:
 
@@ -683,16 +824,19 @@ function (h::OCPControlledVectorFieldFunction{_CTM_Auton,Traits.Fixed,DF})(
 ) where {DF<:Function}
     return _ocp_controlled_vf(h, 0.0, x, u, nothing)
 end
+
 function (h::OCPControlledVectorFieldFunction{_CTM_NonAuton,Traits.Fixed,DF})(
     t, x, u
 ) where {DF<:Function}
     return _ocp_controlled_vf(h, t, x, u, nothing)
 end
+
 function (h::OCPControlledVectorFieldFunction{_CTM_Auton,Traits.NonFixed,DF})(
     x, u, v
 ) where {DF<:Function}
     return _ocp_controlled_vf(h, 0.0, x, u, v)
 end
+
 function (h::OCPControlledVectorFieldFunction{_CTM_NonAuton,Traits.NonFixed,DF})(
     t, x, u, v
 ) where {DF<:Function}
@@ -794,6 +938,8 @@ function _ocp_state_vf(h::OCPStateVectorFieldFunction, t, x, v)
 end
 
 """
+$(TYPEDSIGNATURES)
+
 Call operators for [`CTFlows.Flows.OCPStateVectorFieldFunction`](@ref), dispatching on the
 `(TD, VD)` trait pair for the correct arity:
 
@@ -811,16 +957,19 @@ function (h::OCPStateVectorFieldFunction{_CTM_Auton,Traits.Fixed,DF})(
 ) where {DF<:Function}
     return _ocp_state_vf(h, 0.0, x, nothing)
 end
+
 function (h::OCPStateVectorFieldFunction{_CTM_NonAuton,Traits.Fixed,DF})(
     t, x
 ) where {DF<:Function}
     return _ocp_state_vf(h, t, x, nothing)
 end
+
 function (h::OCPStateVectorFieldFunction{_CTM_Auton,Traits.NonFixed,DF})(
     x, v
 ) where {DF<:Function}
     return _ocp_state_vf(h, 0.0, x, v)
 end
+
 function (h::OCPStateVectorFieldFunction{_CTM_NonAuton,Traits.NonFixed,DF})(
     t, x, v
 ) where {DF<:Function}
@@ -912,11 +1061,36 @@ function OptimalControlFlow(
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return the inner Hamiltonian system of an [`CTFlows.Flows.OptimalControlFlow`](@ref),
+delegating to the inner flow.
+
+See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), [`CTFlows.Flows.system`](@ref).
+"""
 system(F::OptimalControlFlow) = system(F.flow)
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the integrator of an [`CTFlows.Flows.OptimalControlFlow`](@ref), delegating to
+the inner flow.
+
+See also: [`CTFlows.Flows.OptimalControlFlow`](@ref), [`CTFlows.Flows.integrator`](@ref).
+"""
 integrator(F::OptimalControlFlow) = integrator(F.flow)
 
 # ── point eval — pure delegation ────────────────────────────────────────────
 
+"""
+$(TYPEDSIGNATURES)
+
+Point-evaluation call for [`CTFlows.Flows.OptimalControlFlow`](@ref): delegate to the
+inner Hamiltonian flow, returning `(xf, pf)` (and `pvf` when `variable_costate=true`).
+
+See also: [`CTFlows.Flows.OptimalControlFlow`](@ref).
+"""
 function (F::OptimalControlFlow)(
     t0::Real,
     x0,
@@ -931,6 +1105,16 @@ end
 
 # ── trajectory call — builds a CTModels.Solution ────────────────────────────
 
+"""
+$(TYPEDSIGNATURES)
+
+Trajectory call for [`CTFlows.Flows.OptimalControlFlow`](@ref): integrate the inner
+Hamiltonian flow over `tspan` and build a full [`CTModels.Solutions.Solution`](@extref)
+via [`CTFlows.Flows._build_ocp_solution`](@ref).
+
+See also: [`CTFlows.Flows.OptimalControlFlow`](@ref),
+[`CTFlows.Flows._build_ocp_solution`](@ref).
+"""
 function (F::OptimalControlFlow)(
     tspan::Tuple{<:Real,<:Real}, x0, p0; variable=Core.NotProvided, unsafe::Bool=false
 )
@@ -1012,6 +1196,8 @@ end
 # =============================================================================
 
 """
+$(TYPEDSIGNATURES)
+
 Convert a variable argument into a `Vector{Float64}`.
 
 Returns an empty vector when the variable was not provided (`Core.NotProvided`),
@@ -1020,7 +1206,21 @@ a 1-element vector for scalars, and a copy for vectors.
 See also: `_build_ocp_solution`, `CTFlows.Flows._flow_objective`.
 """
 _variable_vector(::Core.NotProvidedType) = Float64[]
+"""
+$(TYPEDSIGNATURES)
+
+Wrap a scalar variable into a 1-element `Vector{Float64}`.
+
+See also: [`CTFlows.Flows._variable_vector`](@ref).
+"""
 _variable_vector(v::Number) = [Float64(v)]
+"""
+$(TYPEDSIGNATURES)
+
+Copy a vector variable into a `Vector{Float64}`.
+
+See also: [`CTFlows.Flows._variable_vector`](@ref).
+"""
 _variable_vector(v::AbstractVector) = Float64.(v)
 
 """

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -375,7 +375,25 @@ every phase kind with no forgotten case.
 - The raw inner flow to integrate for this phase.
 """
 _raw_flow(f::Flows.AbstractFlow) = f
+
+"""
+$(TYPEDSIGNATURES)
+
+Unwrap an [`CTFlows.Flows.OptimalControlFlow`](@ref) to its inner flow.
+
+# Returns
+- `f.flow`: the inner `StateFlow`/`HamiltonianFlow`.
+"""
 _raw_flow(f::Flows.OptimalControlFlow) = f.flow
+
+"""
+$(TYPEDSIGNATURES)
+
+Unwrap a [`CTFlows.Flows.ControlledFlow`](@ref) to its inner flow.
+
+# Returns
+- `f.flow`: the inner `StateFlow`/`HamiltonianFlow`.
+"""
 _raw_flow(f::Flows.ControlledFlow) = f.flow
 
 """
@@ -574,6 +592,15 @@ declared a scalar `x0`); any `AbstractVector`/`AbstractMatrix` `x0`, length-1 in
 returned as-is.
 """
 _reshape_to_x0(x0::Number, raw) = Systems._safe_only(raw)
+
+"""
+$(TYPEDSIGNATURES)
+
+Fallback for `AbstractVector`/`AbstractMatrix` `x0`: return `raw` unchanged.
+
+Unlike the `Number` method, no collapsing is needed — the container type already
+matches what [`CTSolvers.Integrators.merge`](@extref) expects.
+"""
 _reshape_to_x0(x0, raw) = raw
 
 """
@@ -627,6 +654,18 @@ function _extract_final_state(::Type{Traits.HamiltonianDynamics}, segment, curre
     return (final[1:nx], final[(nx + 1):end])
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Extract the final state and costate from a `HamiltonianVectorFieldTrajectory` segment.
+
+Unlike the generic `HamiltonianDynamics` method, no manual splitting is needed because
+`HamiltonianVectorFieldTrajectory` already stores the combined `(x, p)` vector and
+`Integrators.final_state` returns it directly.
+
+# Returns
+- The final combined `(state, costate)` vector from the segment.
+"""
 function _extract_final_state(
     ::Type{Traits.HamiltonianDynamics},
     segment::Trajectories.HamiltonianVectorFieldTrajectory,

--- a/src/MultiPhase/multiphase_flow.jl
+++ b/src/MultiPhase/multiphase_flow.jl
@@ -62,6 +62,23 @@ const MultiPhaseHamiltonianFlow{TD<:Traits.TimeDependence,VD<:Traits.VariableDep
     TD,VD,Traits.HamiltonianDynamics,FS,ST,J
 }
 
+"""
+$(TYPEDSIGNATURES)
+
+Construct a `MultiPhaseStateFlow` from a tuple of flows, switching times, and jumps.
+
+The time and variable dependence traits are inferred from the first flow.
+
+# Arguments
+- `flows::Tuple`: Tuple of phase flows (each `<: Flows.AbstractStateFlow`).
+- `switching_times::Vector{<:Real}`: Switching times between phases.
+- `jumps::Vector{<:Any}`: Jump conditions at each switching time.
+
+# Returns
+- A `MultiPhaseFlow` with `StateDynamics` trait.
+
+See also: [`CTFlows.MultiPhase.MultiPhaseFlow`](@ref), [`CTFlows.MultiPhase.MultiPhaseHamiltonianFlow`](@ref).
+"""
 function MultiPhaseStateFlow(
     flows::FS, switching_times::ST, jumps::J
 ) where {FS<:Tuple,ST,J}
@@ -78,6 +95,23 @@ function MultiPhaseStateFlow(
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Construct a `MultiPhaseHamiltonianFlow` from a tuple of flows, switching times, and jumps.
+
+The time and variable dependence traits are inferred from the first flow.
+
+# Arguments
+- `flows::Tuple`: Tuple of phase flows (each `<: Flows.AbstractHamiltonianFlow`).
+- `switching_times::Vector{<:Real}`: Switching times between phases.
+- `jumps::Vector{<:Any}`: Jump conditions at each switching time.
+
+# Returns
+- A `MultiPhaseFlow` with `HamiltonianDynamics` trait.
+
+See also: [`CTFlows.MultiPhase.MultiPhaseFlow`](@ref), [`CTFlows.MultiPhase.MultiPhaseStateFlow`](@ref).
+"""
 function MultiPhaseHamiltonianFlow(
     flows::FS, switching_times::ST, jumps::J
 ) where {FS<:Tuple,ST,J}
@@ -278,6 +312,12 @@ function _multiphase_display_name(
 )
     return "MultiPhaseStateFlow"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `"MultiPhaseHamiltonianFlow"` for a `MultiPhaseFlow` with `HamiltonianDynamics`.
+"""
 function _multiphase_display_name(
     ::MultiPhaseFlow{
         <:Traits.TimeDependence,<:Traits.VariableDependence,Traits.HamiltonianDynamics
@@ -285,6 +325,12 @@ function _multiphase_display_name(
 )
     return "MultiPhaseHamiltonianFlow"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Fallback: return the concrete type name as a string.
+"""
 function _multiphase_display_name(mpf::MultiPhaseFlow)
     return string(nameof(typeof(mpf)))
 end

--- a/src/Systems/coercion.jl
+++ b/src/Systems/coercion.jl
@@ -31,6 +31,14 @@ Collapse a length-1 array to its single scalar element, GPU-safely.
 See also: [`CTFlows.Systems._coerce_state`](@ref).
 """
 _safe_only(x::GPUArraysCore.AbstractGPUArray) = GPUArraysCore.@allowscalar only(x)
+
+"""
+$(TYPEDSIGNATURES)
+
+Host-array fallback: exactly `only(x)`.
+
+See also: [`CTFlows.Systems._safe_only`](@ref).
+"""
 _safe_only(x) = only(x)
 
 """
@@ -44,7 +52,23 @@ Infer the state dimension from the initial condition shape.
 - `_state_dim(x0::AbstractMatrix) = size(x0, 1)`
 """
 _state_dim(::Number) = 1
+
+"""
+$(TYPEDSIGNATURES)
+
+State dimension of a vector initial condition: `length(x)`.
+
+See also: [`CTFlows.Systems._state_dim`](@ref).
+"""
 _state_dim(x::AbstractVector) = length(x)
+
+"""
+$(TYPEDSIGNATURES)
+
+State dimension of a batched `Matrix` initial condition: `size(x, 1)` (per-column batch).
+
+See also: [`CTFlows.Systems._state_dim`](@ref).
+"""
 _state_dim(x::AbstractMatrix) = size(x, 1)
 
 """
@@ -80,7 +104,23 @@ are left untouched via `identity`.
 See also: [`CTFlows.Systems._safe_only`](@ref).
 """
 _coerce_state(::Number) = _safe_only
+
+"""
+$(TYPEDSIGNATURES)
+
+Batched `Matrix` states are always left untouched (`identity`): batch mode never collapses to a scalar.
+
+See also: [`CTFlows.Systems._coerce_state`](@ref).
+"""
 _coerce_state(::AbstractMatrix) = identity
+
+"""
+$(TYPEDSIGNATURES)
+
+Vector states: `_safe_only` for length 1 (1-D = scalar convention), `identity` otherwise.
+
+See also: [`CTFlows.Systems._coerce_state`](@ref), [`CTFlows.Systems._safe_only`](@ref).
+"""
 _coerce_state(x::AbstractVector) = length(x) == 1 ? _safe_only : identity
 
 """
@@ -121,7 +161,23 @@ Return `src` in a form that can be broadcast into `dst` without a device/host mi
 See also: [`CTFlows.Systems._aug_assign!`](@ref), [`CTFlows.Systems._safe_only`](@ref).
 """
 _device_like(::AbstractArray, src) = src
+
+"""
+$(TYPEDSIGNATURES)
+
+Scalar source is always compatible with any destination: return `src` as-is.
+
+See also: [`CTFlows.Systems._device_like`](@ref).
+"""
 _device_like(::GPUArraysCore.AbstractGPUArray, src::Number) = src
+
+"""
+$(TYPEDSIGNATURES)
+
+Device-resident source on a matching device destination: return `src` as-is (no copy).
+
+See also: [`CTFlows.Systems._device_like`](@ref).
+"""
 _device_like(::GPUArraysCore.AbstractGPUArray, src::GPUArraysCore.AbstractGPUArray) = src
 function _device_like(dst::GPUArraysCore.AbstractGPUArray, src::AbstractArray)
     return copyto!(similar(dst, eltype(src), size(src)), src)
@@ -158,6 +214,14 @@ Allocate an uninitialised length-`n` buffer of eltype `T` in `template`'s array 
 See also: [`CTFlows.Systems._device_like`](@ref), [`CTFlows.Systems._safe_only`](@ref).
 """
 _buffer_like(template::AbstractArray, ::Type{T}, n::Int) where {T} = similar(template, T, n)
+
+"""
+$(TYPEDSIGNATURES)
+
+Scalar fallback: allocate a host `Vector{T}(undef, n)` — `similar` is undefined for `Number`.
+
+See also: [`CTFlows.Systems._buffer_like`](@ref).
+"""
 _buffer_like(::Any, ::Type{T}, n::Int) where {T} = Vector{T}(undef, n)
 
 """

--- a/src/Systems/constrained_pseudo_hamiltonian_rhs_functors.jl
+++ b/src/Systems/constrained_pseudo_hamiltonian_rhs_functors.jl
@@ -253,12 +253,37 @@ end
 # Display
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a descriptive label for the RHS conversion performed by a constrained pseudo-Hamiltonian functor.
+
+Used internally by `Base.show` for display.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref).
+"""
 function _rhs_conversion_label(::ConstrainedPseudoHamIpRHS)
     return "Constrained PseudoHamiltonian AD → in-place interface"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Constrained pseudo-Hamiltonian AD wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::ConstrainedPseudoHamOoPRHS)
     return "Constrained PseudoHamiltonian AD → out-of-place interface"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Constrained pseudo-Hamiltonian AD wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::ConstrainedPseudoHamIpAugRHS)
     return "Constrained PseudoHamiltonian AD → in-place augmented interface"
 end

--- a/src/Systems/constrained_pseudo_hamiltonian_system.jl
+++ b/src/Systems/constrained_pseudo_hamiltonian_system.jl
@@ -62,6 +62,15 @@ struct ConstrainedPseudoHamiltonianSystem{
     backend::BACKEND
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+A `ConstrainedPseudoHamiltonianSystem` is AD-backed: the constrained pseudo-Hamiltonian
+`H̃ + μ·g` is differentiated at frozen `(u, μ)` to produce the RHS.
+
+See also: [`CTFlows.Systems.ConstrainedPseudoHamiltonianSystem`](@ref),
+[`CTBase.Traits.WithAD`](@extref).
+"""
 Traits.ad_trait(::ConstrainedPseudoHamiltonianSystem) = Traits.WithAD
 
 # Note: no explicit outer constructor — Julia's auto-generated default outer
@@ -232,6 +241,16 @@ end
 # Base.show
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of a `ConstrainedPseudoHamiltonianSystem`.
+
+Shows the type name, time/variable dependence traits, and the wrapped pseudo-Hamiltonian,
+control law, constraint, multiplier, and AD backend.
+
+See also: [`CTFlows.Systems.ConstrainedPseudoHamiltonianSystem`](@ref).
+"""
 function Base.show(io::IO, sys::ConstrainedPseudoHamiltonianSystem)
     fmt = Display.format_codes(io)
     Display.print_header(io, "ConstrainedPseudoHamiltonianSystem"; fmt=fmt)

--- a/src/Systems/hamiltonian_rhs_functors.jl
+++ b/src/Systems/hamiltonian_rhs_functors.jl
@@ -309,24 +309,43 @@ end
 # =============================================================================
 
 """
+$(TYPEDSIGNATURES)
+
 Return a descriptive label for the RHS conversion performed by a Hamiltonian functor.
 
-# Arguments
-- `f::AbstractHamRHS`: The Hamiltonian RHS functor.
+Used internally by `Base.show` for display.
 
-# Returns
-- `String`: Description of the conversion (e.g., "Hamiltonian AD → in-place interface").
-
-# Notes
-- Used internally by `Base.show` for display.
-- Different functors have different conversion labels.
-
-See also: [`CTFlows.Systems.AbstractHamRHS`](@ref), [`CTFlows.Systems.HamIpRHS`](@ref), [`CTFlows.Systems.HamOoPRHS`](@ref).
+See also: [`CTFlows.Systems.AbstractHamRHS`](@ref).
 """
 _rhs_conversion_label(::HamIpRHS) = "Hamiltonian AD → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Hamiltonian AD wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::HamOoPRHS) = "Hamiltonian AD → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Hamiltonian AD wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::HamIpAugRHS) = "Hamiltonian AD → in-place augmented interface"
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of an `AbstractHamRHS` functor.
+
+Shows the functor type name, the wrapped Hamiltonian's traits, and the conversion label.
+
+See also: [`CTFlows.Systems.AbstractHamRHS`](@ref), [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function Base.show(io::IO, f::AbstractHamRHS)
     fmt = Display.format_codes(io)
     td = Traits.time_dependence(f.h)
@@ -339,6 +358,15 @@ function Base.show(io::IO, f::AbstractHamRHS)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display an `AbstractHamRHS` functor in the REPL with `text/plain` MIME type.
+
+Delegates to the compact `show` method.
+
+See also: [`CTFlows.Systems.AbstractHamRHS`](@ref).
+"""
 function Base.show(io::IO, ::MIME"text/plain", f::AbstractHamRHS)
     return show(io, f)
 end

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -21,19 +21,18 @@ inputs with consistent output shapes.
 ```julia-repl
 julia> using CTFlows.Systems
 
-julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
-HamiltonianVectorField
-  time_dependence: Autonomous
-  variable_dependence: Fixed
-  mutability: OutOfPlace
-  function: var"#1"
+julia> hvf = Data.HamiltonianVectorField((x, p) -> (x, -p))
+HamiltonianVectorField: autonomous, fixed (no variable), out-of-place
+  natural call: f(x, p)
+  uniform call: f(t, x, p, v)
 
 julia> sys = HamiltonianVectorFieldSystem(hvf)
 HamiltonianVectorFieldSystem
-  time_dependence: Autonomous
-  variable_dependence: Fixed
-  mutability: OutOfPlace
-  hamiltonian_vector_field: HamiltonianVectorField{var"#1", Autonomous, Fixed, OutOfPlace}
+├─ time_dependence: Autonomous
+├─ variable_dependence: Fixed
+└─ HamiltonianVectorField: autonomous, fixed (no variable), out-of-place
+   natural call: f(x, p)
+   uniform call: f(t, x, p, v)
 ```
 
 See also: [`CTBase.Data.HamiltonianVectorField`](@extref), [`CTFlows.Systems.AbstractHamiltonianSystem`](@ref), `TimeDependence`, [`CTBase.Traits.VariableDependence`](@extref), `build_rhs`, `build_oop_rhs`.
@@ -47,6 +46,16 @@ struct HamiltonianVectorFieldSystem{
     hvf::Data.HamiltonianVectorField{F,TD,VD,MD}
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return the AD trait of a `HamiltonianVectorFieldSystem`, which is always
+[`CTBase.Traits.WithoutAD`](@extref): the system stores the Hamiltonian vector field
+`X_H` directly and performs no automatic differentiation.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref),
+[`CTBase.Traits.WithoutAD`](@extref).
+"""
 Traits.ad_trait(::HamiltonianVectorFieldSystem) = Traits.WithoutAD
 
 # Note: no explicit outer constructor — Julia's auto-generated default outer
@@ -82,6 +91,14 @@ Dispatches on the array type (`AbstractVector` or `AbstractMatrix`) and the know
 - The `CTFlowsStaticArrays` extension provides a type-stable method for `StaticVector`.
 """
 _ham_split(u::AbstractVector, N::Int) = (@view(u[1:N]), @view(u[(N + 1):2N]))
+
+"""
+$(TYPEDSIGNATURES)
+
+Matrix variant of [`CTFlows.Systems._ham_split`](@ref): splits each column of `u` into state and costate row-block views.
+
+See also: [`CTFlows.Systems._ham_split`](@ref).
+"""
 _ham_split(u::AbstractMatrix, N::Int) = (@view(u[1:N, :]), @view(u[(N + 1):2N, :]))
 
 """
@@ -105,6 +122,14 @@ Dispatches on the array type (`AbstractVector` or `AbstractMatrix`) and the know
 - Performs in-place assignment using broadcasting.
 """
 _ham_assign!(du::AbstractVector, dx, dp, N::Int) = (du[1:N].=dx; du[(N + 1):2N].=dp)
+
+"""
+$(TYPEDSIGNATURES)
+
+Matrix variant of [`CTFlows.Systems._ham_assign!`](@ref): assigns state and costate derivatives into the corresponding row-blocks of each column.
+
+See also: [`CTFlows.Systems._ham_assign!`](@ref).
+"""
 _ham_assign!(du::AbstractMatrix, dx, dp, N::Int) = (du[1:N, :].=dx; du[(N + 1):2N, :].=dp)
 
 # =============================================================================
@@ -142,6 +167,14 @@ function _aug_split(u::AbstractVector, n_x::Int, n_v::Int)
     pv = @view(u[(end - n_v + 1):end])
     return (x, p, pv)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Matrix variant of [`CTFlows.Systems._aug_split`](@ref): splits each column of `u` into state, costate, and variable-costate row-block views.
+
+See also: [`CTFlows.Systems._aug_split`](@ref).
+"""
 function _aug_split(u::AbstractMatrix, n_x::Int, n_v::Int)
     return (
         @view(u[1:n_x, :]),
@@ -184,6 +217,14 @@ function _aug_assign!(du::AbstractVector, dx, dp, dpv, n_x::Int, n_v::Int)
     du[(end - n_v + 1):end] .= _device_like(du, dpv)
     return nothing
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Matrix variant of [`CTFlows.Systems._aug_assign!`](@ref): assigns state, costate, and variable-costate derivatives into the corresponding row-blocks of each column.
+
+See also: [`CTFlows.Systems._aug_assign!`](@ref).
+"""
 function _aug_assign!(du::AbstractMatrix, dx, dp, dpv, n_x::Int, n_v::Int)
     du[1:n_x, :] .= _device_like(du, dx)
     du[(n_x + 1):(2 * n_x), :] .= _device_like(du, dp)
@@ -365,11 +406,48 @@ end
 # Trait: variable_costate
 # =============================================================================
 
-# TODO: docstring
+"""
+$(TYPEDSIGNATURES)
+
+Return the variable-costate trait of a `HamiltonianVectorFieldSystem` with
+`NonFixed` variable dependence, which is
+[`CTBase.Traits.SupportsVariableCostate`](@extref): the Hamiltonian vector field
+carries a variable argument `v`, so the augmented system `ṗv = -∂H/∂v` can be
+integrated.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref),
+[`CTBase.Traits.SupportsVariableCostate`](@extref).
+"""
 function Traits.variable_costate_trait(
     ::HamiltonianVectorFieldSystem{F,TD,Traits.NonFixed,MD}
 ) where {F<:Function,TD<:Traits.TimeDependence,MD<:Traits.AbstractMutabilityTrait}
     return Traits.SupportsVariableCostate
+end
+
+# =============================================================================
+# hamiltonian getter — informative error (no scalar Hamiltonian stored)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Throw an `IncorrectArgument` error: a `HamiltonianVectorFieldSystem` stores the
+vector field `X_H` directly and carries no scalar Hamiltonian. Use
+[`CTFlows.Systems.hamiltonian_vector_field`](@ref) to retrieve `X_H` instead.
+
+See also: [`CTFlows.Systems.HamiltonianVectorFieldSystem`](@ref),
+[`CTFlows.Systems.hamiltonian_vector_field`](@ref).
+"""
+function hamiltonian(::HamiltonianVectorFieldSystem)
+    return throw(
+        Exceptions.IncorrectArgument(
+            "no scalar Hamiltonian available for a HamiltonianVectorFieldSystem";
+            got="a HamiltonianVectorFieldSystem (stores the vector field directly, no AD)",
+            expected="a HamiltonianSystem or PseudoHamiltonianSystem (built from a scalar Hamiltonian with AD)",
+            suggestion="use hamiltonian_vector_field(flow) to retrieve X_H, or build the flow from a scalar Hamiltonian",
+            context="hamiltonian(sys::HamiltonianVectorFieldSystem)",
+        ),
+    )
 end
 
 # =============================================================================
@@ -398,9 +476,22 @@ function Base.show(
     MD<:Traits.AbstractMutabilityTrait,
 }
     fmt = Display.format_codes(io)
-    wraps = "HamiltonianVectorField: $(Data._td_label(TD)), $(Data._vd_label(VD)), $(Data._md_label(MD))"
     Display.print_header(io, "HamiltonianVectorFieldSystem"; fmt=fmt)
-    return Display.print_field(io, "wraps", wraps; last=true, fmt=fmt, value_style="")
+    Display.print_field(
+        io,
+        "time_dependence",
+        nameof(Traits.time_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    Display.print_field(
+        io,
+        "variable_dependence",
+        nameof(Traits.variable_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    return Display.print_field(io, "", sys.hvf; last=true, fmt=fmt, value_style="")
 end
 
 """

--- a/src/Systems/hvf_rhs_functors.jl
+++ b/src/Systems/hvf_rhs_functors.jl
@@ -363,16 +363,81 @@ end
 # Display helpers
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a descriptive label for the RHS conversion performed by a Hamiltonian vector field functor.
+
+Used internally by `Base.show` for display.
+
+See also: [`CTFlows.Systems.AbstractHVFRHS`](@ref).
+"""
 _rhs_conversion_label(::IPHVFOoPRHS) = "out-of-place HVF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place HVF wrapped as in-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::IPHVFIpRHS) = "in-place HVF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place HVF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::OoPHVFOoPRHS) = "out-of-place HVF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place HVF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::OoPHVFIpRHS) = "in-place HVF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place HVF wrapped as out-of-place interface with type-finalize conversion.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::OoPHVFIpFinalizeRHS)
     return "in-place HVF → out-of-place interface + finalize"
 end
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place HVF wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::IPHVFOoPAugRHS) = "out-of-place HVF → in-place augmented interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place HVF wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::IPHVFIpAugRHS) = "in-place HVF → in-place augmented interface"
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of an `AbstractHVFRHS` functor.
+
+Shows the functor type name, the wrapped HamiltonianVectorField's traits, and the conversion label.
+
+See also: [`CTFlows.Systems.AbstractHVFRHS`](@ref), [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function Base.show(io::IO, f::AbstractHVFRHS)
     fmt = Display.format_codes(io)
     td = Traits.time_dependence(f.hvf)
@@ -386,6 +451,15 @@ function Base.show(io::IO, f::AbstractHVFRHS)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display an `AbstractHVFRHS` functor in the REPL with `text/plain` MIME type.
+
+Delegates to the compact `show` method.
+
+See also: [`CTFlows.Systems.AbstractHVFRHS`](@ref).
+"""
 function Base.show(io::IO, ::MIME"text/plain", f::AbstractHVFRHS)
     return show(io, f)
 end

--- a/src/Systems/pseudo_hamiltonian_rhs_functors.jl
+++ b/src/Systems/pseudo_hamiltonian_rhs_functors.jl
@@ -187,12 +187,46 @@ end
 # Display
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a descriptive label for the RHS conversion performed by a pseudo-Hamiltonian functor.
+
+Used internally by `Base.show` for display.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref).
+"""
 _rhs_conversion_label(::PseudoHamIpRHS) = "PseudoHamiltonian AD → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Pseudo-Hamiltonian AD wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::PseudoHamOoPRHS) = "PseudoHamiltonian AD → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Pseudo-Hamiltonian AD wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::PseudoHamIpAugRHS)
     return "PseudoHamiltonian AD → in-place augmented interface"
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of an `AbstractPseudoHamRHS` functor.
+
+Shows the functor type name, the wrapped pseudo-Hamiltonian's traits, and the conversion label.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref), [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function Base.show(io::IO, f::AbstractPseudoHamRHS)
     fmt = Display.format_codes(io)
     td = Traits.time_dependence(f.h̃)
@@ -205,6 +239,15 @@ function Base.show(io::IO, f::AbstractPseudoHamRHS)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display an `AbstractPseudoHamRHS` functor in the REPL with `text/plain` MIME type.
+
+Delegates to the compact `show` method.
+
+See also: [`CTFlows.Systems.AbstractPseudoHamRHS`](@ref).
+"""
 function Base.show(io::IO, ::MIME"text/plain", f::AbstractPseudoHamRHS)
     return show(io, f)
 end

--- a/src/Systems/pseudo_hamiltonian_system.jl
+++ b/src/Systems/pseudo_hamiltonian_system.jl
@@ -183,6 +183,16 @@ end
 # Base.show
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of a `PseudoHamiltonianSystem`.
+
+Shows the type name, time/variable dependence traits, and the wrapped pseudo-Hamiltonian,
+control law, and AD backend.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianSystem`](@ref).
+"""
 function Base.show(io::IO, sys::PseudoHamiltonianSystem)
     fmt = Display.format_codes(io)
     Display.print_header(io, "PseudoHamiltonianSystem"; fmt=fmt)

--- a/src/Systems/pseudo_hamiltonian_vector_field_system.jl
+++ b/src/Systems/pseudo_hamiltonian_vector_field_system.jl
@@ -45,6 +45,16 @@ struct PseudoHamiltonianVectorFieldSystem{
     law::L
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Return the AD trait of a `PseudoHamiltonianVectorFieldSystem`, which is always
+[`CTBase.Traits.WithoutAD`](@extref): the system stores the pseudo-Hamiltonian vector
+field `X_H̃` directly and performs no automatic differentiation.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianVectorFieldSystem`](@ref),
+[`CTBase.Traits.WithoutAD`](@extref).
+"""
 Traits.ad_trait(::PseudoHamiltonianVectorFieldSystem) = Traits.WithoutAD
 
 # Note: no explicit outer constructor — Julia's auto-generated default outer
@@ -216,6 +226,32 @@ function Traits.variable_costate_trait(
 end
 
 # =============================================================================
+# hamiltonian getter — informative error (no scalar Hamiltonian stored)
+# =============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Throw an `IncorrectArgument` error: a `PseudoHamiltonianVectorFieldSystem` stores the
+pseudo-Hamiltonian vector field `X_H̃` directly and carries no scalar Hamiltonian. Use
+[`CTFlows.Systems.hamiltonian_vector_field`](@ref) to retrieve `X_H̃` instead.
+
+See also: [`CTFlows.Systems.PseudoHamiltonianVectorFieldSystem`](@ref),
+[`CTFlows.Systems.hamiltonian_vector_field`](@ref).
+"""
+function hamiltonian(::PseudoHamiltonianVectorFieldSystem)
+    return throw(
+        Exceptions.IncorrectArgument(
+            "no scalar Hamiltonian available for a PseudoHamiltonianVectorFieldSystem";
+            got="a PseudoHamiltonianVectorFieldSystem (stores the vector field directly, no AD)",
+            expected="a HamiltonianSystem or PseudoHamiltonianSystem (built from a scalar Hamiltonian with AD)",
+            suggestion="use hamiltonian_vector_field(flow) to retrieve X_H̃, or build the flow from a scalar PseudoHamiltonian",
+            context="hamiltonian(sys::PseudoHamiltonianVectorFieldSystem)",
+        ),
+    )
+end
+
+# =============================================================================
 # Base.show
 # =============================================================================
 
@@ -239,9 +275,22 @@ function Base.show(
     L<:Data.ControlLaw{<:Function,Traits.DynClosedLoopFeedback},
 }
     fmt = Display.format_codes(io)
-    wraps = "PseudoHamiltonianVectorField: $(Data._td_label(TD)), $(Data._vd_label(VD)), $(Data._md_label(MD))"
     Display.print_header(io, "PseudoHamiltonianVectorFieldSystem"; fmt=fmt)
-    Display.print_field(io, "wraps", wraps; fmt=fmt, value_style="")
+    Display.print_field(
+        io,
+        "time_dependence",
+        nameof(Traits.time_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    Display.print_field(
+        io,
+        "variable_dependence",
+        nameof(Traits.variable_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    Display.print_field(io, "", sys.h̃vf; fmt=fmt, value_style="")
     return Display.print_field(io, "", sys.law; last=true, fmt=fmt, value_style="")
 end
 

--- a/src/Systems/pseudo_hvf_rhs_functors.jl
+++ b/src/Systems/pseudo_hvf_rhs_functors.jl
@@ -378,20 +378,86 @@ end
 # Display
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a descriptive label for the RHS conversion performed by a pseudo-Hamiltonian vector field functor.
+
+Used internally by `Base.show` for display.
+
+See also: [`CTFlows.Systems.AbstractPseudoHVFRHS`](@ref).
+"""
 _rhs_conversion_label(::IPPseudoHVFOoPRHS) = "out-of-place PHVF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place PHVF wrapped as in-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::IPPseudoHVFIpRHS) = "in-place PHVF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place PHVF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::OoPPseudoHVFOoPRHS) = "out-of-place PHVF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place PHVF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(::OoPPseudoHVFIpRHS) = "in-place PHVF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place PHVF wrapped as out-of-place interface with type-finalize conversion.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::OoPPseudoHVFIpFinalizeRHS)
     return "in-place PHVF → out-of-place interface + finalize"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place PHVF wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::IPPseudoHVFOoPAugRHS)
     return "out-of-place PHVF → in-place augmented interface"
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place PHVF wrapped as in-place augmented interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(::IPPseudoHVFIpAugRHS)
     return "in-place PHVF → in-place augmented interface"
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of an `AbstractPseudoHVFRHS` functor.
+
+Shows the functor type name, the wrapped PseudoHamiltonianVectorField's traits, and the conversion label.
+
+See also: [`CTFlows.Systems.AbstractPseudoHVFRHS`](@ref), [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function Base.show(io::IO, f::AbstractPseudoHVFRHS)
     fmt = Display.format_codes(io)
     td = Traits.time_dependence(f.h̃vf)
@@ -405,6 +471,15 @@ function Base.show(io::IO, f::AbstractPseudoHVFRHS)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display an `AbstractPseudoHVFRHS` functor in the REPL with `text/plain` MIME type.
+
+Delegates to the compact `show` method.
+
+See also: [`CTFlows.Systems.AbstractPseudoHVFRHS`](@ref).
+"""
 function Base.show(io::IO, ::MIME"text/plain", f::AbstractPseudoHVFRHS)
     return show(io, f)
 end

--- a/src/Systems/rhs_functors.jl
+++ b/src/Systems/rhs_functors.jl
@@ -217,14 +217,64 @@ end
 # Display helpers
 # =============================================================================
 
+"""
+$(TYPEDSIGNATURES)
+
+Return a descriptive label for the RHS conversion performed by a vector-field functor.
+
+Used internally by `Base.show` for display.
+
+See also: [`CTFlows.Systems.AbstractRHS`](@ref).
+"""
 _rhs_conversion_label(f::IPVFOoPRHS) = "out-of-place VF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place VF wrapped as in-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(f::IPVFIpRHS) = "in-place VF → in-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+Out-of-place VF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(f::OoPVFOoPRHS) = "out-of-place VF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place VF wrapped as out-of-place interface.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 _rhs_conversion_label(f::OoPVFIpRHS) = "in-place VF → out-of-place interface"
+
+"""
+$(TYPEDSIGNATURES)
+
+In-place VF wrapped as out-of-place interface with type-finalize conversion.
+
+See also: [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function _rhs_conversion_label(f::OoPVFIpFinalizeRHS)
     return "in-place VF → out-of-place interface + finalize"
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact representation of an `AbstractRHS` functor.
+
+Shows the functor type name, the wrapped vector field's traits, and the conversion label.
+
+See also: [`CTFlows.Systems.AbstractRHS`](@ref), [`CTFlows.Systems._rhs_conversion_label`](@ref).
+"""
 function Base.show(io::IO, f::AbstractRHS)
     fmt = Display.format_codes(io)
     td = Traits.time_dependence(f.vf)
@@ -238,6 +288,15 @@ function Base.show(io::IO, f::AbstractRHS)
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Display an `AbstractRHS` functor in the REPL with `text/plain` MIME type.
+
+Delegates to the compact `show` method.
+
+See also: [`CTFlows.Systems.AbstractRHS`](@ref).
+"""
 function Base.show(io::IO, ::MIME"text/plain", f::AbstractRHS)
     return show(io, f)
 end

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -19,19 +19,18 @@ coercing a 1-D state to a scalar before calling the user's vector field (issue
 \`\`\`julia-repl
 julia> using CTFlows.Systems
 
-julia> vf = VectorField(x -> -x; autonomous=true, variable=false)
-VectorField
-  time_dependence: Autonomous
-  variable_dependence: Fixed
-  mutability: OutOfPlace
-  function: var"#1"
+julia> vf = Data.VectorField(x -> -x)
+VectorField: autonomous, fixed (no variable), out-of-place
+  natural call: f(x)
+  uniform call: f(t, x, v)
 
 julia> sys = VectorFieldSystem(vf)
 VectorFieldSystem
-  time_dependence: Autonomous
-  variable_dependence: Fixed
-  mutability: OutOfPlace
-  vector_field: VectorField{var"#1", Autonomous, Fixed, OutOfPlace}
+├─ time_dependence: Autonomous
+├─ variable_dependence: Fixed
+└─ VectorField: autonomous, fixed (no variable), out-of-place
+   natural call: f(x)
+   uniform call: f(t, x, v)
 \`\`\`
 
 See also: [`CTBase.Data.VectorField`](@extref), `TimeDependence`, [`CTBase.Traits.VariableDependence`](@extref), [`CTFlows.Systems.ODEParameters`](@ref).
@@ -212,9 +211,22 @@ function Base.show(
     F<:Data.AbstractVectorField{TD,VD,MD},
 }
     fmt = Display.format_codes(io)
-    wraps = "VectorField: $(Data._td_label(TD)), $(Data._vd_label(VD)), $(Data._md_label(MD))"
     Display.print_header(io, "VectorFieldSystem"; fmt=fmt)
-    return Display.print_field(io, "wraps", wraps; last=true, fmt=fmt, value_style="")
+    Display.print_field(
+        io,
+        "time_dependence",
+        nameof(Traits.time_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    Display.print_field(
+        io,
+        "variable_dependence",
+        nameof(Traits.variable_dependence(sys));
+        fmt=fmt,
+        value_style=fmt.type,
+    )
+    return Display.print_field(io, "", sys.vf; last=true, fmt=fmt, value_style="")
 end
 
 """

--- a/src/Trajectories/hamiltonian_vector_field_trajectory.jl
+++ b/src/Trajectories/hamiltonian_vector_field_trajectory.jl
@@ -97,10 +97,30 @@ For vector/matrix x0, extracts views of the appropriate size.
 function _ham_split_solution(u::AbstractVector, x0::Number)
     return (Systems._safe_only(u[1:1]), Systems._safe_only(u[2:2]))
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Split a combined state–costate vector into two sub-vectors, using `length(x0)` as the
+state dimension `n`.
+
+# Returns
+- `(u[1:n], u[(n+1):2n])`: state and costate sub-vectors.
+"""
 _ham_split_solution(u::AbstractVector, x0::AbstractVector) =
     let n = length(x0)
         (u[1:n], u[(n + 1):2n])
     end
+
+"""
+$(TYPEDSIGNATURES)
+
+Split a combined state–costate matrix into two sub-matrices (column-wise), using
+`size(x0, 1)` as the state dimension `n`.
+
+# Returns
+- `(u[1:n, :], u[(n+1):2n, :])`: state and costate sub-matrices.
+"""
 function _ham_split_solution(u::AbstractMatrix, x0::AbstractMatrix)
     let n = size(x0, 1)
         (u[1:n, :], u[(n + 1):2n, :])
@@ -185,6 +205,15 @@ struct StateProjection{R<:Integrators.AbstractIntegrationResult,X0} <: Function
     result::R
     x0::X0
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate the state projection at time `t`: returns `x(t)`, the state component of the
+underlying `HamiltonianVectorFieldTrajectory`.
+
+Equivalent to `sol(t)[1]`.
+"""
 function (sp::StateProjection)(t::Real)
     return _ham_split_solution(Integrators.evaluate_at(sp.result, t), sp.x0)[1]
 end
@@ -210,6 +239,15 @@ struct CostateProjection{R<:Integrators.AbstractIntegrationResult,X0} <: Functio
     result::R
     x0::X0
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Evaluate the costate projection at time `t`: returns `p(t)`, the costate component of the
+underlying `HamiltonianVectorFieldTrajectory`.
+
+Equivalent to `sol(t)[2]`.
+"""
 function (cp::CostateProjection)(t::Real)
     return _ham_split_solution(Integrators.evaluate_at(cp.result, t), cp.x0)[2]
 end

--- a/src/Trajectories/state_flow_trajectory.jl
+++ b/src/Trajectories/state_flow_trajectory.jl
@@ -202,6 +202,16 @@ projection (`cp === nothing`, a basic control-free `Flow(ocp)`). Dispatch helper
 [`CTFlows.Trajectories.control`](@ref).
 """
 _sft_control(cp::ControlProjection) = cp
+
+"""
+$(TYPEDSIGNATURES)
+
+Throw a `PreconditionError` because the `StateFlowTrajectory` has no control projection
+(`cp === nothing`, a basic control-free `Flow(ocp)`).
+
+This happens when the flow was built without a control law (e.g. for direct shooting),
+so there is no control to reconstruct.
+"""
 function _sft_control(::Nothing)
     return throw(
         Exceptions.PreconditionError(

--- a/test/suite/flows/test_abstract_flow.jl
+++ b/test/suite/flows/test_abstract_flow.jl
@@ -38,6 +38,7 @@ end
 Strategies.id(::Type{FakeIntegrator}) = :fake_integrator
 Strategies.metadata(::Type{FakeIntegrator}) = Strategies.StrategyMetadata()
 Strategies.options(integ::FakeIntegrator) = Strategies.StrategyOptions()
+Strategies.parameter(::Type{FakeIntegrator}) = nothing
 
 """
 Fake flow for testing the AbstractFlow contract.

--- a/test/suite/flows/test_flow.jl
+++ b/test/suite/flows/test_flow.jl
@@ -28,6 +28,7 @@ end
 Strategies.id(::Type{FakeIntegrator}) = :fake_integrator
 Strategies.metadata(::Type{FakeIntegrator}) = Strategies.StrategyMetadata()
 Strategies.options(integ::FakeIntegrator) = Strategies.StrategyOptions()
+Strategies.parameter(::Type{FakeIntegrator}) = nothing
 
 """
 Fake flow for testing Flow contract without requiring SciML extension.

--- a/test/suite/multiphase/test_multiphase_flow.jl
+++ b/test/suite/multiphase/test_multiphase_flow.jl
@@ -32,6 +32,7 @@ import CTBase.Options
 Strategies.id(::Type{FakeIntegrator}) = :fake_integrator
 Strategies.metadata(::Type{FakeIntegrator}) = Strategies.StrategyMetadata()
 Strategies.options(integ::FakeIntegrator) = Options.StrategyOptions()
+Strategies.parameter(::Type{FakeIntegrator}) = nothing
 
 # ==============================================================================
 # Test function

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -354,10 +354,13 @@ function test_vector_field_system()
                 show(io, sys)
                 str = String(take!(io))
                 Test.@test occursin("VectorFieldSystem", str)
-                Test.@test occursin("wraps:", str)
+                Test.@test occursin("time_dependence", str)
+                Test.@test occursin("variable_dependence", str)
                 Test.@test occursin("autonomous", str)
                 Test.@test occursin("fixed (no variable)", str)
                 Test.@test occursin("out-of-place", str)
+                Test.@test occursin("natural call", str)
+                Test.@test occursin("uniform call", str)
             end
 
             Test.@testset "Base.show (text/plain)" begin
@@ -365,7 +368,7 @@ function test_vector_field_system()
                 show(io, MIME("text/plain"), sys)
                 str = String(take!(io))
                 Test.@test occursin("VectorFieldSystem", str)
-                Test.@test occursin("wraps:", str)
+                Test.@test occursin("time_dependence", str)
             end
         end
 


### PR DESCRIPTION
## Summary

This PR reviews the documentation — both content and form.

### Changes

- **`docs/src/getting-started.md`**: switched numbered list to bullet points in the "Mental model" section; clarified that SciML is the default (and unique) strategy; cleaned up `@example` blocks (removed `nothing # hide`, separated Hamiltonian example into its own block, added `using Plots` before `plot(sol)`).
- **`docs/src/index.md`**: updated the layer table with missing types (`PseudoHamiltonianVectorField`, `StateTrajectoryConfig`, `HamiltonianEndPointConfig`, `HamiltonianVectorFieldSystem`, `PseudoHamiltonianVectorFieldSystem`, `ConstrainedPseudoHamiltonianSystem`, `MultiPhaseHamiltonianFlow`); aligned inline comments.
- **`src/Display/Display.jl`**: updated `print_field` docstring and removed value-column padding for continuation lines (now indented under the branch character).
- **`src/Flows/abstract_flow.jl`**: updated `show` docstring example to reflect the new tree-style display format (`├─`, `│  └─`, `└─`).

### Goal

Ensure the documentation accurately reflects the current API surface and that the rendered output is clean and consistent.