### PR TITLE
ci: remove opened from pull_request triggers

### DIFF
--- a/.github/workflows/CPUProbe.yml
+++ b/.github/workflows/CPUProbe.yml
@@ -8,7 +8,7 @@ name: CPU probe
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, reopened]
 
 jobs:
   cpu-probe:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v[0-9]+\.[0-9]+\.[0-9]+'   # v0.5.0 yes, v0.5.0-beta no
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
+    types: [labeled, synchronize, reopened]
   
 jobs:
   call:


### PR DESCRIPTION
Remove `opened` from `pull_request` trigger types in `CPUProbe.yml` and `Documentation.yml` to avoid redundant workflow runs on PR creation (already covered by `labeled` + `synchronize`).