### PR TITLE
Unify Trajectories accessors with CTModels.Components generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1-beta] - 2026-07-28
+
+### Changed
+
+- **`Trajectories.{state,control,costate,objective,time_grid}` are now methods of the
+  `CTModels.Components` generics of the same name** ([#370]), instead of distinct
+  CTFlows-local generics that happened to share a spelling. `VectorFieldTrajectory`,
+  `HamiltonianVectorFieldTrajectory` and `StateFlowTrajectory` contribute methods to
+  `CTModels.Components.{state,control,costate,objective,time_grid}` rather than shadowing
+  them. Non-breaking for callers: every existing call site and export keeps working
+  unchanged; the only observable difference is that `parentmodule` changes and that
+  importing both `CTFlows.Trajectories` and `CTModels.Components` accessors into one
+  module now succeeds instead of erroring.
+
 ## [0.16.0-beta] - 2026-07-25
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.16.0-beta"
+version = "0.16.1-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,6 +7,7 @@ extend-ignore-re = [
     "_godd",
     "_ANF",
     "mis-dispatching",
+    "fo",
 ]
 
 [files]

--- a/src/Trajectories/Trajectories.jl
+++ b/src/Trajectories/Trajectories.jl
@@ -8,7 +8,9 @@ This module provides:
 - `VectorFieldTrajectory`: Trajectory type wrapping integration results
 - `build_trajectory`: Trajectory building functions for different configuration types
 - `final_state`, `times`, `evaluate_at`: Semantic accessors for integration results
-- `state`, `time_grid`: Semantic accessors for VectorFieldTrajectory
+- `state`, `control`, `costate`, `objective`, `time_grid`: methods on the
+  [`CTModels.Components`](@extref) generics, contributed here for `VectorFieldTrajectory`,
+  `HamiltonianVectorFieldTrajectory` and `StateFlowTrajectory`
 - `Trajectories.plot`: plotting for trajectories via the Plots extension (a `RecipesBase.plot`
   method; not re-exported — call it qualified or load `Plots`)
 
@@ -25,6 +27,7 @@ import CTBase.Core
 import CTBase.Data
 import CTBase.Exceptions
 import CTBase.Traits
+import CTModels.Components: Components, state, control, costate, objective, time_grid
 import RecipesBase: RecipesBase, plot
 
 # ==============================================================================

--- a/src/Trajectories/hamiltonian_vector_field_trajectory.jl
+++ b/src/Trajectories/hamiltonian_vector_field_trajectory.jl
@@ -155,8 +155,9 @@ $(TYPEDSIGNATURES)
 
 Alias for `times(sol)` — returns the time grid from the solution.
 
-This is an alternative, more explicit name for `times` in numerical contexts
-where "time grid" is the standard terminology.
+This is a method of the [`CTModels.Components.time_grid`](@extref) generic, contributed by
+CTFlows for `HamiltonianVectorFieldTrajectory`: an alternative, more explicit name for
+`times` in numerical contexts where "time grid" is the standard terminology.
 
 # Arguments
 - `sol::HamiltonianVectorFieldTrajectory`: The Hamiltonian vector field solution.
@@ -164,9 +165,9 @@ where "time grid" is the standard terminology.
 # Returns
 - `AbstractVector`: The vector of time points.
 
-See also: [`CTSolvers.Integrators.times`](@extref), [`CTFlows.Trajectories.state`](@ref).
+See also: [`CTSolvers.Integrators.times`](@extref), [`CTFlows.Trajectories.state`](@ref), [`CTModels.Components.time_grid`](@extref).
 """
-function time_grid(sol::HamiltonianVectorFieldTrajectory)
+function Components.time_grid(sol::HamiltonianVectorFieldTrajectory)
     return Integrators.times(sol)
 end
 
@@ -266,7 +267,9 @@ $(TYPEDSIGNATURES)
 
 Return the solution as a state function of time `x(t)`.
 
-Returns a [`CTFlows.Trajectories.StateProjection`](@ref) wrapping the solution, callable as `x(t)`.
+This is a method of the [`CTModels.Components.state`](@extref) generic, contributed by
+CTFlows for `HamiltonianVectorFieldTrajectory`. Returns a
+[`CTFlows.Trajectories.StateProjection`](@ref) wrapping the solution, callable as `x(t)`.
 
 # Arguments
 - `sol::HamiltonianVectorFieldTrajectory`: The Hamiltonian vector field solution.
@@ -284,9 +287,9 @@ x(0.0)            # initial state
 x(0.5)            # interpolated state at t = 0.5
 ```
 
-See also: [`CTFlows.Trajectories.costate`](@ref), [`CTSolvers.Integrators.times`](@extref).
+See also: [`CTFlows.Trajectories.costate`](@ref), [`CTSolvers.Integrators.times`](@extref), [`CTModels.Components.state`](@extref).
 """
-function state(sol::HamiltonianVectorFieldTrajectory)
+function Components.state(sol::HamiltonianVectorFieldTrajectory)
     return sol.state_proj
 end
 
@@ -295,7 +298,9 @@ $(TYPEDSIGNATURES)
 
 Return the solution as a costate function of time `p(t)`.
 
-Returns a [`CTFlows.Trajectories.CostateProjection`](@ref) wrapping the solution, callable as `p(t)`.
+This is a method of the [`CTModels.Components.costate`](@extref) generic, contributed by
+CTFlows for `HamiltonianVectorFieldTrajectory`. Returns a
+[`CTFlows.Trajectories.CostateProjection`](@ref) wrapping the solution, callable as `p(t)`.
 
 # Arguments
 - `sol::HamiltonianVectorFieldTrajectory`: The Hamiltonian vector field solution.
@@ -313,9 +318,9 @@ p(0.0)            # initial costate
 p(0.5)            # interpolated costate at t = 0.5
 ```
 
-See also: [`CTFlows.Trajectories.state`](@ref), [`CTSolvers.Integrators.times`](@extref).
+See also: [`CTFlows.Trajectories.state`](@ref), [`CTSolvers.Integrators.times`](@extref), [`CTModels.Components.costate`](@extref).
 """
-function costate(sol::HamiltonianVectorFieldTrajectory)
+function Components.costate(sol::HamiltonianVectorFieldTrajectory)
     return sol.costate_proj
 end
 

--- a/src/Trajectories/state_flow_trajectory.jl
+++ b/src/Trajectories/state_flow_trajectory.jl
@@ -172,12 +172,13 @@ $(TYPEDSIGNATURES)
 
 Return the state function `x(t)` of a `StateFlowTrajectory` (scalar for a 1-D state).
 
-Returns the stored [`CTFlows.Trajectories.ControlledStateProjection`](@ref) precomputed at
-construction.
+This is a method of the [`CTModels.Components.state`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`. Returns the stored
+[`CTFlows.Trajectories.ControlledStateProjection`](@ref) precomputed at construction.
 
-See also: [`CTFlows.Trajectories.control`](@ref).
+See also: [`CTFlows.Trajectories.control`](@ref), [`CTModels.Components.state`](@extref).
 """
-state(sol::StateFlowTrajectory) = sol.state_proj
+Components.state(sol::StateFlowTrajectory) = sol.state_proj
 
 """
 $(TYPEDSIGNATURES)
@@ -185,13 +186,16 @@ $(TYPEDSIGNATURES)
 Return the reconstructed control function `u(t) = law(t, x(t), v)` of a
 `StateFlowTrajectory`, as the stored [`CTFlows.Trajectories.ControlProjection`](@ref).
 
+This is a method of the [`CTModels.Components.control`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`.
+
 Raises a [`CTBase.Exceptions.PreconditionError`](@extref) when the trajectory was built
 without a control law (a basic control-free `Flow(ocp)`), which has no control to
 reconstruct.
 
-See also: [`CTFlows.Trajectories.state`](@ref).
+See also: [`CTFlows.Trajectories.state`](@ref), [`CTModels.Components.control`](@extref).
 """
-control(sol::StateFlowTrajectory) = _sft_control(sol.control_proj)
+Components.control(sol::StateFlowTrajectory) = _sft_control(sol.control_proj)
 
 """
 $(TYPEDSIGNATURES)
@@ -235,8 +239,11 @@ Integrators.times(sol::StateFlowTrajectory) = Integrators.times(sol.traj)
 $(TYPEDSIGNATURES)
 
 Alias for `times(sol)` — the time grid of a `StateFlowTrajectory`.
+
+This is a method of the [`CTModels.Components.time_grid`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`.
 """
-time_grid(sol::StateFlowTrajectory) = Integrators.times(sol.traj)
+Components.time_grid(sol::StateFlowTrajectory) = Integrators.times(sol.traj)
 
 """
 $(TYPEDSIGNATURES)
@@ -275,9 +282,12 @@ Return the objective value of a `StateFlowTrajectory` (Mayer + Lagrange, with th
 control reconstructed from the law). Available only when the trajectory was built from
 an OCP (trajectory mode); otherwise a clear error is raised.
 
-See also: [`CTFlows.Trajectories.state`](@ref), [`CTFlows.Trajectories.control`](@ref).
+This is a method of the [`CTModels.Components.objective`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`.
+
+See also: [`CTFlows.Trajectories.state`](@ref), [`CTFlows.Trajectories.control`](@ref), [`CTModels.Components.objective`](@extref).
 """
-function objective(
+function Components.objective(
     sol::StateFlowTrajectory{T,L,V,<:Real}
 ) where {T<:VectorFieldTrajectory,L,V}
     return sol.objective
@@ -289,9 +299,12 @@ $(TYPEDSIGNATURES)
 Throw a [`CTBase.Exceptions.PreconditionError`](@extref) when the objective is not
 available (the trajectory was built without an OCP, e.g. from `Flow(fc, law)`).
 
-See also: [`CTFlows.Trajectories.objective`](@ref).
+This is a method of the [`CTModels.Components.objective`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`.
+
+See also: [`CTFlows.Trajectories.objective`](@ref), [`CTModels.Components.objective`](@extref).
 """
-function objective(
+function Components.objective(
     sol::StateFlowTrajectory{T,L,V,Nothing}
 ) where {T<:VectorFieldTrajectory,L,V}
     return throw(
@@ -313,9 +326,12 @@ A `StateFlowTrajectory` has **no costate** — it is the trajectory of a control
 state flow (`OpenLoop`/`ClosedLoop`), not a Hamiltonian flow. Raises a
 `PreconditionError` pointing at the available getters.
 
-See also: [`CTFlows.Trajectories.state`](@ref), [`CTFlows.Trajectories.control`](@ref).
+This is a method of the [`CTModels.Components.costate`](@extref) generic, contributed by
+CTFlows for `StateFlowTrajectory`.
+
+See also: [`CTFlows.Trajectories.state`](@ref), [`CTFlows.Trajectories.control`](@ref), [`CTModels.Components.costate`](@extref).
 """
-function costate(sol::StateFlowTrajectory)
+function Components.costate(sol::StateFlowTrajectory)
     return throw(
         Exceptions.PreconditionError(
             "a StateFlowTrajectory has no costate";

--- a/src/Trajectories/vector_field_trajectory.jl
+++ b/src/Trajectories/vector_field_trajectory.jl
@@ -113,7 +113,8 @@ $(TYPEDSIGNATURES)
 
 Return the solution itself as a state function of time.
 
-This is a semantic accessor that returns `sol` itself (which is already callable),
+This is a method of the [`CTModels.Components.state`](@extref) generic, contributed by
+CTFlows for `VectorFieldTrajectory`. It returns `sol` itself (which is already callable),
 providing a clear, self-documenting way to obtain the trajectory function.
 
 # Arguments
@@ -138,9 +139,9 @@ x.(0.0:0.1:1.0)   # broadcast over time grid
   `state(sol)`, `costate(sol)`, `control(sol)` when extended to Hamiltonian systems.
 - No allocation occurs — returns `sol` directly.
 
-See also: [`CTSolvers.Integrators.times`](@extref), [`CTSolvers.Integrators.evaluate_at`](@extref), [`CTFlows.Trajectories.time_grid`](@ref).
+See also: [`CTSolvers.Integrators.times`](@extref), [`CTSolvers.Integrators.evaluate_at`](@extref), [`CTFlows.Trajectories.time_grid`](@ref), [`CTModels.Components.state`](@extref).
 """
-function state(sol::VectorFieldTrajectory)
+function Components.state(sol::VectorFieldTrajectory)
     return sol
 end
 
@@ -149,8 +150,9 @@ $(TYPEDSIGNATURES)
 
 Alias for `times(sol)` — returns the time grid from the solution.
 
-This is an alternative, more explicit name for `times` in numerical contexts
-where "time grid" is the standard terminology.
+This is a method of the [`CTModels.Components.time_grid`](@extref) generic, contributed by
+CTFlows for `VectorFieldTrajectory`: an alternative, more explicit name for `times` in
+numerical contexts where "time grid" is the standard terminology.
 
 # Arguments
 - `sol::VectorFieldTrajectory`: The vector field solution.
@@ -171,9 +173,9 @@ tg = time_grid(sol)  # same as times(sol)
 - Use `time_grid` when "grid" terminology is clearer in context.
 - Use `times` for brevity in everyday use.
 
-See also: [`CTSolvers.Integrators.times`](@extref), [`CTFlows.Trajectories.state`](@ref).
+See also: [`CTSolvers.Integrators.times`](@extref), [`CTFlows.Trajectories.state`](@ref), [`CTModels.Components.time_grid`](@extref).
 """
-function time_grid(sol::VectorFieldTrajectory)
+function Components.time_grid(sol::VectorFieldTrajectory)
     return Integrators.times(sol)
 end
 

--- a/test/suite/trajectories/test_trajectories_module.jl
+++ b/test/suite/trajectories/test_trajectories_module.jl
@@ -16,6 +16,11 @@ using Test: Test
 using CTFlows: CTFlows
 import CTFlows.Trajectories
 using CTFlows.Trajectories  # For testing exported symbols
+import CTFlows.Flows: Flows
+import CTModels: CTModels
+import CTBase.Data: Data
+using OrdinaryDiffEqTsit5: Tsit5
+using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -72,6 +77,29 @@ function test_internal_symbols(module_ref::Module, symbols::Tuple, test_module::
         end
     end
 end
+
+# ============================================================================
+# OCP fixture — double integrator with a stationary control law
+# ============================================================================
+# Used only to build a genuine CTModels.Solution via Flow(ocp, law), for the
+# unification test below (contrasted with a raw HamiltonianVectorFieldTrajectory
+# from Flow(HamiltonianVectorField(...))).
+
+function _build_double_integrator()
+    pre = CTModels.Building.PreModel()
+    CTModels.Building.time_dependence!(pre; autonomous=true)
+    CTModels.Building.time!(pre; t0=0.0, tf=1.0)
+    CTModels.Building.state!(pre, 2)
+    CTModels.Building.control!(pre, 1)
+    CTModels.Building.dynamics!(pre, (r, t, x, u, v) -> (r.=[x[2], u[1]]; nothing))
+    CTModels.Building.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5 * u[1]^2)
+    return CTModels.Building.build(pre)
+end
+
+# Built once at module top level (not inside the test function): the AD-differentiated
+# Hamiltonian glue is keyed on the closure/OCP types, and rebuilding per-call defeats it.
+const _OCP_DI_UNIFY = _build_double_integrator()
+const _LAW_UNIFY = Data.DynClosedLoop((x, p) -> p[2])
 
 # ============================================================================
 # Test function
@@ -133,6 +161,41 @@ function test_trajectories_module()
                 Test.@test Trajectories.HamiltonianVectorFieldTrajectory <:
                     Trajectories.AbstractHamiltonianVectorFieldTrajectory
             end
+        end
+
+        # ====================================================================
+        # Unification with CTModels.Components (issue #370)
+        # ====================================================================
+        # `Trajectories.{state,control,costate,objective,time_grid}` must *be* the
+        # CTModels.Components generics of the same name — not distinct function
+        # objects with the same spelling — so that importing both into one module
+        # succeeds instead of erroring.
+
+        Test.@testset "CTModels.Components generic identity" begin
+            for f in (:state, :control, :costate, :objective, :time_grid)
+                Test.@test getproperty(Trajectories, f) === getproperty(CTModels.Components, f)
+            end
+        end
+
+        Test.@testset "One import resolves both a trajectory and a solution" begin
+            # Raw geometric API: Flow(HamiltonianVectorField(...)) over a span →
+            # HamiltonianVectorFieldTrajectory (harmonic oscillator, AD-free vector field —
+            # avoids the AD-differentiated Hamiltonian path, orthogonal to this test's point).
+            hvf = Data.HamiltonianVectorField((x, p) -> (p, -x))
+            fh = Flows.Flow(hvf; alg=Tsit5(), reltol=1e-10, abstol=1e-10)
+            traj = fh((0.0, 1.0), [1.0, 0.0], [0.0, 1.0])
+            Test.@test traj isa Trajectories.HamiltonianVectorFieldTrajectory
+
+            # Flow(ocp, law) → genuine CTModels.Solution
+            fo = Flows.Flow(_OCP_DI_UNIFY, _LAW_UNIFY; alg=Tsit5(), reltol=1e-10, abstol=1e-10)
+            sol = fo((0.0, 1.0), [-1.0, 0.0], [12.0, 6.0])
+            Test.@test sol isa CTModels.Solutions.Solution
+
+            # A single unqualified `state`, imported once, resolves both shapes.
+            x_traj = state(traj)
+            x_sol = state(sol)
+            Test.@test x_traj(0.0) isa Union{Number,AbstractVector}
+            Test.@test x_sol(0.0) isa Union{Number,AbstractVector}
         end
     end
 end


### PR DESCRIPTION
## Summary
- `Trajectories.{state,control,costate,objective,time_grid}` are now methods of the `CTModels.Components` generics of the same name, instead of distinct CTFlows-local generics that happened to share a spelling.
- `VectorFieldTrajectory`, `HamiltonianVectorFieldTrajectory` and `StateFlowTrajectory` contribute methods to `CTModels.Components.{state,control,costate,objective,time_grid}` rather than shadowing them.
- Unblocks the OptimalControl v2.1.0-beta upgrade, which needs to re-export a single `state`/`control`/`costate`/`objective`/`time_grid` regardless of whether the user holds a raw CTFlows trajectory or a full `CTModels.Solution` (control-toolbox/CTFlows.jl#370).
- Non-breaking for callers: every existing export and call site keeps working unchanged. The only observable difference is that `parentmodule` changes, and that importing both `CTFlows.Trajectories` and `CTModels.Components` accessors into one module now succeeds instead of erroring.
- Version bump to `0.16.1-beta`; Aqua's piracy check stays green (the three trajectory types are CTFlows-owned).

Implements the plan in `.reports/2026-07-28_unify-trajectory-accessors-with-ctmodels.md`.

## Test plan
- [x] `test/suite/trajectories` — 215/215 passing, including new identity assertions (`Trajectories.f === CTModels.Components.f` for all 5 generics) and a cross-shape integration test (one unqualified `state` resolving both a `HamiltonianVectorFieldTrajectory` and a genuine `CTModels.Solution`)
- [x] `test/suite/meta/test_aqua.jl` — 11/11 passing (piracy check green)
- [x] Full suite — 3032/3032 passing

Closes control-toolbox/CTFlows.jl#370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)