### PR TITLE
Fix #375: GPU test suites now skip explicitly instead of silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3-beta] - 2026-07-29
+
+### Fixed
+
+- **GPU test suites now skip explicitly instead of silently** ([#375]): the GPU
+  `test_gpu_flows.jl` and `test_gpu_ensemble.jl` suites used a local `is_cuda_on()`
+  early-return that produced `Pass 0` on CPU — indistinguishable from having run and
+  passed. Consolidated `is_cuda_on()` into a `Main.TestCapabilities` module (pattern
+  from [CTSolvers.jl#190]), replaced the silent return with `Test.@test_skip false`
+  (shows as `Broken`), and added an `on_gpu_runner()` guard that fails loudly if the
+  `kkt` runner lost its device.
+
+### Added
+
+- **`test/suite/environment/test_environment_contract.jl`** ([#375]): environment
+  contract tests verifying that (1) the SciML extensions are armed, (2) the GPU driver
+  is functional when running on the `kkt` runner, and (3) the local `is_cuda_on()`
+  anti-pattern has not been reintroduced anywhere under `test/suite/`.
+
+### Testing
+
+- Full suite green: **3033 pass, 2 broken** (the 2 `Broken` are the GPU testsets
+  correctly marked as skipped on CPU).
+
 ## [0.16.2-beta] - 2026-07-29
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTFlows"
 uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.16.2-beta"
+version = "0.16.3-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,12 +19,16 @@ using Test
 using CTBase
 using CTFlows
 
-# CUDA availability check — GPU execution tests (suite/extensions/test_gpu_flows.jl) self-gate
-# on `is_cuda_on()` and skip cleanly when no functional device is present (e.g. CI CPU runners,
-# dev machines). The real GPU run is the `test-gpu-kkt` job on the kkt NVIDIA runner.
+# Capability constants computed once, here, where a top-level `using` is guaranteed
+# to bind into Main. Suite files read Main.TestCapabilities.* instead of redefining
+# is_cuda_on() locally (see issue #375 / CTSolvers.jl#190).
 using CUDA
-is_cuda_on() = CUDA.functional()
-if is_cuda_on()
+module TestCapabilities
+using CUDA: CUDA
+const CUDA_FUNCTIONAL = CUDA.functional()
+end
+
+if Main.TestCapabilities.CUDA_FUNCTIONAL
     println("✓ CUDA functional, GPU tests enabled")
 else
     println("⚠️  CUDA not functional, GPU tests will be skipped")

--- a/test/suite/environment/test_environment_contract.jl
+++ b/test/suite/environment/test_environment_contract.jl
@@ -1,0 +1,64 @@
+module TestEnvironmentContract
+
+using Test: Test
+using CTFlows: CTFlows
+using SciMLBase: SciMLBase  # triggers CTFlowsSciMLFlows + CTFlowsSciMLIntegrator extensions
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# CTFlows has no dedicated GPU extension (no MadNLPGPU/CUDSS). The GPU path runs
+# through the SciML extensions, so we check those are armed.
+const _SciMLFlows = Base.get_extension(CTFlows, :CTFlowsSciMLFlows)
+const _SciMLIntegrator = Base.get_extension(CTFlows, :CTFlowsSciMLIntegrator)
+
+"""
+    _local_is_cuda_on_offenders()
+
+Recursively find, under `test/suite/`, source lines defining a local `is_cuda_on()`
+function — the anti-pattern consolidated into Main.TestCapabilities by this fix
+(see issue #375 / CTSolvers.jl#190).
+"""
+function _local_is_cuda_on_offenders()
+    suite_dir = joinpath(@__DIR__, "..")
+    offenders = Tuple{String,Int}[]
+    for (root, _, files) in walkdir(suite_dir)
+        for f in files
+            endswith(f, ".jl") || continue
+            path = joinpath(root, f)
+            for (lineno, line) in enumerate(eachline(path))
+                if occursin(r"is_cuda_on\(\)\s*=", line)
+                    push!(offenders, (relpath(path, suite_dir), lineno))
+                end
+            end
+        end
+    end
+    return offenders
+end
+
+function test_environment_contract()
+    Test.@testset "Test-environment contract" verbose=VERBOSE showtiming=SHOWTIMING begin
+        Test.@testset "SciML extensions armed" begin
+            Test.@test !isnothing(_SciMLFlows)
+            Test.@test !isnothing(_SciMLIntegrator)
+        end
+
+        Test.@testset "GPU driver required on the GPU runner" begin
+            if get(ENV, "RUNNER_NAME", "") == "kkt"
+                Test.@test Main.TestCapabilities.CUDA_FUNCTIONAL
+            end
+        end
+
+        Test.@testset "local is_cuda_on() anti-pattern has not returned" begin
+            offenders = _local_is_cuda_on_offenders()
+            Test.@test isempty(offenders)
+            for (file, lineno) in offenders
+                @warn "local is_cuda_on() at $file:$lineno — use Main.TestCapabilities instead"
+            end
+        end
+    end
+end
+
+end # module
+
+test_environment_contract() = TestEnvironmentContract.test_environment_contract()

--- a/test/suite/extensions/test_gpu_ensemble.jl
+++ b/test/suite/extensions/test_gpu_ensemble.jl
@@ -32,7 +32,8 @@ import StaticArrays: StaticArrays                 # SVector for the EnsembleGPUK
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-is_cuda_on() = CUDA.functional()
+# CUDA availability — read from Main.TestCapabilities (consolidated in runtests.jl)
+_cuda_on() = isdefined(Main, :TestCapabilities) ? Main.TestCapabilities.CUDA_FUNCTIONAL : false
 
 # N independent trajectories of ẋ = -x, trajectory i starting at [i, 2i] ⇒ x(1) = [i, 2i]·e⁻¹.
 const _N_ENS = 8
@@ -42,8 +43,13 @@ _expected(i) = _u0(i) .* exp(-1.0)
 function test_gpu_ensemble()
     Test.@testset "GPU ensemble (Family-C, DiffEqGPU tooling PoC)" verbose = VERBOSE showtiming =
         SHOWTIMING begin
-        if !is_cuda_on()
+        on_gpu_runner() = get(ENV, "RUNNER_NAME", "") == "kkt"
+
+        if on_gpu_runner()
+            Test.@test _cuda_on()   # fails loudly if kkt lost its device
+        elseif !_cuda_on()
             @info "CUDA not functional — GPU ensemble tests skipped (run on the kkt runner)"
+            Test.@test_skip false   # shows as Broken, not Pass 0
             return nothing
         end
 

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -45,9 +45,8 @@ import Zygote: Zygote      # backs the rows that pass `ad_backend=AutoZygote()` 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-is_cuda_on() = CUDA.functional()
-
-# Move a host array onto the device. Only ever called inside an `is_cuda_on()` guard.
+# Move a host array onto the device. Only ever called inside a CUDA_FUNCTIONAL guard.
+_cuda_on() = isdefined(Main, :TestCapabilities) ? Main.TestCapabilities.CUDA_FUNCTIONAL : false
 _dev(x) = CUDA.CuArray(x)
 
 # Analytic references (tf = 1).
@@ -109,8 +108,13 @@ const OCP_GPU_CTRL = _build_gpu_ctrl_ocp()
 
 function test_gpu_flows()
     Test.@testset "GPU flows (Family-B, device execution)" verbose=VERBOSE showtiming=SHOWTIMING begin
-        if !is_cuda_on()
+        on_gpu_runner() = get(ENV, "RUNNER_NAME", "") == "kkt"
+
+        if on_gpu_runner()
+            Test.@test _cuda_on()   # fails loudly if kkt lost its device
+        elseif !_cuda_on()
             @info "CUDA not functional — GPU flow tests skipped (run on the kkt runner)"
+            Test.@test_skip false   # shows as Broken, not Pass 0
             return nothing
         end
 


### PR DESCRIPTION
## Summary

Fixes #375.

GPU test suites (`test_gpu_flows.jl`, `test_gpu_ensemble.jl`) were silently skipping on CPU via an early `return nothing` after a local `is_cuda_on()` check. This produced `Pass 0` in the test summary — indistinguishable from having run and passed — making it impossible to detect actual GPU test failures or regressions.

## Changes

### Phase A — Consolidate capability checks

- **`test/runtests.jl`**: Replaced the standalone `is_cuda_on()` function with a `Main.TestCapabilities` module exposing a `CUDA_FUNCTIONAL` const, computed once at top level. Pattern adopted from [CTSolvers.jl#190](https://github.com/control-toolbox/CTSolvers.jl/pull/190).
- **`test/suite/extensions/test_gpu_flows.jl`**: Removed local `is_cuda_on()` definition. Added `_cuda_on()` helper reading from `Main.TestCapabilities`. Replaced the silent early-return with:
  - `on_gpu_runner()` check: if on the `kkt` runner, asserts `_cuda_on()` and fails loudly if the device is missing.
  - `Test.@test_skip false` on non-GPU environments: shows as `Broken` in the summary instead of `Pass 0`.
- **`test/suite/extensions/test_gpu_ensemble.jl`**: Same treatment as `test_gpu_flows.jl`.

### Phase B — Environment contract test

- **`test/suite/environment/test_environment_contract.jl`** (new file): Three contract tests:
  1. **SciML extensions armed** — verifies `CTFlowsSciMLFlows` and `CTFlowsSciMLIntegrator` extensions are loaded.
  2. **GPU driver required on the GPU runner** — on the `kkt` runner, asserts `Main.TestCapabilities.CUDA_FUNCTIONAL`.
  3. **Local `is_cuda_on()` anti-pattern has not returned** — recursively scans `test/suite/` for any local `is_cuda_on()` definition and fails if found.

### Version & changelog

- Bumped version to `0.16.3-beta`.
- Updated `CHANGELOG.md` with Fixed, Added, and Testing sections.

## Verification

| Checkpoint | Result |
|---|---|
| Phase A — GPU test files only | `Broken 2` (1 per GPU testset) ✅ |
| Phase B — Environment contract test | `3/3 pass` ✅ |
| Phase C — Full suite (98 files) | `3033 pass, 2 broken, 0 fail` ✅ |

The 2 `Broken` are the GPU testsets correctly marked as skipped on CPU — visible in the summary instead of the previous silent `Pass 0`.

## Out of scope

- No changes to `Project.toml` dependencies (no CUDSS/MadNLPGPU addition).
- No changes to CI workflows (`CI.yml`).
- No `@test_skip` on individual GPU assertions — only at the testset level.