### PR TITLE
refactor(Systems): rename gradient accessors to get_* to disambiguate from Differentiation

### DIFF
--- a/docs/src/flows/building_a_flow.md
+++ b/docs/src/flows/building_a_flow.md
@@ -221,8 +221,8 @@ Flows.hamiltonian_vector_field(hflow_ad)
 from a pseudo-Hamiltonian or an OCP together with a control law — the Hamiltonian is
 then a `CTBase.Data.ComposedHamiltonian` (`:total` mode) or reconstructed from a
 `PseudoHamiltonianSystem` (`:partial` mode). The pseudo-Hamiltonian getters
-(`pseudo_hamiltonian`, `control_law`, `pseudo_hamiltonian_gradient`,
-`pseudo_variable_gradient`) and `variable_gradient` are shown on
+(`pseudo_hamiltonian`, `control_law`, `get_pseudo_hamiltonian_gradient`,
+`get_pseudo_variable_gradient`) and `get_variable_gradient` are shown on
 [Control laws](control_laws.md) and [Integrating](integrating.md) respectively.
 
 ---

--- a/docs/src/flows/integrating.md
+++ b/docs/src/flows/integrating.md
@@ -149,15 +149,15 @@ Systems.hamiltonian(hflow_v)          # the callable H(t, x, p, v)
 ```
 
 ```@example flows_integrating
-Systems.hamiltonian_gradient(hflow_v) # functor: (t, x, p, v) -> (∂H/∂x, ∂H/∂p)
+Systems.get_hamiltonian_gradient(hflow_v) # functor: (t, x, p, v) -> (∂H/∂x, ∂H/∂p)
 ```
 
 ```@example flows_integrating
-Systems.variable_gradient(hflow_v)    # functor: (t, x, p, v) -> ∂H/∂v
+Systems.get_variable_gradient(hflow_v)    # functor: (t, x, p, v) -> ∂H/∂v
 ```
 
-`Systems.pseudo_hamiltonian`, `Systems.control_law`, `Systems.pseudo_hamiltonian_gradient`
-and `Systems.pseudo_variable_gradient` are available on flows built from a
+`Systems.pseudo_hamiltonian`, `Systems.control_law`, `Systems.get_pseudo_hamiltonian_gradient`
+and `Systems.get_pseudo_variable_gradient` are available on flows built from a
 pseudo-Hamiltonian (or an OCP) and a control law — see [Control laws](control_laws.md).
 Calling them on a flow with no associated control law throws `IncorrectArgument`.
 

--- a/src/Flows/abstract_flow.jl
+++ b/src/Flows/abstract_flow.jl
@@ -393,18 +393,18 @@ end
 $(TYPEDSIGNATURES)
 
 Return a callable `(t, x, p, v) -> (∂H/∂x, ∂H/∂p)` for the true Hamiltonian of a
-Hamiltonian flow. Delegates to [`CTFlows.Systems.hamiltonian_gradient`](@ref); the
+Hamiltonian flow. Delegates to [`CTFlows.Systems.get_hamiltonian_gradient`](@ref); the
 `ad_backend` keyword (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.variable_gradient`](@ref).
+See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.get_variable_gradient`](@ref).
 """
-function Systems.hamiltonian_gradient(
+function Systems.get_hamiltonian_gradient(
     f::AbstractFlow{
         <:Traits.TimeDependence,<:Traits.VariableDependence,Traits.HamiltonianDynamics
     };
     kwargs...,
 )
-    return Systems.hamiltonian_gradient(system(f); kwargs...)
+    return Systems.get_hamiltonian_gradient(system(f); kwargs...)
 end
 
 """
@@ -412,18 +412,18 @@ $(TYPEDSIGNATURES)
 
 Return a callable `(t, x, p, v) -> ∂H/∂v` for the true Hamiltonian of a Hamiltonian
 flow — the quantity (before negation) driving `ṗv = -∂H/∂v`. Delegates to
-[`CTFlows.Systems.variable_gradient`](@ref); the `ad_backend` keyword (default: the
+[`CTFlows.Systems.get_variable_gradient`](@ref); the `ad_backend` keyword (default: the
 system's backend) selects the AD backend.
 
-See also: [`CTFlows.Systems.hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.get_hamiltonian_gradient`](@ref).
 """
-function Systems.variable_gradient(
+function Systems.get_variable_gradient(
     f::AbstractFlow{
         <:Traits.TimeDependence,<:Traits.VariableDependence,Traits.HamiltonianDynamics
     };
     kwargs...,
 )
-    return Systems.variable_gradient(system(f); kwargs...)
+    return Systems.get_variable_gradient(system(f); kwargs...)
 end
 
 """
@@ -431,18 +431,18 @@ $(TYPEDSIGNATURES)
 
 Return a callable `(t, x, p, u, v) -> (∂H̃/∂x, ∂H̃/∂p)` for the pseudo-Hamiltonian of a
 Hamiltonian flow (differentiated at fixed control), when available. Delegates to
-[`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref); the `ad_backend` keyword
+[`CTFlows.Systems.get_pseudo_hamiltonian_gradient`](@ref); the `ad_backend` keyword
 (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.pseudo_variable_gradient`](@ref).
+See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.get_pseudo_variable_gradient`](@ref).
 """
-function Systems.pseudo_hamiltonian_gradient(
+function Systems.get_pseudo_hamiltonian_gradient(
     f::AbstractFlow{
         <:Traits.TimeDependence,<:Traits.VariableDependence,Traits.HamiltonianDynamics
     };
     kwargs...,
 )
-    return Systems.pseudo_hamiltonian_gradient(system(f); kwargs...)
+    return Systems.get_pseudo_hamiltonian_gradient(system(f); kwargs...)
 end
 
 """
@@ -450,18 +450,18 @@ $(TYPEDSIGNATURES)
 
 Return a callable `(t, x, p, u, v) -> ∂H̃/∂v` for the pseudo-Hamiltonian of a
 Hamiltonian flow (differentiated at fixed control), when available. Delegates to
-[`CTFlows.Systems.pseudo_variable_gradient`](@ref); the `ad_backend` keyword
+[`CTFlows.Systems.get_pseudo_variable_gradient`](@ref); the `ad_backend` keyword
 (default: the system's backend) selects the AD backend.
 
-See also: [`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.get_pseudo_hamiltonian_gradient`](@ref).
 """
-function Systems.pseudo_variable_gradient(
+function Systems.get_pseudo_variable_gradient(
     f::AbstractFlow{
         <:Traits.TimeDependence,<:Traits.VariableDependence,Traits.HamiltonianDynamics
     };
     kwargs...,
 )
-    return Systems.pseudo_variable_gradient(system(f); kwargs...)
+    return Systems.get_pseudo_variable_gradient(system(f); kwargs...)
 end
 
 """

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -78,8 +78,8 @@ export ConstrainedPseudoHamiltonianSystem
 export build_system
 export hamiltonian, backend
 export pseudo_hamiltonian, control_law
-export hamiltonian_gradient, variable_gradient
-export pseudo_hamiltonian_gradient, pseudo_variable_gradient
+export get_hamiltonian_gradient, get_variable_gradient
+export get_pseudo_hamiltonian_gradient, get_pseudo_variable_gradient
 export HamiltonianGradient, HamiltonianVariableGradient
 export PseudoHamiltonianGradient, PseudoHamiltonianVariableGradient
 

--- a/src/Systems/hamiltonian_getters_extra.jl
+++ b/src/Systems/hamiltonian_getters_extra.jl
@@ -90,7 +90,7 @@ Functor returning the gradient `(∂H/∂x, ∂H/∂p)` of a true Hamiltonian, e
 - `h::H`: the Hamiltonian to differentiate.
 - `backend::B`: the AD backend.
 
-See also: [`CTFlows.Systems.hamiltonian_gradient`](@ref), [`CTFlows.Systems.HamiltonianVariableGradient`](@ref).
+See also: [`CTFlows.Systems.get_hamiltonian_gradient`](@ref), [`CTFlows.Systems.HamiltonianVariableGradient`](@ref).
 """
 struct HamiltonianGradient{H<:Data.AbstractHamiltonian,B<:Differentiation.AbstractADBackend}
     h::H
@@ -112,7 +112,7 @@ variable-costate equation `ṗv = -∂H/∂v`. Non-negated.
 - `h::H`: the Hamiltonian to differentiate.
 - `backend::B`: the AD backend.
 
-See also: [`CTFlows.Systems.variable_gradient`](@ref), [`CTFlows.Systems.HamiltonianGradient`](@ref).
+See also: [`CTFlows.Systems.get_variable_gradient`](@ref), [`CTFlows.Systems.HamiltonianGradient`](@ref).
 """
 struct HamiltonianVariableGradient{
     H<:Data.AbstractHamiltonian,B<:Differentiation.AbstractADBackend
@@ -135,7 +135,7 @@ Functor returning the gradient `(∂H̃/∂x, ∂H̃/∂p)` of a pseudo-Hamilton
 - `h̃::H`: the pseudo-Hamiltonian to differentiate.
 - `backend::B`: the AD backend.
 
-See also: [`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref), [`CTFlows.Systems.PseudoHamiltonianVariableGradient`](@ref).
+See also: [`CTFlows.Systems.get_pseudo_hamiltonian_gradient`](@ref), [`CTFlows.Systems.PseudoHamiltonianVariableGradient`](@ref).
 """
 struct PseudoHamiltonianGradient{
     H<:Data.AbstractPseudoHamiltonian,B<:Differentiation.AbstractADBackend
@@ -158,7 +158,7 @@ Functor returning the variable gradient `∂H̃/∂v` of a pseudo-Hamiltonian, e
 - `h̃::H`: the pseudo-Hamiltonian to differentiate.
 - `backend::B`: the AD backend.
 
-See also: [`CTFlows.Systems.pseudo_variable_gradient`](@ref), [`CTFlows.Systems.PseudoHamiltonianGradient`](@ref).
+See also: [`CTFlows.Systems.get_pseudo_variable_gradient`](@ref), [`CTFlows.Systems.PseudoHamiltonianGradient`](@ref).
 """
 struct PseudoHamiltonianVariableGradient{
     H<:Data.AbstractPseudoHamiltonian,B<:Differentiation.AbstractADBackend
@@ -183,9 +183,9 @@ The `ad_backend` keyword selects the AD backend used to differentiate; it defaul
 the system's own backend but can be overridden (e.g. to use reverse mode for the
 gradient).
 
-See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.variable_gradient`](@ref).
+See also: [`CTFlows.Systems.hamiltonian`](@ref), [`CTFlows.Systems.get_variable_gradient`](@ref).
 """
-function hamiltonian_gradient(
+function get_hamiltonian_gradient(
     sys::Union{HamiltonianSystem,PseudoHamiltonianSystem};
     ad_backend::Differentiation.AbstractADBackend=backend(sys),
 )
@@ -201,9 +201,9 @@ Return a [`CTFlows.Systems.HamiltonianVariableGradient`](@ref) functor `(t, x, p
 
 The `ad_backend` keyword selects the AD backend (default: the system's own backend).
 
-See also: [`CTFlows.Systems.hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.get_hamiltonian_gradient`](@ref).
 """
-function variable_gradient(
+function get_variable_gradient(
     sys::Union{HamiltonianSystem,PseudoHamiltonianSystem};
     ad_backend::Differentiation.AbstractADBackend=backend(sys),
 )
@@ -220,9 +220,9 @@ wrapping a `ComposedHamiltonian`.
 
 The `ad_backend` keyword selects the AD backend (default: the system's own backend).
 
-See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.pseudo_variable_gradient`](@ref).
+See also: [`CTFlows.Systems.pseudo_hamiltonian`](@ref), [`CTFlows.Systems.get_pseudo_variable_gradient`](@ref).
 """
-function pseudo_hamiltonian_gradient(
+function get_pseudo_hamiltonian_gradient(
     sys::Union{HamiltonianSystem,PseudoHamiltonianSystem};
     ad_backend::Differentiation.AbstractADBackend=backend(sys),
 )
@@ -238,9 +238,9 @@ control** `u`.
 
 The `ad_backend` keyword selects the AD backend (default: the system's own backend).
 
-See also: [`CTFlows.Systems.pseudo_hamiltonian_gradient`](@ref).
+See also: [`CTFlows.Systems.get_pseudo_hamiltonian_gradient`](@ref).
 """
-function pseudo_variable_gradient(
+function get_pseudo_variable_gradient(
     sys::Union{HamiltonianSystem,PseudoHamiltonianSystem};
     ad_backend::Differentiation.AbstractADBackend=backend(sys),
 )

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -360,15 +360,15 @@ function test_optimal_control_flow()
             Test.@test H(0.0, 2.0, 0.5, [3.0]) ≈ 0.5 * 3.0 * 2.0 atol=ATOL
         end
 
-        Test.@testset "Unit: hamiltonian_gradient(flow) → (∂H/∂x, ∂H/∂p)" begin
-            ∇H = Systems.hamiltonian_gradient(FLOW_ANF)
+        Test.@testset "Unit: get_hamiltonian_gradient(flow) → (∂H/∂x, ∂H/∂p)" begin
+            ∇H = Systems.get_hamiltonian_gradient(FLOW_ANF)
             ∂x, ∂p = ∇H(0.0, 2.0, 0.5, [3.0])
             Test.@test ∂x[1] ≈ 0.5 * 3.0 atol=ATOL   # ∂H/∂x = p·v
             Test.@test ∂p[1] ≈ 3.0 * 2.0 atol=ATOL   # ∂H/∂p = v·x
         end
 
-        Test.@testset "Unit: variable_gradient(flow) → ∂H/∂v = p·x" begin
-            ∇vH = Systems.variable_gradient(FLOW_ANF)
+        Test.@testset "Unit: get_variable_gradient(flow) → ∂H/∂v = p·x" begin
+            ∇vH = Systems.get_variable_gradient(FLOW_ANF)
             gv = ∇vH(0.0, 2.0, 0.5, [3.0])
             Test.@test gv[1] ≈ 0.5 * 2.0 atol=ATOL   # ∂H/∂v = p·x
         end

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -396,7 +396,7 @@ function test_ocp_control()
             Test.@test pvf isa Number
             # pvf = -∫ ∂H̃/∂v dt (u held at the law value) — quadrature on the flow's own
             # (x(t), p(t)) trajectory, using the pseudo variable-gradient getter.
-            ∇ṽ = Systems.pseudo_variable_gradient(fp)
+            ∇ṽ = Systems.get_pseudo_variable_gradient(fp)
             ts = range(t0, tf; length=101)
             ys = map(ts) do t
                 x, p = t == t0 ? (x0, p0) : fp(t0, x0, p0, t; variable=v)
@@ -426,7 +426,7 @@ function test_ocp_control()
             # non-stationary law ⇒ chain term ≠ 0 ⇒ the two modes give different pv
             Test.@test !isapprox(pvt, pvp; atol=1e-4)
             # absolute check on :total via quadrature of the total ∂H/∂v (through the law)
-            ∇v = Systems.variable_gradient(ft)
+            ∇v = Systems.get_variable_gradient(ft)
             ts = range(t0, tf; length=101)
             ys = map(ts) do t
                 x, p = t == t0 ? (x0, p0) : ft(t0, x0, p0, t; variable=v)
@@ -453,13 +453,13 @@ function test_ocp_control()
             Test.@test Systems.hamiltonian(fp) isa Data.AbstractHamiltonian
             Test.@test Systems.hamiltonian(ft) isa Data.AbstractHamiltonian
             # gradient getters return callable functors (not closures)
-            Test.@test Systems.pseudo_hamiltonian_gradient(fp) isa
+            Test.@test Systems.get_pseudo_hamiltonian_gradient(fp) isa
                 Systems.PseudoHamiltonianGradient
-            Test.@test Systems.hamiltonian_gradient(ft) isa Systems.HamiltonianGradient
+            Test.@test Systems.get_hamiltonian_gradient(ft) isa Systems.HamiltonianGradient
             # the AD backend can be provided explicitly (forwarded flow → system)
             be = Systems.backend(Flows.system(ft))
-            g_default = Systems.hamiltonian_gradient(ft)
-            g_custom = Systems.hamiltonian_gradient(ft; ad_backend=be)
+            g_default = Systems.get_hamiltonian_gradient(ft)
+            g_custom = Systems.get_hamiltonian_gradient(ft; ad_backend=be)
             Test.@test g_custom isa Systems.HamiltonianGradient
             Test.@test all(g_default(0.0, 1.0, 0.5, 0.5) .≈ g_custom(0.0, 1.0, 0.5, 0.5))
         end
@@ -648,13 +648,13 @@ function test_ocp_control()
                 c * x0 atol = 1e-10
 
             # (3) total gradient ∇H = (∂ₓH, ∂ₚH) = (-p+c, -x+p) — chain-rule through law
-            ∇H = Systems.hamiltonian_gradient(f)
+            ∇H = Systems.get_hamiltonian_gradient(f)
             dxH, dpH = ∇H(0.0, x0, p0, Float64[])
             Test.@test dxH ≈ -p0 + c atol = 1e-8
             Test.@test dpH ≈ -x0 + p0 atol = 1e-8
 
             # (4) pseudo gradient at fixed u: ∂ₓH̃_c = -p+c, ∂ₚH̃_c = -x+u
-            ∇H̃ = Systems.pseudo_hamiltonian_gradient(f)
+            ∇H̃ = Systems.get_pseudo_hamiltonian_gradient(f)
             dxH̃, dpH̃ = ∇H̃(0.0, x0, p0, u0, Float64[])
             Test.@test dxH̃ ≈ -p0 + c atol = 1e-8
             Test.@test dpH̃ ≈ -x0 + u0 atol = 1e-8
@@ -682,7 +682,7 @@ function test_ocp_control()
             law = Data.DynClosedLoop((x, p, v) -> p; is_variable=true)
             f = Flows.Flow(OCP_VAR, law; constraint=g, multiplier=μ, _opts()...)
             x0, p0, vv = 0.7, 0.4, 0.5
-            ∇vH = Systems.variable_gradient(f)
+            ∇vH = Systems.get_variable_gradient(f)
             Test.@test first(∇vH(0.0, x0, p0, vv)) ≈ -p0 * x0 atol = 1e-8
         end
 


### PR DESCRIPTION
## Summary
- `CTFlows.Systems.hamiltonian_gradient` / `variable_gradient` / `pseudo_hamiltonian_gradient` / `pseudo_variable_gradient` shared their names with the unrelated `CTBase.Differentiation` compute functions of the same name, forcing readers to track `Differentiation.` qualification at every call site to tell accessor from compute function apart.
- Renamed the accessor side (CTFlows) to `get_hamiltonian_gradient` / `get_variable_gradient` / `get_pseudo_hamiltonian_gradient` / `get_pseudo_variable_gradient`, matching the `get_*` accessor convention already used by `CTFlows.MultiPhase` (`get_flow`, `get_switching_time`, …).
- The exported functor types (`HamiltonianGradient`, `HamiltonianVariableGradient`, `PseudoHamiltonianGradient`, `PseudoHamiltonianVariableGradient`) are unchanged. `CTBase.Differentiation.*` compute functions are untouched — out of scope.

Closes #368.

## Test plan
- [x] `suite/systems` + `suite/flows` green after the `src/` rename
- [x] Full test suite green after tests/docs updated (3030/3030 passed)