### PR TITLE
fix(docs): OpenLoop now requires t argument (CTBase 0.28.9-beta breaking change)

### DIFF
--- a/docs/src/compatibility/controlled_vector_field.md
+++ b/docs/src/compatibility/controlled_vector_field.md
@@ -56,7 +56,7 @@ using ForwardDiff: ForwardDiff
 fc = Data.ControlledVectorField((x, u) -> u .- x)
 
 law_cl = Data.ClosedLoop(x -> -x)
-law_ol = Data.OpenLoop(() -> 1.0)
+law_ol = Data.OpenLoop(t -> 1.0)
 
 flow_cl = Flows.Flow(fc, law_cl; reltol=1e-8)
 flow_ol = Flows.Flow(fc, law_ol; reltol=1e-8)

--- a/docs/src/flows/control_laws.md
+++ b/docs/src/flows/control_laws.md
@@ -242,8 +242,8 @@ calls return the final state (no costate); trajectory calls return a
 state, reconstructed control, and objective (Mayer + Lagrange).
 
 ```@example flows_laws
-# OpenLoop law: u() = 1 (constant, autonomous ⇒ no time argument)
-law_ol = Data.OpenLoop(() -> 1.0)
+# OpenLoop law: u(t) = 1 (constant control, always takes t)
+law_ol = Data.OpenLoop(t -> 1.0)
 f_cflow = Flows.Flow(ocp, law_ol; reltol=1e-8)
 ```
 


### PR DESCRIPTION
## Summary

CTBase 0.28.9-beta made `OpenLoop` unconditionally non-autonomous: the function must always take `t` as argument. The zero-argument closure `OpenLoop(() -> 1.0)` is no longer valid and must be replaced by `OpenLoop(t -> 1.0)`.

## Changes

- `docs/src/flows/control_laws.md`: `OpenLoop(() -> 1.0)` → `OpenLoop(t -> 1.0)` (line 246)
- `docs/src/compatibility/controlled_vector_field.md`: same fix (line 59)

## Verification

`julia --project=docs/ -e 'ENV["GKSwstype"]="nul"; include("docs/make.jl")'` builds successfully (exit code 0, VitePress rendering complete).