### PR TITLE
fix(Configs): extend CTBase.Traits.dynamics_trait instead of shadowing it

### DIFF
--- a/src/Configs/Configs.jl
+++ b/src/Configs/Configs.jl
@@ -27,7 +27,7 @@ Configuration types encode these choices as type parameters for compile-time dis
 - [`CTFlows.Configs.initial_costate`](@ref): Initial costate (Hamiltonian configs)
 - [`CTFlows.Configs.initial_variable_costate`](@ref): Initial variable costate (augmented configs)
 - [`CTFlows.Configs.mode_trait`](@ref): Integration mode trait
-- [`CTFlows.Configs.dynamics_trait`](@ref): Dynamics trait
+- [`CTBase.Traits.dynamics_trait`](@extref): Dynamics trait
 
 See also: [`CTFlows.Flows.build_flow`](@ref), [`CTFlows.Trajectories.build_trajectory`](@ref).
 """
@@ -68,6 +68,6 @@ export StateEndPointConfig, StateTrajectoryConfig
 export HamiltonianEndPointConfig,
     HamiltonianTrajectoryConfig, AugmentedHamiltonianEndPointConfig
 export tspan, initial_condition, initial_state, initial_costate, initial_variable_costate
-export initial_time, final_time, mode_trait, dynamics_trait
+export initial_time, final_time, mode_trait
 
 end # module Configs

--- a/src/Configs/abstract.jl
+++ b/src/Configs/abstract.jl
@@ -99,7 +99,7 @@ config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
 Configs.mode_trait(config) === Traits.EndPointMode  # true
 \`\`\`
 
-See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTBase.Traits.EndPointMode`](@extref), [`CTBase.Traits.TrajectoryMode`](@extref), [`CTFlows.Configs.dynamics_trait`](@ref).
+See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTBase.Traits.EndPointMode`](@extref), [`CTBase.Traits.TrajectoryMode`](@extref), [`CTBase.Traits.dynamics_trait`](@extref).
 """
 function mode_trait(
     ::AbstractConfigWithMaC{X0,Mode,Dyn}
@@ -124,12 +124,12 @@ enabling trait-based dispatch on the integration dynamics (state, Hamiltonian, a
 # Example
 \`\`\`julia
 config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
-Configs.dynamics_trait(config) === Traits.HamiltonianDynamics  # true
+Traits.dynamics_trait(config) === Traits.HamiltonianDynamics  # true
 \`\`\`
 
-See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTBase.Traits.StateDynamics`](@extref), [`CTBase.Traits.HamiltonianDynamics`](@extref), [`CTBase.Traits.AugmentedHamiltonianDynamics`](@extref), [`CTFlows.Configs.mode_trait`](@ref).
+See also: [`CTFlows.Configs.AbstractConfigWithMaC`](@ref), [`CTBase.Traits.dynamics_trait`](@extref), [`CTBase.Traits.StateDynamics`](@extref), [`CTBase.Traits.HamiltonianDynamics`](@extref), [`CTBase.Traits.AugmentedHamiltonianDynamics`](@extref), [`CTFlows.Configs.mode_trait`](@ref).
 """
-function dynamics_trait(
+function Traits.dynamics_trait(
     ::AbstractConfigWithMaC{X0,Mode,Dyn}
 ) where {X0,Mode<:Traits.AbstractModeTrait,Dyn<:Traits.AbstractDynamicsTrait}
     return Dyn

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -275,7 +275,7 @@ function _core_invoke_flow(
 
     # build flow solution
     flow_sol = Trajectories.build_trajectory(
-        Configs.mode_trait(config), Configs.dynamics_trait(config), config, result, variable
+        Configs.mode_trait(config), Traits.dynamics_trait(config), config, result, variable
     )
 
     return flow_sol

--- a/test/suite/configs/test_abstract_configs.jl
+++ b/test/suite/configs/test_abstract_configs.jl
@@ -139,12 +139,12 @@ function test_abstract_configs()
             Test.@testset "dynamics_trait" begin
                 Test.@testset "dynamics_trait for StateEndPointConfig" begin
                     config = Configs.StateEndPointConfig(0.0, [1.0], 1.0)
-                    Test.@test Configs.dynamics_trait(config) === Traits.StateDynamics
+                    Test.@test Traits.dynamics_trait(config) === Traits.StateDynamics
                 end
 
                 Test.@testset "dynamics_trait for HamiltonianEndPointConfig" begin
                     config = Configs.HamiltonianEndPointConfig(0.0, [1.0], [0.5], 1.0)
-                    Test.@test Configs.dynamics_trait(config) === Traits.HamiltonianDynamics
+                    Test.@test Traits.dynamics_trait(config) === Traits.HamiltonianDynamics
                 end
             end
         end

--- a/test/suite/configs/test_configs_module.jl
+++ b/test/suite/configs/test_configs_module.jl
@@ -58,7 +58,6 @@ const EXPORTED_FUNCTIONS = (
     :initial_time,
     :final_time,
     :mode_trait,
-    :dynamics_trait,
 )
 
 # Note: Configs module has no private symbols (after filtering Julia internals)

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -2,6 +2,7 @@ module TestSciMLExtension
 
 using Test: Test
 import CTBase.Data: Data
+import CTBase.Traits: Traits
 import CTFlows: CTFlows
 import CTFlows.Configs: Configs
 import CTFlows.Systems: Systems
@@ -219,7 +220,7 @@ function test_sciml_extension()
                 result = CommonSolve.solve(prob, integ; options=opts)
                 flow_sol = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -239,7 +240,7 @@ function test_sciml_extension()
                 result = CommonSolve.solve(prob, integ; options=opts)
                 flow_sol = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )

--- a/test/suite/flows/test_variable_costate_flows.jl
+++ b/test/suite/flows/test_variable_costate_flows.jl
@@ -132,7 +132,7 @@ function test_variable_costate_flows()
             result = FakeIntegrationResult(u_final)
 
             xf, pf, pvf = Trajectories.build_trajectory(
-                Configs.mode_trait(config), Configs.dynamics_trait(config), config, result
+                Configs.mode_trait(config), Traits.dynamics_trait(config), config, result
             )
 
             Test.@test xf == [1.0, 2.0]

--- a/test/suite/trajectories/test_building_trajectories.jl
+++ b/test/suite/trajectories/test_building_trajectories.jl
@@ -5,6 +5,7 @@ import CTFlows.Trajectories
 import CTFlows.Systems
 import CTFlows.Configs
 import CTBase.Data
+import CTBase.Traits: Traits
 import CTFlows.Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -44,7 +45,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -62,7 +63,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -86,7 +87,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -102,7 +103,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -126,7 +127,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -149,7 +150,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -176,7 +177,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -205,7 +206,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )
@@ -227,7 +228,7 @@ function test_building_trajectories()
 
                 output = Trajectories.build_trajectory(
                     Configs.mode_trait(config),
-                    Configs.dynamics_trait(config),
+                    Traits.dynamics_trait(config),
                     config,
                     result,
                 )


### PR DESCRIPTION
## Summary
- `Configs.dynamics_trait` was a separate, unqualified generic — homonymous with but disjoint from `CTBase.Traits.dynamics_trait`, even though CTBase's own docstring documents `Configs` as a contributor to it (like `Systems`/`Flows` already are).
- Fold it into a `Traits.dynamics_trait` method on `AbstractConfigWithMaC`, drop the separate `Configs` export, and update the one production call site (`Flows/calling.jl`) plus all test call sites.
- `Configs.mode_trait` is untouched — `CTBase` has no `mode_trait` accessor to extend, so it's genuinely `Configs`-owned.

Closes #369

## Test plan
- [x] `suite/configs` + `suite/flows` + `suite/trajectories` + `suite/extensions` + `suite/multiphase` — 2053/2053 passed
- [x] Full test suite (`Pkg.test()`) — 3030/3030 passed, including `suite/meta/test_aqua.jl` (no ambiguity/piracy introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)