### PR TITLE
fix: enforce Handbook tenet 2 — using, never import

### DIFF
--- a/docs/src/compatibility/controlled_vector_field.md
+++ b/docs/src/compatibility/controlled_vector_field.md
@@ -44,10 +44,10 @@ at ``t_f = 1``.
 
 ```@setup fc_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/hamiltonian.md
+++ b/docs/src/compatibility/hamiltonian.md
@@ -37,10 +37,10 @@ identical: ``(x_f, p_f) = (p_0, -x_0)`` at ``t_f = \pi/2``.
 
 ```@setup h_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/hamiltonian_vector_field.md
+++ b/docs/src/compatibility/hamiltonian_vector_field.md
@@ -29,10 +29,10 @@ fixed) with the default SciML integrator (`OrdinaryDiffEqTsit5`). The analytic s
 
 ```@setup hvf_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/ocp_control_laws.md
+++ b/docs/src/compatibility/ocp_control_laws.md
@@ -34,10 +34,10 @@ second.
 ```@setup ocp_laws_compat
 using CTFlows
 using CTModels
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/ocp_free.md
+++ b/docs/src/compatibility/ocp_free.md
@@ -37,9 +37,9 @@ containers against the first and the vector-family containers against the second
 ```@setup ocp_free_compat
 using CTFlows
 using CTModels
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/pseudo_hamiltonian.md
+++ b/docs/src/compatibility/pseudo_hamiltonian.md
@@ -44,10 +44,10 @@ x_f = x_0 + p_0, \qquad p_f = p_0 \quad\text{at } t_f = 1.
 
 ```@setup ph_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/pseudo_hamiltonian_vector_field.md
+++ b/docs/src/compatibility/pseudo_hamiltonian_vector_field.md
@@ -52,10 +52,10 @@ supplied directly — no AD anywhere in this constructor.
 
 ```@setup phvf_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/sciml.md
+++ b/docs/src/compatibility/sciml.md
@@ -28,11 +28,11 @@ All examples integrate the scalar exponential decay ``\dot{x} = -p\,x`` with ``p
 
 ```@setup sciml_compat
 using CTFlows
-using CTFlows.Flows
-using CTFlows.Integrators
-using CTFlows.Trajectories
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
 using SciMLBase: SciMLBase
-import OrdinaryDiffEqTsit5
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/compatibility/shape_contract.md
+++ b/docs/src/compatibility/shape_contract.md
@@ -19,11 +19,11 @@ every other page in this section.
 
 ```@setup shape_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
 using SciMLBase: SciMLBase
-import OrdinaryDiffEqTsit5
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 ```
 
 ---

--- a/docs/src/compatibility/vector_field.md
+++ b/docs/src/compatibility/vector_field.md
@@ -28,10 +28,10 @@ condition ``x_0`` to ``x_0\,e^{-1}``.
 
 ```@setup vf_compat
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 ```

--- a/docs/src/flows/building_a_flow.md
+++ b/docs/src/flows/building_a_flow.md
@@ -16,14 +16,14 @@ call. This page explains both paths.
 
 ```@setup flows_building
 using CTFlows
-using CTBase.Data
-using CTBase.Traits
-using CTFlows.Systems
-using CTFlows.Integrators
-using CTFlows.Flows
-using CTFlows.Trajectories
-using CTFlows.Configs
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Configs
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 ```
 
 ---
@@ -46,7 +46,8 @@ hflow = Flows.Flow(hvf; reltol=1e-10)
 
 ```@example flows_building
 # From a scalar Hamiltonian (AD computes the derivatives) → HamiltonianFlow
-import DifferentiationInterface, ForwardDiff
+using DifferentiationInterface: DifferentiationInterface
+using ForwardDiff: ForwardDiff
 using LinearAlgebra
 h = Data.Hamiltonian((x, p) -> 0.5 * (dot(x, x) + dot(p, p)))
 hflow_ad = Flows.Flow(h; reltol=1e-10)

--- a/docs/src/flows/constrained.md
+++ b/docs/src/flows/constrained.md
@@ -12,12 +12,13 @@ agree on a constrained arc), and two worked examples.
 
 ```@setup flows_constrained
 using CTFlows
-using CTBase.Data
-using CTBase.Traits
-using CTFlows.Flows
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Flows
 using CTModels
-import OrdinaryDiffEqTsit5
-import DifferentiationInterface, ForwardDiff
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using DifferentiationInterface: DifferentiationInterface
+using ForwardDiff: ForwardDiff
 ```
 
 ---

--- a/docs/src/flows/control_laws.md
+++ b/docs/src/flows/control_laws.md
@@ -11,14 +11,15 @@ three kinds of control laws, each leading to a different flow type.
 
 ```@setup flows_laws
 using CTFlows
-using CTBase.Data
-using CTBase.Traits
-using CTFlows.Flows
-using CTFlows.Systems
-using CTFlows.Trajectories
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Flows
+using CTFlows: Systems
+using CTFlows: Trajectories
 using CTModels
-import OrdinaryDiffEqTsit5
-import DifferentiationInterface, ForwardDiff
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using DifferentiationInterface: DifferentiationInterface
+using ForwardDiff: ForwardDiff
 ```
 
 ---

--- a/docs/src/flows/gpu.md
+++ b/docs/src/flows/gpu.md
@@ -49,10 +49,10 @@ Move the state to the device and call the flow as usual.
 
 ```julia
 using CTFlows
-using CTFlows.Flows
-using CTBase.Data
-import OrdinaryDiffEqTsit5
-import CUDA
+using CTFlows: Flows
+using CTBase: Data
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using CUDA: CUDA
 
 x0 = CUDA.CuArray([1.0, 2.0])
 
@@ -128,10 +128,10 @@ runs on both:
 
 ```@setup flows_gpu
 using CTFlows
-using CTFlows.Flows
-using CTBase.Data
-using CTBase.Strategies
-import OrdinaryDiffEqTsit5
+using CTFlows: Flows
+using CTBase: Data
+using CTBase: Strategies
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 ```
 
 ```@example flows_gpu
@@ -246,8 +246,8 @@ Strategies.describe(:di, Flows.flow_registry())
 You can always override the backend explicitly:
 
 ```julia
-import ADTypes
-import Zygote   # the package must be loaded: AutoZygote() is only a marker type
+using ADTypes: ADTypes
+using Zygote: Zygote   # the package must be loaded: AutoZygote() is only a marker type
 flow = Flows.Flow(h; ad_backend=ADTypes.AutoZygote())
 ```
 
@@ -277,8 +277,11 @@ flow = Flows.Flow(h; ad_backend=ADTypes.AutoZygote())
 Two algorithms from DiffEqGPU.jl, with **different requirements on the right-hand side**:
 
 ```julia
-import CUDA, DiffEqGPU, SciMLBase
-import OrdinaryDiffEqTsit5, StaticArrays
+using CUDA: CUDA
+using DiffEqGPU: DiffEqGPU
+using SciMLBase: SciMLBase
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using StaticArrays: StaticArrays
 
 N = 8
 init(i) = [Float64(i), 2.0 * i]   # trajectory i starts at [i, 2i]
@@ -341,7 +344,7 @@ the final state vector — a bug that looks like a numerical error.
 The pattern CTFlows uses for its own device tests transfers directly:
 
 ```julia
-import CUDA
+using CUDA: CUDA
 CUDA.functional() || return          # skip cleanly on machines without a device
 CUDA.allowscalar(false)              # make every pass genuinely scalar-index-free
 ```

--- a/docs/src/flows/integrating.md
+++ b/docs/src/flows/integrating.md
@@ -9,15 +9,15 @@ styles depending on whether you need the **full trajectory** or just the **final
 
 ```@setup flows_integrating
 using CTFlows
-using CTBase.Data
-using CTBase.Traits
-using CTFlows.Systems
-using CTFlows.Integrators
-using CTFlows.Flows
-using CTFlows.Trajectories
-using CTFlows.Configs
-import OrdinaryDiffEqTsit5
-import ForwardDiff  # triggers the DifferentiationInterface ForwardDiff extension
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Configs
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using ForwardDiff: ForwardDiff  # triggers the DifferentiationInterface ForwardDiff extension
 
 vf = Data.VectorField(x -> -x)
 flow = Flows.Flow(vf; reltol=1e-8)
@@ -196,7 +196,7 @@ Options are passed as keyword arguments to `Flows.Flow(data; opts...)` or, when 
 the integrator explicitly, to `Integrators.SciML(; opts...)`.
 
 The default integrator is **SciML** backed by `OrdinaryDiffEqTsit5` (loaded when
-`import OrdinaryDiffEqTsit5` appears in your session).
+`using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5` appears in your session).
 
 ### Common options
 

--- a/docs/src/flows/multiphase.md
+++ b/docs/src/flows/multiphase.md
@@ -11,11 +11,11 @@ of one phase becomes the initial condition of the next.
 
 ```@setup flows_multiphase
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.MultiPhase
-using CTFlows.Trajectories
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: MultiPhase
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 
 f_dyn(x) = -x
 vf = Data.VectorField(f_dyn)

--- a/docs/src/flows/optimal_control.md
+++ b/docs/src/flows/optimal_control.md
@@ -14,10 +14,11 @@ trajectory calls return a full
 ```@setup flows_ocp
 using CTFlows
 using CTModels
-using CTFlows.Flows
-using CTBase.Traits
-import OrdinaryDiffEqTsit5
-import DifferentiationInterface, ForwardDiff
+using CTFlows: Flows
+using CTBase: Traits
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
+using DifferentiationInterface: DifferentiationInterface
+using ForwardDiff: ForwardDiff
 ```
 
 ---
@@ -170,7 +171,7 @@ sol_basic = f((0.0, 1.0), x0)
 ```
 
 ```@repl flows_ocp
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 Trajectories.state(sol_basic)(0.5)
 Trajectories.objective(sol_basic)   # ≈ exp(λ)
 ```

--- a/docs/src/flows/overview.md
+++ b/docs/src/flows/overview.md
@@ -58,14 +58,14 @@ CTFlows exports nothing at the package level. Bring submodules into scope explic
 
 ```@example flows_overview
 using CTFlows
-using CTFlows.Flows        # StateFlow, HamiltonianFlow, Flow, build_flow
-using CTBase.Data          # VectorField, Hamiltonian, HamiltonianVectorField
-using CTFlows.Systems      # build_system
-using CTFlows.Integrators  # SciML, build_problem, build_options
-using CTFlows.Trajectories # VectorFieldTrajectory, state, time_grid
-using CTBase.Traits        # Autonomous, NonAutonomous, Fixed, NonFixed, InPlace, OutOfPlace
-using CTFlows.Configs      # StateEndPointConfig, StateTrajectoryConfig, …
-import OrdinaryDiffEqTsit5 # activates the SciML extension
+using CTFlows: Flows        # StateFlow, HamiltonianFlow, Flow, build_flow
+using CTBase: Data          # VectorField, Hamiltonian, HamiltonianVectorField
+using CTFlows: Systems      # build_system
+using CTFlows: Integrators  # SciML, build_problem, build_options
+using CTFlows: Trajectories # VectorFieldTrajectory, state, time_grid
+using CTBase: Traits        # Autonomous, NonAutonomous, Fixed, NonFixed, InPlace, OutOfPlace
+using CTFlows: Configs      # StateEndPointConfig, StateTrajectoryConfig, …
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5 # activates the SciML extension
 nothing # hide
 ```
 

--- a/docs/src/flows/sciml.md
+++ b/docs/src/flows/sciml.md
@@ -19,10 +19,10 @@ interface (point/trajectory styles, configs, multi-phase concatenation).
 
 ```@setup flows_sciml
 using CTFlows
-using CTFlows.Flows
-using CTFlows.Integrators
+using CTFlows: Flows
+using CTFlows: Integrators
 using SciMLBase
-import OrdinaryDiffEqTsit5
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 ```
 
 ---

--- a/docs/src/flows/trajectories.md
+++ b/docs/src/flows/trajectories.md
@@ -10,11 +10,11 @@ submodule provides these wrappers.
 
 ```@setup flows_solutions
 using CTFlows
-using CTBase.Data
-using CTFlows.Flows
-using CTFlows.Trajectories
-using CTFlows.Integrators
-import OrdinaryDiffEqTsit5
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Integrators
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 
 vf  = Data.VectorField(x -> -x)
 flow = Flows.Flow(vf; reltol=1e-8)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -10,7 +10,7 @@ minutes.
 ## Installation
 
 ```julia
-import Pkg
+using Pkg: Pkg
 Pkg.add("CTFlows")
 ```
 
@@ -26,7 +26,7 @@ Three ideas explain most of the API:
 
 - **No top-level exports.** CTFlows exports nothing at the package level. Every
    symbol lives in a submodule and is reached via a qualified path
-   (`CTFlows.Flows.Flow`) or an explicit `using CTFlows.Flows`. The same holds for
+   (`CTFlows.Flows.Flow`) or an explicit `using CTFlows: Flows`. The same holds for
   the data layer, which lives in CTBase (`CTBase.Data.VectorField`).
 - **A pipeline of small layers.** Data (your functions, wrapped) → Systems (ODE
    right-hand side) → Integrators (solver strategy) → Flows (the callable object) →
@@ -42,10 +42,10 @@ Bring the relevant submodules into scope and load a solver:
 
 ```@example getting_started
 using CTFlows
-using CTBase.Data          # VectorField, Hamiltonian, HamiltonianVectorField
-using CTFlows.Flows        # Flow
-using CTFlows.Trajectories # time_grid, state, costate
-import OrdinaryDiffEqTsit5 # activates the SciML integrator extension
+using CTBase: Data          # VectorField, Hamiltonian, HamiltonianVectorField
+using CTFlows: Flows        # Flow
+using CTFlows: Trajectories # time_grid, state, costate
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5 # activates the SciML integrator extension
 nothing # hide
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,8 +23,10 @@ optional automatic differentiation.
 
 ```julia
 using CTFlows
-using CTBase.Data, CTFlows.Flows, CTFlows.Trajectories
-import OrdinaryDiffEqTsit5   # activates the SciML integrator extension
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5   # activates the SciML integrator extension
 
 # 1. Wrap the dynamics
 vf = Data.VectorField(x -> -x)     # autonomous, fixed, out-of-place
@@ -44,8 +46,8 @@ x(0.5)                             # interpolate
 
 !!! note "Qualified access"
     CTFlows exports nothing at the package level. Every symbol lives in a submodule
-    (`CTBase.Data`, `CTFlows.Flows`, …) and is reached via a qualified path or a
-    `using CTFlows.SubModule` import.
+    (`CTBase.Data`, `CTFlows.Flows`, …) and is reached via a qualified path after a
+    `using CTFlows: SubModule` import.
 
 The same `Flow` constructor also builds directly from an **optimal control
 problem** — a [`CTModels.Models.Model`](@extref CTModels.Models.Model) — with no

--- a/ext/CTFlowsPlots/TrajectoryPlots/TrajectoryPlots.jl
+++ b/ext/CTFlowsPlots/TrajectoryPlots/TrajectoryPlots.jl
@@ -16,13 +16,13 @@ and its `CTBasePlots` backend.
 """
 module TrajectoryPlots
 
-import DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
-import CTBase.Exceptions
-import CTBase.Plotting
+using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
+using CTBase: Exceptions
+using CTBase: Plotting
 using Plots: Plots
 
-using CTFlows.Trajectories: Trajectories
-using CTFlows.Integrators: Integrators
+using CTFlows: Trajectories
+using CTFlows: Integrators
 using CTModels: CTModels
 
 include("description.jl")

--- a/ext/CTFlowsSciMLFlows/CTFlowsSciMLFlows.jl
+++ b/ext/CTFlowsSciMLFlows/CTFlowsSciMLFlows.jl
@@ -15,18 +15,18 @@ integration itself is `CommonSolve.solve(prob, integrator)`, implemented by the
 """
 module CTFlowsSciMLFlows
 
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-import CTBase.Exceptions
-import CTBase.Core
-import CommonSolve: CommonSolve
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: Exceptions
+using CTBase: Core
+using CommonSolve: CommonSolve
 
 using CTFlows: CTFlows
-using CTFlows.Display: Display
-using CTFlows.Configs: Configs
-using CTBase.Traits: Traits
-using CTFlows.Systems: Systems
-using CTFlows.Integrators: Integrators
-using CTFlows.Flows: Flows, AbstractFlow, build_flow
+using CTFlows: Display
+using CTFlows: Configs
+using CTBase: Traits
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
 using SciMLBase: SciMLBase, ODEProblem
 
 # =============================================================================

--- a/ext/CTFlowsSciMLFlows/flow_constructors.jl
+++ b/ext/CTFlowsSciMLFlows/flow_constructors.jl
@@ -31,7 +31,7 @@ xf = flow(0.0, [1.0], 1.0; variable=2.0)
 function Flows.Flow(f::SciMLBase.AbstractODEFunction; opts...)
     sys = SciMLFunctionSystem(f)
     integ = Flows._build_integrator(opts)
-    return build_flow(sys, integ)
+    return Flows.build_flow(sys, integ)
 end
 
 """

--- a/ext/CTFlowsSciMLFlows/problem_flow.jl
+++ b/ext/CTFlowsSciMLFlows/problem_flow.jl
@@ -43,7 +43,7 @@ sol = flow((0.5, 2.0), [2.0]; variable=3.0, unsafe=false)
 """
 struct SciMLProblemFlow{
     P<:SciMLBase.AbstractODEProblem,I<:Integrators.AbstractIntegrator
-} <: AbstractFlow{Traits.NonAutonomous,Traits.NonFixed,Traits.StateDynamics}
+} <: Flows.AbstractFlow{Traits.NonAutonomous,Traits.NonFixed,Traits.StateDynamics}
     prob::P
     integrator::I
 end

--- a/ext/CTFlowsSciMLIntegrator/CTFlowsSciMLIntegrator.jl
+++ b/ext/CTFlowsSciMLIntegrator/CTFlowsSciMLIntegrator.jl
@@ -18,14 +18,14 @@ in `CTSolvers.Integrators` and its `CTSolversSciMLIntegrator` extension. The use
 """
 module CTFlowsSciMLIntegrator
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTBase.Exceptions
+using DocStringExtensions: TYPEDSIGNATURES
+using CTBase: Exceptions
 
 using CTFlows: CTFlows
-using CTFlows.Configs: Configs
-using CTFlows.Systems: Systems
-using CTBase.Traits: Traits
-using CTFlows.Integrators: Integrators
+using CTFlows: Configs
+using CTFlows: Systems
+using CTBase: Traits
+using CTFlows: Integrators
 using SciMLBase: SciMLBase, ODEProblem
 
 # =============================================================================

--- a/ext/CTFlowsStaticArrays.jl
+++ b/ext/CTFlowsStaticArrays.jl
@@ -36,8 +36,7 @@ Xf, Pf = flow(0.0, X0, P0, π/2)
 """
 module CTFlowsStaticArrays
 
-using CTFlows
-import CTFlows.Systems: _ham_split
+using CTFlows: CTFlows, Systems
 using StaticArrays: SVector, SMatrix
 
 """
@@ -54,7 +53,7 @@ Type-stable split of a `SVector` into state and costate components.
 - This method provides type stability for SciML's out-of-place ODE solvers when using `StaticArrays`.
 - Used automatically when the `CTFlowsStaticArrays` extension is loaded.
 """
-function _ham_split(u::SVector{NN,T}, N::Int) where {NN,T}
+function Systems._ham_split(u::SVector{NN,T}, N::Int) where {NN,T}
     x = SVector{N,T}(ntuple(i -> u[i], Val(N)))
     pk = SVector{N,T}(ntuple(i -> u[N + i], Val(N)))
     return (x, pk)
@@ -77,7 +76,7 @@ Type-stable split of a `SMatrix` into state and costate components.
   row = `(k-1) % N + 1`, col = `(k-1) ÷ N + 1`.
 - Used automatically when the `CTFlowsStaticArrays` extension is loaded.
 """
-function _ham_split(u::SMatrix{NN,M,T}, N::Int) where {NN,M,T}
+function Systems._ham_split(u::SMatrix{NN,M,T}, N::Int) where {NN,M,T}
     # Enumerate result elements in column-major order via single index k
     X = SMatrix{N,M,T}(ntuple(k -> u[(k - 1) % N + 1, (k - 1) ÷ N + 1], Val(N*M)))
     P = SMatrix{N,M,T}(ntuple(k -> u[N + (k - 1) % N + 1, (k - 1) ÷ N + 1], Val(N*M)))

--- a/probe/cpu/probe_cpu.jl
+++ b/probe/cpu/probe_cpu.jl
@@ -45,10 +45,10 @@ using StaticArrays: SA, SVector, MVector, SMatrix, MMatrix
 using ForwardDiff: ForwardDiff
 using SciMLBase: SciMLBase
 
-import CTBase.Data
-import CTFlows.Flows
-import CTFlows.Trajectories
-import CTFlows.Integrators
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Integrators
 using CTModels: CTModels
 
 # ---------------------------------------------------------------------------

--- a/probe/gpu/probe_gpu.jl
+++ b/probe/gpu/probe_gpu.jl
@@ -47,10 +47,10 @@ using Enzyme: Enzyme                             # activates DI AutoEnzyme    (B
 using DiffEqGPU: DiffEqGPU                        # ensemble GPU tooling (Block 6)
 using StaticArrays: SVector                       # for the EnsembleGPUKernel path
 
-import CTBase.Data
-import CTBase.Differentiation
-import CTFlows.Flows
-import CTModels: CTModels                        # OCP fixture for Block 8
+using CTBase: Data
+using CTBase: Differentiation
+using CTFlows: Flows
+using CTModels: CTModels                        # OCP fixture for Block 8
 
 # ---------------------------------------------------------------------------
 # Probe harness: run a labelled experiment, catch everything, record + print

--- a/src/Configs/Configs.jl
+++ b/src/Configs/Configs.jl
@@ -37,15 +37,15 @@ module Configs
 # External package imports
 # ==============================================================================
 
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-import CTBase.Exceptions
-import CTBase.Traits
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: Exceptions
+using CTBase: Traits
 
 # ==============================================================================
 # Internal sibling-submodule imports
 # ==============================================================================
 
-import ..Display: Display
+using ..Display: Display
 
 # ==============================================================================
 # Includes

--- a/src/Configs/abstract.jl
+++ b/src/Configs/abstract.jl
@@ -24,15 +24,15 @@ All subtypes must implement:
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> StateEndPointConfig <: Configs.AbstractConfig
+julia> Configs.StateEndPointConfig <: Configs.AbstractConfig
 true
 
-julia> StateEndPointConfig <: Configs.AbstractEndPointConfig
+julia> Configs.StateEndPointConfig <: Configs.AbstractEndPointConfig
 true
 
-julia> StateEndPointConfig <: Configs.AbstractStateConfig
+julia> Configs.StateEndPointConfig <: Configs.AbstractStateConfig
 true
 \`\`\`
 
@@ -64,12 +64,12 @@ All subtypes must implement:
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> StateEndPointConfig <: Configs.AbstractConfigWithMaC
+julia> Configs.StateEndPointConfig <: Configs.AbstractConfigWithMaC
 true
 
-julia> HamiltonianEndPointConfig <: Configs.AbstractConfigWithMaC
+julia> Configs.HamiltonianEndPointConfig <: Configs.AbstractConfigWithMaC
 true
 \`\`\`
 

--- a/src/Configs/concrete.jl
+++ b/src/Configs/concrete.jl
@@ -17,9 +17,9 @@ integration from a single initial condition to a specific final time.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> config = StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
+julia> config = Configs.StateEndPointConfig(0.0, [1.0, 0.0], 1.0)
 StateEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]
@@ -58,9 +58,9 @@ time interval, useful for generating full trajectories.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> config = StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
+julia> config = Configs.StateTrajectoryConfig((0.0, 1.0), [1.0, 0.0])
 StateTrajectoryConfig
   tspan: (0.0, 1.0)
   x0: [1.0, 0.0]
@@ -99,9 +99,9 @@ Hamiltonian framework.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> config = HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
+julia> config = Configs.HamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 HamiltonianEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]
@@ -147,9 +147,9 @@ full Hamiltonian trajectories.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> config = HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
+julia> config = Configs.HamiltonianTrajectoryConfig((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
 HamiltonianTrajectoryConfig
   tspan: (0.0, 1.0)
   x0: [1.0, 0.0]
@@ -194,9 +194,9 @@ final time in the augmented Hamiltonian framework.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Configs
+julia> using CTFlows: Configs
 
-julia> config = AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
+julia> config = Configs.AugmentedHamiltonianEndPointConfig(0.0, [1.0, 0.0], [0.5, 0.3], [0.0, 0.0], 1.0)
 AugmentedHamiltonianEndPointConfig
   t0: 0.0
   x0: [1.0, 0.0]

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -21,8 +21,8 @@ module Display
 # External package imports
 # ==============================================================================
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTBase.Core
+using DocStringExtensions: TYPEDSIGNATURES
+using CTBase: Core
 
 # ==============================================================================
 # Tree characters (styled with the `muted` palette role at print time)

--- a/src/Flows/Flows.jl
+++ b/src/Flows/Flows.jl
@@ -12,28 +12,28 @@ This module defines the `AbstractFlow` type and its required methods:
 module Flows
 
 # 1. External-package imports (qualified, pollution-free)
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-import CTBase.Core
-import CTBase.Data
-import CTBase.Descriptions
-import CTBase.Differentiation
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Orchestration
-import CTBase.Traits
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: Core
+using CTBase: Data
+using CTBase: Descriptions
+using CTBase: Differentiation
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Orchestration
+using CTBase: Traits
 using CTModels: CTModels
-import CommonSolve: CommonSolve
+using CommonSolve: CommonSolve
 
 # ==============================================================================
 # Internal sibling-submodule imports
 # ==============================================================================
 
-import ..Display: Display
-import ..Configs: Configs
-import ..Systems: Systems, hamiltonian, hamiltonian_vector_field, vector_field
-import ..Integrators: Integrators
-import ..Trajectories: Trajectories
+using ..Display: Display
+using ..Configs: Configs
+using ..Systems: Systems, hamiltonian, hamiltonian_vector_field, vector_field
+using ..Integrators: Integrators
+using ..Trajectories: Trajectories
 
 # ==============================================================================
 # Include files

--- a/src/Flows/abstract_flow.jl
+++ b/src/Flows/abstract_flow.jl
@@ -24,7 +24,7 @@ trait queries encoded in their type parameters:
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
 julia> MyFlow <: Flows.AbstractFlow
 true
@@ -49,9 +49,9 @@ Matches any `AbstractFlow` with `StateDynamics` as the dynamics parameter.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> Flow(vf) isa Flows.AbstractStateFlow
+julia> Flows.Flow(vf) isa Flows.AbstractStateFlow
 true
 \`\`\`
 
@@ -74,9 +74,9 @@ Matches any `AbstractFlow` with `HamiltonianDynamics` as the dynamics parameter.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> Flow(hvf) isa Flows.AbstractHamiltonianFlow
+julia> Flows.Flow(hvf) isa Flows.AbstractHamiltonianFlow
 true
 \`\`\`
 
@@ -120,7 +120,7 @@ Extract the time dependence trait from an `AbstractFlow`.
 
 # Example
 \`\`\`julia
-using CTFlows.Flows
+using CTFlows: Flows
 
 struct MyFlow <: Flows.AbstractFlow{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics}
     data::Vector{Float64}
@@ -147,7 +147,7 @@ Extract the variable dependence trait from an `AbstractFlow`.
 
 # Example
 \`\`\`julia
-using CTFlows.Flows
+using CTFlows: Flows
 
 struct MyFlow <: Flows.AbstractFlow{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics}
     data::Vector{Float64}
@@ -514,9 +514,9 @@ integrator displays.
 
 # Example
 ```julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = Flow(system, integrator)
+julia> flow = Flows.Flow(system, integrator)
 StateFlow
 ├─ system: VectorFieldSystem
 │  ├─ time_dependence: Autonomous
@@ -562,9 +562,9 @@ Compact display of the flow.
 
 # Example
 ```julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = Flow(system, integrator)
+julia> flow = Flows.Flow(system, integrator)
 Flow(system=FakeSystem(n_x=2, n_p=2), integrator=FakeIntegrator)
 ```
 """

--- a/src/Flows/building.jl
+++ b/src/Flows/building.jl
@@ -22,7 +22,8 @@ This constructor builds a complete flow by:
 
 # Example
 \`\`\`julia
-using CTBase.Data, CTFlows.Flows
+using CTBase: Data
+using CTFlows: Flows
 
 vf = Data.VectorField((t, x, v) -> x, Traits.Autonomous(), Traits.Fixed())
 flow = Flows.Flow(vf; reltol=1e-8)
@@ -55,7 +56,8 @@ This constructor builds a complete Hamiltonian flow by:
 
 # Example
 ```julia
-using CTBase.Data, CTFlows.Flows
+using CTBase: Data
+using CTFlows: Flows
 
 hvf = Data.HamiltonianVectorField((x, p) -> (x, -p); is_autonomous=true, is_variable=false)
 flow = Flows.Flow(hvf; reltol=1e-8)
@@ -100,7 +102,8 @@ This constructor builds a complete Hamiltonian flow by:
 
 # Example
 ```julia
-using CTBase.Data, CTFlows.Flows
+using CTBase: Data
+using CTFlows: Flows
 
 h = Data.Hamiltonian((t, x, p, v) -> 0.5 * (x[1]^2 + p[1]^2); is_autonomous=true, is_variable=false)
 flow = Flows.Flow(h; reltol=1e-8, ad_backend=ADTypes.AutoForwardDiff())

--- a/src/Flows/calling.jl
+++ b/src/Flows/calling.jl
@@ -18,9 +18,9 @@ Builds a `StateEndPointConfig` internally and calls the flow with it.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = StateFlow(system, integrator)
+julia> flow = Flows.StateFlow(system, integrator)
 
 julia> sol = flow(0.0, [1.0, 0.0], 1.0)
 \`\`\`
@@ -74,9 +74,9 @@ with `H` obtained from [`CTFlows.Systems.hamiltonian`](@ref).
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = HamiltonianFlow(system, integrator)
+julia> flow = Flows.HamiltonianFlow(system, integrator)
 
 julia> sol = flow(0.0, [1.0, 0.0], [0.5, 0.3], 1.0)
 \`\`\`
@@ -117,9 +117,9 @@ Builds a `StateTrajectoryConfig` internally and calls the flow with it.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = StateFlow(system, integrator)
+julia> flow = Flows.StateFlow(system, integrator)
 
 julia> sol = flow((0.0, 1.0), [1.0, 0.0])
 \`\`\`
@@ -154,9 +154,9 @@ Builds a `HamiltonianTrajectoryConfig` internally and calls the flow with it.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows
+julia> using CTFlows: Flows
 
-julia> flow = HamiltonianFlow(system, integrator)
+julia> flow = Flows.HamiltonianFlow(system, integrator)
 
 julia> sol = flow((0.0, 1.0), [1.0, 0.0], [0.5, 0.3])
 \`\`\`

--- a/src/Flows/flow.jl
+++ b/src/Flows/flow.jl
@@ -20,13 +20,13 @@ The dynamics axis is encoded in the type parameter `D`:
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Flows, CTFlows.Systems, CTFlows.Integrators
+julia> using CTFlows: Flows, Systems, Integrators
 
-julia> system = VectorFieldSystem(VectorField(x -> -x))
+julia> system = Systems.VectorFieldSystem(VectorField(x -> -x))
 
-julia> integrator = SciML()
+julia> integrator = Integrators.SciML()
 
-julia> flow = StateFlow(system, integrator)
+julia> flow = Flows.StateFlow(system, integrator)
 StateFlow{...}
 \`\`\`
 

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -23,30 +23,31 @@ module Integrators
 # External package imports
 # ==============================================================================
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTBase.Exceptions
+using DocStringExtensions: TYPEDSIGNATURES
+using CTBase: Exceptions
 
 # Re-home the CTSolvers integrator surface consumed inside CTFlows so that
 # `Integrators.<symbol>` call sites resolve to CTSolvers.
-using CTSolvers.Integrators:
-    AbstractIntegrator,
-    SciML,
-    AbstractIntegrationResult,
-    final_state,
-    times,
-    evaluate_at,
-    status,
-    successful,
-    merge,
-    options_point,
-    options_trajectory
+using CTSolvers: Integrators as CTSolversIntegrators
+
+const AbstractIntegrator = CTSolversIntegrators.AbstractIntegrator
+const SciML = CTSolversIntegrators.SciML
+const AbstractIntegrationResult = CTSolversIntegrators.AbstractIntegrationResult
+const final_state = CTSolversIntegrators.final_state
+const times = CTSolversIntegrators.times
+const evaluate_at = CTSolversIntegrators.evaluate_at
+const status = CTSolversIntegrators.status
+const successful = CTSolversIntegrators.successful
+const merge = CTSolversIntegrators.merge
+const options_point = CTSolversIntegrators.options_point
+const options_trajectory = CTSolversIntegrators.options_trajectory
 
 # ==============================================================================
 # Internal sibling-submodule imports (used by the glue-function signatures)
 # ==============================================================================
 
-import ..Configs: Configs
-import ..Systems: Systems
+using ..Configs: Configs
+using ..Systems: Systems
 
 # ==============================================================================
 # CTFlows-owned glue generics (domain-specific; concrete methods in the ext)

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -27,20 +27,23 @@ using DocStringExtensions: TYPEDSIGNATURES
 using CTBase: Exceptions
 
 # Re-home the CTSolvers integrator surface consumed inside CTFlows so that
-# `Integrators.<symbol>` call sites resolve to CTSolvers.
+# `Integrators.<symbol>` call sites resolve to CTSolvers. The two-step alias + relative
+# `using` (rather than `const sym = CTSolversIntegrators.sym`) keeps each binding's doc
+# origin traceable to CTSolvers.Integrators, so `@doc CTFlows.Integrators.SciML` (and the
+# API reference build) still finds the docstring.
 using CTSolvers: Integrators as CTSolversIntegrators
-
-const AbstractIntegrator = CTSolversIntegrators.AbstractIntegrator
-const SciML = CTSolversIntegrators.SciML
-const AbstractIntegrationResult = CTSolversIntegrators.AbstractIntegrationResult
-const final_state = CTSolversIntegrators.final_state
-const times = CTSolversIntegrators.times
-const evaluate_at = CTSolversIntegrators.evaluate_at
-const status = CTSolversIntegrators.status
-const successful = CTSolversIntegrators.successful
-const merge = CTSolversIntegrators.merge
-const options_point = CTSolversIntegrators.options_point
-const options_trajectory = CTSolversIntegrators.options_trajectory
+using .CTSolversIntegrators:
+    AbstractIntegrator,
+    SciML,
+    AbstractIntegrationResult,
+    final_state,
+    times,
+    evaluate_at,
+    status,
+    successful,
+    merge,
+    options_point,
+    options_trajectory
 
 # ==============================================================================
 # Internal sibling-submodule imports (used by the glue-function signatures)

--- a/src/MultiPhase/MultiPhase.jl
+++ b/src/MultiPhase/MultiPhase.jl
@@ -9,22 +9,22 @@ and optional jumps, implementing exact sequential integration.
 module MultiPhase
 
 # 1. External-package imports (qualified, pollution-free)
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Traits
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Traits
 
 # ==============================================================================
 # Internal sibling-submodule imports
 # ==============================================================================
 
-import ..Display: Display
-import ..Configs: Configs
-import ..Systems: Systems
-import ..Integrators: Integrators
-import ..Flows: Flows
-import ..Trajectories: Trajectories
+using ..Display: Display
+using ..Configs: Configs
+using ..Systems: Systems
+using ..Integrators: Integrators
+using ..Flows: Flows
+using ..Trajectories: Trajectories
 
 # ==============================================================================
 # Include files

--- a/src/MultiPhase/calling.jl
+++ b/src/MultiPhase/calling.jl
@@ -940,7 +940,7 @@ Builds a `StateEndPointConfig` internally and evaluates the multi-phase flow.
 
 # Example
 \`\`\`julia
-using CTFlows.MultiPhase
+using CTFlows: MultiPhase
 
 mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf(0.0, [1.0, 0.0], 3.0)
@@ -976,7 +976,7 @@ returning a merged trajectory from all phases.
 
 # Example
 \`\`\`julia
-using CTFlows.MultiPhase
+using CTFlows: MultiPhase
 
 mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf((0.0, 3.0), [1.0, 0.0])
@@ -1012,7 +1012,7 @@ Builds a `HamiltonianEndPointConfig` internally and evaluates the multi-phase fl
 
 # Example
 \`\`\`julia
-using CTFlows.MultiPhase
+using CTFlows: MultiPhase
 
 mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf(0.0, [1.0, 0.0], [0.5, 0.3], 3.0)
@@ -1048,7 +1048,7 @@ returning a merged trajectory from all phases.
 
 # Example
 \`\`\`julia
-using CTFlows.MultiPhase
+using CTFlows: MultiPhase
 
 mpf = flow1 * (1.0, flow2) * (2.0, flow3)
 sol = mpf((0.0, 3.0), [1.0, 0.0], [0.5, 0.3])

--- a/src/MultiPhase/concatenation.jl
+++ b/src/MultiPhase/concatenation.jl
@@ -51,7 +51,7 @@ Creates a multi-phase flow with no jump at the switching time.
 
 # Example
 \`\`\`julia
-using CTFlows.Flows, CTFlows.MultiPhase
+using CTFlows: Flows, MultiPhase
 
 mpf = flow1 * (1.0, flow2)
 \`\`\`
@@ -87,7 +87,7 @@ Concatenate two state flows with a switching time and a state jump using the `*`
 
 # Example
 \`\`\`julia
-using CTFlows.Flows, CTFlows.MultiPhase
+using CTFlows: Flows, MultiPhase
 
 # additive jump
 mpf = flow1 * (1.0, [0.1, 0.2], flow2)   # x ← x + [0.1, 0.2] at t = 1.0
@@ -126,7 +126,7 @@ Creates a multi-phase Hamiltonian flow with no jump at the switching time.
 
 # Example
 \`\`\`julia
-using CTFlows.Flows, CTFlows.MultiPhase
+using CTFlows: Flows, MultiPhase
 
 mpf = flow1 * (1.0, flow2)
 \`\`\`
@@ -163,7 +163,7 @@ Concatenate two Hamiltonian flows with a switching time and a jump using the `*`
 
 # Example
 \`\`\`julia
-using CTFlows.Flows, CTFlows.MultiPhase
+using CTFlows: Flows, MultiPhase
 
 # additive costate jump
 mpf = flow1 * (1.0, [0.5, 0.0], flow2)   # p ← p + [0.5, 0.0] at t = 1.0
@@ -208,7 +208,7 @@ switching time. Three forms are accepted per component:
 
 # Example
 \`\`\`julia
-using CTFlows.Flows, CTFlows.MultiPhase
+using CTFlows: Flows, MultiPhase
 
 # additive on both
 mpf = flow1 * (1.0, [0.1, 0.0], [0.0, 0.5], flow2)

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -12,20 +12,20 @@ This module defines the `AbstractSystem` type and its required methods:
 module Systems
 
 # 1. External-package imports (qualified, pollution-free)
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using GPUArraysCore: GPUArraysCore
-import CTBase.Core
-import CTBase.Data
-import CTBase.Differentiation
-import CTBase.Exceptions
-import CTBase.Traits
+using CTBase: Core
+using CTBase: Data
+using CTBase: Differentiation
+using CTBase: Exceptions
+using CTBase: Traits
 
 # ==============================================================================
 # Internal sibling-submodule imports
 # ==============================================================================
 
-import ..Display: Display
-import ..Configs: Configs
+using ..Display: Display
+using ..Configs: Configs
 
 # ==============================================================================
 # Include files

--- a/src/Systems/abstract_system.jl
+++ b/src/Systems/abstract_system.jl
@@ -19,7 +19,7 @@ Hamiltonian systems supporting variable-costate integration additionally impleme
 # Example
 
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 # Define a concrete system
 struct MySystem <: Systems.AbstractSystem{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics}
@@ -55,9 +55,9 @@ Matches any `AbstractSystem` with `StateDynamics` as the dynamics parameter.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
-julia> VectorFieldSystem <: Systems.AbstractStateSystem
+julia> Systems.VectorFieldSystem <: Systems.AbstractStateSystem
 true
 \`\`\`
 
@@ -82,9 +82,9 @@ not as a type parameter of this alias.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
-julia> HamiltonianSystem <: Systems.AbstractHamiltonianSystem
+julia> Systems.HamiltonianSystem <: Systems.AbstractHamiltonianSystem
 true
 \`\`\`
 
@@ -105,7 +105,7 @@ Concrete subtypes must implement `time_dependence` to return the specific trait 
 # Example
 
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 struct MySystem <: Systems.AbstractSystem end
 
@@ -133,7 +133,7 @@ Concrete subtypes must implement `variable_dependence` to return the specific tr
 # Example
 
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 struct MySystem <: Systems.AbstractSystem end
 
@@ -160,7 +160,7 @@ Extract the time dependence trait from an `AbstractSystem`.
 
 # Example
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 struct MySystem <: Systems.AbstractSystem{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics}
     data::Vector{Float64}
@@ -187,7 +187,7 @@ Extract the variable dependence trait from an `AbstractSystem`.
 
 # Example
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 struct MySystem <: Systems.AbstractSystem{Traits.Autonomous, Traits.Fixed, Traits.StateDynamics}
     data::Vector{Float64}

--- a/src/Systems/building.jl
+++ b/src/Systems/building.jl
@@ -15,7 +15,7 @@ with flow integration pipelines.
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
 julia> vf = VectorField(x -> -x; autonomous=true, variable=false)
 VectorField
@@ -23,7 +23,7 @@ VectorField
   variable_dependence: Fixed
   function: var"#1"
 
-julia> sys = build_system(vf)
+julia> sys = Systems.build_system(vf)
 VectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
@@ -52,7 +52,7 @@ RHS closures are built lazily based on actual initial condition types during flo
 
 # Example
 ```julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
 julia> hvf = HamiltonianVectorField((x, p) -> (x, -p); autonomous=true, variable=false)
 HamiltonianVectorField
@@ -60,7 +60,7 @@ HamiltonianVectorField
   variable_dependence: Fixed
   function: var"#1"
 
-julia> sys = build_system(hvf)
+julia> sys = Systems.build_system(hvf)
 HamiltonianVectorFieldSystem
   time_dependence: Autonomous
   variable_dependence: Fixed
@@ -90,12 +90,14 @@ RHS closures are built lazily based on actual initial condition types during flo
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems, CTBase.Data
+julia> using CTFlows: Systems
 
-julia> h = Hamiltonian((t, x, p, v) -> 0.5 * sum(x.^2) + sum(p.^2); autonomous=true, variable=false)
+julia> using CTBase: Data
+
+julia> h = Data.Hamiltonian((t, x, p, v) -> 0.5 * sum(x.^2) + sum(p.^2); autonomous=true, variable=false)
 Hamiltonian{var"#1", Autonomous, Fixed}
 
-julia> sys = build_system(h, AutoForwardDiff())
+julia> sys = Systems.build_system(h, AutoForwardDiff())
 HamiltonianSystem
   time_dependence: Autonomous
   variable_dependence: Fixed

--- a/src/Systems/hamiltonian_system.jl
+++ b/src/Systems/hamiltonian_system.jl
@@ -27,12 +27,14 @@ inputs with consistent output shapes.
 
 # Example
 ```julia-repl
-julia> using CTFlows.Systems, CTBase.Data
+julia> using CTFlows: Systems
 
-julia> h = Hamiltonian((t, x, p, v) -> 0.5 * sum(x.^2) + sum(p.^2); autonomous=true, variable=false)
+julia> using CTBase: Data
+
+julia> h = Data.Hamiltonian((t, x, p, v) -> 0.5 * sum(x.^2) + sum(p.^2); autonomous=true, variable=false)
 Hamiltonian{var"#1", Autonomous, Fixed}
 
-julia> sys = HamiltonianSystem(h, AutoForwardDiff())
+julia> sys = Systems.HamiltonianSystem(h, AutoForwardDiff())
 HamiltonianSystem
   time_dependence: Autonomous
   variable_dependence: Fixed

--- a/src/Systems/hamiltonian_vector_field_system.jl
+++ b/src/Systems/hamiltonian_vector_field_system.jl
@@ -19,14 +19,14 @@ inputs with consistent output shapes.
 
 # Example
 ```julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
 julia> hvf = Data.HamiltonianVectorField((x, p) -> (x, -p))
 HamiltonianVectorField: autonomous, fixed (no variable), out-of-place
   natural call: f(x, p)
   uniform call: f(t, x, p, v)
 
-julia> sys = HamiltonianVectorFieldSystem(hvf)
+julia> sys = Systems.HamiltonianVectorFieldSystem(hvf)
 HamiltonianVectorFieldSystem
 ├─ time_dependence: Autonomous
 ├─ variable_dependence: Fixed

--- a/src/Systems/ode_parameters.jl
+++ b/src/Systems/ode_parameters.jl
@@ -21,16 +21,16 @@ can be added later (callbacks, extra data) without breaking existing code.
 
 # Example
 \`\`\`julia
-using CTFlows.Systems
+using CTFlows: Systems
 
 # Fixed system: variable is nothing
-params_fixed = ODEParameters(nothing)
+params_fixed = Systems.ODEParameters(nothing)
 
 # NonFixed system: variable is a value
-params_nonfixed = ODEParameters(0.5)
+params_nonfixed = Systems.ODEParameters(0.5)
 
 # NonFixed system: variable is a vector
-params_vector = ODEParameters([1.0, 2.0])
+params_vector = Systems.ODEParameters([1.0, 2.0])
 \`\`\`
 
 # Notes
@@ -61,18 +61,18 @@ the actual variable value (scalar or vector).
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
-julia> params_fixed = ODEParameters(nothing)
+julia> params_fixed = Systems.ODEParameters(nothing)
 ODEParameters{Nothing}(nothing)
 
-julia> variable(params_fixed)
+julia> Systems.variable(params_fixed)
 nothing
 
-julia> params_nonfixed = ODEParameters(0.5)
+julia> params_nonfixed = Systems.ODEParameters(0.5)
 ODEParameters{Float64}(0.5)
 
-julia> variable(params_nonfixed)
+julia> Systems.variable(params_nonfixed)
 0.5
 \`\`\`
 

--- a/src/Systems/vector_field_system.jl
+++ b/src/Systems/vector_field_system.jl
@@ -17,14 +17,14 @@ coercing a 1-D state to a scalar before calling the user's vector field (issue
 
 # Example
 \`\`\`julia-repl
-julia> using CTFlows.Systems
+julia> using CTFlows: Systems
 
 julia> vf = Data.VectorField(x -> -x)
 VectorField: autonomous, fixed (no variable), out-of-place
   natural call: f(x)
   uniform call: f(t, x, v)
 
-julia> sys = VectorFieldSystem(vf)
+julia> sys = Systems.VectorFieldSystem(vf)
 VectorFieldSystem
 ├─ time_dependence: Autonomous
 ├─ variable_dependence: Fixed

--- a/src/Trajectories/Trajectories.jl
+++ b/src/Trajectories/Trajectories.jl
@@ -22,22 +22,32 @@ module Trajectories
 # External package imports
 # ==============================================================================
 
-import DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
-import CTBase.Core
-import CTBase.Data
-import CTBase.Exceptions
-import CTBase.Traits
-import CTModels.Components: Components, state, control, costate, objective, time_grid
-import RecipesBase: RecipesBase, plot
+using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
+using CTBase: Core
+using CTBase: Data
+using CTBase: Exceptions
+using CTBase: Traits
+using CTModels: Components
+using RecipesBase: RecipesBase, plot
+
+# `Components.state`/`control`/`costate`/`objective`/`time_grid` are re-homed here
+# (const-bound) so that `Trajectories.<symbol>` resolves and can be exported below;
+# methods are contributed for VectorFieldTrajectory / HamiltonianVectorFieldTrajectory /
+# StateFlowTrajectory in the included files.
+const state = Components.state
+const control = Components.control
+const costate = Components.costate
+const objective = Components.objective
+const time_grid = Components.time_grid
 
 # ==============================================================================
 # Internal submodule imports
 # ==============================================================================
 
-import ..Display: Display
-import ..Configs: Configs
-import ..Systems: Systems
-import ..Integrators: Integrators
+using ..Display: Display
+using ..Configs: Configs
+using ..Systems: Systems
+using ..Integrators: Integrators
 
 # ==============================================================================
 # Include files

--- a/src/Trajectories/hamiltonian_vector_field_trajectory.jl
+++ b/src/Trajectories/hamiltonian_vector_field_trajectory.jl
@@ -29,12 +29,12 @@ semantic accessors for time grids, state functions, and costate functions.
 
 # Example
 ```julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = HamiltonianVectorFieldTrajectory(result)
-ts = times(sol)           # or time_grid(sol)
-x = state(sol)            # callable state function x(t)
-p = costate(sol)          # callable costate function p(t)
+sol = Trajectories.HamiltonianVectorFieldTrajectory(result)
+ts = times(sol)           # or Trajectories.time_grid(sol)
+x = Trajectories.state(sol)            # callable state function x(t)
+p = Trajectories.costate(sol)          # callable costate function p(t)
 x(0.5), p(0.5)           # evaluate at t = 0.5
 x0, p0 = sol(0.0)        # returns tuple (x(0), p(0))
 ```
@@ -279,10 +279,10 @@ CTFlows for `HamiltonianVectorFieldTrajectory`. Returns a
 
 # Example
 ```julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = HamiltonianVectorFieldTrajectory(result)
-x = state(sol)    # x is a callable StateProjection
+sol = Trajectories.HamiltonianVectorFieldTrajectory(result)
+x = Trajectories.state(sol)    # x is a callable StateProjection
 x(0.0)            # initial state
 x(0.5)            # interpolated state at t = 0.5
 ```
@@ -310,10 +310,10 @@ CTFlows for `HamiltonianVectorFieldTrajectory`. Returns a
 
 # Example
 ```julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = HamiltonianVectorFieldTrajectory(result)
-p = costate(sol)  # p is a callable CostateProjection
+sol = Trajectories.HamiltonianVectorFieldTrajectory(result)
+p = Trajectories.costate(sol)  # p is a callable CostateProjection
 p(0.0)            # initial costate
 p(0.5)            # interpolated costate at t = 0.5
 ```

--- a/src/Trajectories/vector_field_trajectory.jl
+++ b/src/Trajectories/vector_field_trajectory.jl
@@ -34,11 +34,11 @@ semantic accessors for time grids and state functions.
 
 # Example
 \`\`\`julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = VectorFieldTrajectory(result)
-ts = times(sol)           # or time_grid(sol)
-x = state(sol)            # callable state function
+sol = Trajectories.VectorFieldTrajectory(result)
+ts = times(sol)           # or Trajectories.time_grid(sol)
+x = Trajectories.state(sol)            # callable state function
 x(0.5)                    # evaluate at t = 0.5
 \`\`\`
 
@@ -125,10 +125,10 @@ providing a clear, self-documenting way to obtain the trajectory function.
 
 # Example
 \`\`\`julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = VectorFieldTrajectory(result)
-x = state(sol)    # x is a function of time
+sol = Trajectories.VectorFieldTrajectory(result)
+x = Trajectories.state(sol)    # x is a function of time
 x(0.0)            # initial state
 x(0.5)            # interpolated state at t = 0.5
 x.(0.0:0.1:1.0)   # broadcast over time grid
@@ -162,10 +162,10 @@ numerical contexts where "time grid" is the standard terminology.
 
 # Example
 \`\`\`julia
-using CTFlows.Trajectories
+using CTFlows: Trajectories
 
-sol = VectorFieldTrajectory(result)
-tg = time_grid(sol)  # same as times(sol)
+sol = Trajectories.VectorFieldTrajectory(result)
+tg = Trajectories.time_grid(sol)  # same as times(sol)
 \`\`\`
 
 # Notes

--- a/test/suite/common/test_default.jl
+++ b/test/suite/common/test_default.jl
@@ -1,10 +1,10 @@
 module TestDefault
 
 using Test: Test
-import CTBase.Data
-import CTFlows.Flows
-import CTFlows.Systems
-import CTBase.Core
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Systems
+using CTBase: Core
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/common/test_ode_parameters.jl
+++ b/test/suite/common/test_ode_parameters.jl
@@ -1,7 +1,7 @@
 module TestODEParameters
 
 using Test: Test
-import CTFlows.Systems
+using CTFlows: Systems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/configs/test_abstract_configs.jl
+++ b/test/suite/configs/test_abstract_configs.jl
@@ -1,8 +1,8 @@
 module TestAbstractConfigs
 
 using Test: Test
-import CTFlows.Configs
-import CTBase.Traits
+using CTFlows: Configs
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/configs/test_concrete_configs.jl
+++ b/test/suite/configs/test_concrete_configs.jl
@@ -1,8 +1,8 @@
 module TestConcreteConfigs
 
 using Test: Test
-import CTFlows.Configs
-import CTBase.Traits
+using CTFlows: Configs
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/configs/test_configs_module.jl
+++ b/test/suite/configs/test_configs_module.jl
@@ -18,7 +18,7 @@ module TestConfigsModule
 
 using Test: Test
 using CTFlows: CTFlows
-import CTFlows.Configs
+using CTFlows: Configs
 using CTFlows.Configs  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/configs/test_implementations_configs.jl
+++ b/test/suite/configs/test_implementations_configs.jl
@@ -1,9 +1,9 @@
 module TestImplementationsConfigs
 
 using Test: Test
-import CTBase.Exceptions
-import CTFlows.Configs
-import CTBase.Traits
+using CTBase: Exceptions
+using CTFlows: Configs
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/configs/test_interface_configs.jl
+++ b/test/suite/configs/test_interface_configs.jl
@@ -1,8 +1,8 @@
 module TestInterfaceConfigs
 
 using Test: Test
-import CTBase.Exceptions
-import CTFlows.Configs
+using CTBase: Exceptions
+using CTFlows: Configs
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/configs/test_show_configs.jl
+++ b/test/suite/configs/test_show_configs.jl
@@ -1,7 +1,7 @@
 module TestShowConfigs
 
 using Test: Test
-import CTFlows.Configs
+using CTFlows: Configs
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system.jl
@@ -1,13 +1,13 @@
 module TestFlowCallablesSciMLHamiltonianSystem
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTFlows.Systems: Systems
-import CTFlows.Flows: Flows
-import CTFlows.Integrators: Integrators
-import CTBase.Differentiation
-import CTFlows.Trajectories: Trajectories
+using CTBase: Exceptions
+using CTBase: Data
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTBase: Differentiation
+using CTFlows: Trajectories
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system_di.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_system_di.jl
@@ -5,13 +5,13 @@ Mirror of test_flow_callables_sciml_hamiltonian_system.jl using real Differentia
 module TestFlowCallablesSciMLHamiltonianSystemDI
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTFlows.Systems: Systems
-import CTFlows.Flows: Flows
-import CTFlows.Integrators: Integrators
-import CTBase.Differentiation
-import CTFlows.Trajectories: Trajectories
+using CTBase: Exceptions
+using CTBase: Data
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTBase: Differentiation
+using CTFlows: Trajectories
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_flow_callables_sciml_hamiltonian_vector_field.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_hamiltonian_vector_field.jl
@@ -1,11 +1,11 @@
 module TestFlowCallablesSciMLHamiltonianVectorField
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTBase.Data
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Data
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_flow_callables_sciml_vector_field.jl
+++ b/test/suite/extensions/test_flow_callables_sciml_vector_field.jl
@@ -1,11 +1,11 @@
 module TestFlowCallablesSciMLVectorField
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTBase.Data
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Data
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_forwarddiff_extension.jl
+++ b/test/suite/extensions/test_forwarddiff_extension.jl
@@ -1,10 +1,10 @@
 module TestForwardDiffExtension
 
 using Test: Test
-import CTFlows: CTFlows
-import CTBase.Data: Data
-import CTFlows.Integrators: Integrators
-import CTFlows.Flows: Flows
+using CTFlows: CTFlows
+using CTBase: Data
+using CTFlows: Integrators
+using CTFlows: Flows
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_gpu_ensemble.jl
+++ b/test/suite/extensions/test_gpu_ensemble.jl
@@ -23,11 +23,11 @@ Accessor discipline (probe runs 9–10): read a trajectory's final state via the
 module TestGPUEnsemble
 
 using Test: Test
-import CUDA: CUDA
-import SciMLBase: SciMLBase
-import DiffEqGPU: DiffEqGPU
-import OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5   # Tsit5 for the CPU/EnsembleGPUArray paths
-import StaticArrays: StaticArrays                 # SVector for the EnsembleGPUKernel path
+using CUDA: CUDA
+using SciMLBase: SciMLBase
+using DiffEqGPU: DiffEqGPU
+using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5   # Tsit5 for the CPU/EnsembleGPUArray paths
+using StaticArrays: StaticArrays                 # SVector for the EnsembleGPUKernel path
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/extensions/test_gpu_flows.jl
+++ b/test/suite/extensions/test_gpu_flows.jl
@@ -30,17 +30,17 @@ Out of scope here: the ensemble path (phase 4b, `test_gpu_ensemble.jl`).
 module TestGPUFlows
 
 using Test: Test
-import CUDA: CUDA
-import CTBase.Data: Data
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTModels: CTModels
-import ADTypes: ADTypes
-import SciMLBase: SciMLBase
+using CUDA: CUDA
+using CTBase: Data
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTModels: CTModels
+using ADTypes: ADTypes
+using SciMLBase: SciMLBase
 # Both AD backends are ADTypes *markers*: they construct without their package, but evaluating a
 # gradient needs the package loaded so DI can dispatch.
-import Mooncake: Mooncake  # backs the `method=:gpu` default (AutoMooncake, CTBase 0.28.2-beta)
-import Zygote: Zygote      # backs the rows that pass `ad_backend=AutoZygote()` explicitly
+using Mooncake: Mooncake  # backs the `method=:gpu` default (AutoMooncake, CTBase 0.28.2-beta)
+using Zygote: Zygote      # backs the rows that pass `ad_backend=AutoZygote()` explicitly
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/extensions/test_optimal_control_flow.jl
+++ b/test/suite/extensions/test_optimal_control_flow.jl
@@ -18,16 +18,16 @@ module TestOptimalControlFlow
 
 using Test: Test
 using CTModels: CTModels
-import CTBase: CTBase
-import CTBase.Exceptions: Exceptions
-import CTFlows: CTFlows
-import CTFlows.Flows: Flows
-import CTFlows.Systems: Systems
-import CTFlows.Integrators: Integrators
-import CTFlows.Configs: Configs
-import CTBase.Differentiation
-import CTBase.Data: Data
-import CTBase.Traits: Traits
+using CTBase: CTBase
+using CTBase: Exceptions
+using CTFlows: CTFlows
+using CTFlows: Flows
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Configs
+using CTBase: Differentiation
+using CTBase: Data
+using CTBase: Traits
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/extensions/test_plots_extension.jl
+++ b/test/suite/extensions/test_plots_extension.jl
@@ -7,13 +7,13 @@ in `CTBase.Plotting` and is tested there.
 module TestPlotsExtension
 
 using Test: Test
-import CTFlows: CTFlows
-import CTFlows.Integrators: Integrators
-import CTFlows.Trajectories: Trajectories
-import CTBase.Data: Data
-import CTBase.Core: Core
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
+using CTFlows: CTFlows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Data
+using CTBase: Core
+using CTBase: Exceptions
+using CTModels: CTModels
 
 using Plots
 

--- a/test/suite/extensions/test_sciml_extension.jl
+++ b/test/suite/extensions/test_sciml_extension.jl
@@ -1,19 +1,19 @@
 module TestSciMLExtension
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTFlows: CTFlows
-import CTFlows.Configs: Configs
-import CTFlows.Systems: Systems
-import CTFlows.Integrators: Integrators
-import CTFlows.Trajectories: Trajectories
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: CTFlows
+using CTFlows: Configs
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Trajectories
 using CommonSolve: CommonSolve
 
 # Get extensions to check they are loaded
 using SciMLBase: SciMLBase, ODEProblem
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
-import StaticArrays: SA
+using StaticArrays: SA
 const CTFlowsSciMLIntegrator = Base.get_extension(CTFlows, :CTFlowsSciMLIntegrator)
 const CTFlowsSciMLFlows = Base.get_extension(CTFlows, :CTFlowsSciMLFlows)
 

--- a/test/suite/extensions/test_sciml_rhs_functors.jl
+++ b/test/suite/extensions/test_sciml_rhs_functors.jl
@@ -1,10 +1,10 @@
 module TestSciMLRHSFunctors
 
 using Test: Test
-import CTFlows: CTFlows
-import CTBase.Traits: Traits
-import CTFlows.Systems: Systems
-import SciMLBase: SciMLBase, ODEFunction
+using CTFlows: CTFlows
+using CTBase: Traits
+using CTFlows: Systems
+using SciMLBase: SciMLBase, ODEFunction
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5
 using StaticArrays: SA, SVector
 

--- a/test/suite/extensions/test_scimlbase_flow_constructors.jl
+++ b/test/suite/extensions/test_scimlbase_flow_constructors.jl
@@ -1,13 +1,13 @@
 module TestSciMLBaseFlowConstructors
 
 using Test: Test
-import CTBase.Exceptions: Exceptions
-import CTFlows: CTFlows
-import CTFlows.Systems: Systems
-import CTFlows.Integrators: Integrators
-import CTFlows.Flows: Flows, AbstractFlow, StateFlow, build_flow
-import CTFlows.Trajectories: Trajectories
-import SciMLBase: SciMLBase, ODEProblem, ODEFunction
+using CTBase: Exceptions
+using CTFlows: CTFlows
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTFlows: Trajectories
+using SciMLBase: SciMLBase, ODEProblem, ODEFunction
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using StaticArrays: SA, SVector
 
@@ -31,16 +31,16 @@ function test_scimlbase_flow_constructors()
             Test.@testset "in-place function returns StateFlow" begin
                 f = ODEFunction((du, u, p, t) -> du .= -p .* u)
                 flow = Flows.Flow(f; reltol=1e-10)
-                Test.@test flow isa StateFlow
-                Test.@test flow isa AbstractFlow
+                Test.@test flow isa Flows.StateFlow
+                Test.@test flow isa Flows.AbstractFlow
                 Test.@test Flows.system(flow) isa CTFlowsSciMLFlows.SciMLFunctionSystem
             end
 
             Test.@testset "out-of-place function returns StateFlow" begin
                 f = ODEFunction{false}((u, p, t) -> -p .* u)
                 flow = Flows.Flow(f; reltol=1e-10)
-                Test.@test flow isa StateFlow
-                Test.@test flow isa AbstractFlow
+                Test.@test flow isa Flows.StateFlow
+                Test.@test flow isa Flows.AbstractFlow
                 Test.@test Flows.system(flow) isa CTFlowsSciMLFlows.SciMLFunctionSystem
             end
 
@@ -62,7 +62,7 @@ function test_scimlbase_flow_constructors()
                 prob = ODEProblem(f, [1.0], (0.0, 1.0), 2.0)
                 flow = Flows.Flow(prob; reltol=1e-10)
                 Test.@test flow isa CTFlowsSciMLFlows.SciMLProblemFlow
-                Test.@test flow isa AbstractFlow
+                Test.@test flow isa Flows.AbstractFlow
             end
 
             Test.@testset "kwargs passed to integrator" begin

--- a/test/suite/extensions/test_scimlbase_function_system.jl
+++ b/test/suite/extensions/test_scimlbase_function_system.jl
@@ -1,15 +1,15 @@
 module TestSciMLBaseFunctionSystem
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions: Exceptions
-import CTBase.Strategies: Strategies
-import CTFlows: CTFlows
-import CTFlows.Configs: Configs
-import CTFlows.Systems: Systems
-import CTFlows.Integrators: Integrators
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
+using CTBase: Core
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTFlows: CTFlows
+using CTFlows: Configs
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTFlows: Trajectories
 
 # Fake tag type for testing stub behavior
 struct FakeTag <: Core.AbstractTag end

--- a/test/suite/extensions/test_scimlbase_problem_flow.jl
+++ b/test/suite/extensions/test_scimlbase_problem_flow.jl
@@ -1,10 +1,10 @@
 module TestSciMLBaseProblemFlow
 
 using Test: Test
-import CTBase.Exceptions: Exceptions
-import CTFlows: CTFlows
-import CTFlows.Integrators: Integrators
-import CTFlows.Flows: Flows, AbstractFlow
+using CTBase: Exceptions
+using CTFlows: CTFlows
+using CTFlows: Integrators
+using CTFlows: Flows
 
 # Get extension to access SciML integrator
 using SciMLBase: SciMLBase, ODEProblem, ODEFunction
@@ -32,7 +32,7 @@ function test_scimlbase_problem_flow()
                 integ = Integrators.SciML()
                 flow = CTFlowsSciMLFlows.SciMLProblemFlow(prob, integ)
                 Test.@test flow isa CTFlowsSciMLFlows.SciMLProblemFlow
-                Test.@test flow isa AbstractFlow
+                Test.@test flow isa Flows.AbstractFlow
                 Test.@test flow.prob === prob
                 Test.@test flow.integrator === integ
             end
@@ -43,7 +43,7 @@ function test_scimlbase_problem_flow()
                 integ = Integrators.SciML()
                 flow = CTFlowsSciMLFlows.SciMLProblemFlow(prob, integ)
                 Test.@test flow isa CTFlowsSciMLFlows.SciMLProblemFlow
-                Test.@test flow isa AbstractFlow
+                Test.@test flow isa Flows.AbstractFlow
                 Test.@test flow.prob === prob
                 Test.@test flow.integrator === integ
             end

--- a/test/suite/flows/test_abstract_flow.jl
+++ b/test/suite/flows/test_abstract_flow.jl
@@ -1,14 +1,14 @@
 module TestAbstractFlow
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Configs
-import CTBase.Traits
-import CTFlows.Integrators
-import CTBase.Data
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Configs
+using CTBase: Traits
+using CTFlows: Integrators
+using CTBase: Data
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_building_flows.jl
+++ b/test/suite/flows/test_building_flows.jl
@@ -2,12 +2,12 @@ module TestBuildingFlows
 
 using Test: Test
 using OrdinaryDiffEqTsit5
-import CTBase.Data
-import CTBase.Exceptions
-import CTFlows.Flows
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTBase.Traits
+using CTBase: Data
+using CTBase: Exceptions
+using CTFlows: Flows
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_calling_flows.jl
+++ b/test/suite/flows/test_calling_flows.jl
@@ -1,20 +1,20 @@
 module TestCallingFlows
 
 using Test: Test
-import CTFlows.Systems
-import CTBase.Data
-import CTBase.Differentiation
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTBase.Core
-import CTFlows.Configs
-import CTBase.Traits
+using CTFlows: Systems
+using CTBase: Data
+using CTBase: Differentiation
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Core
+using CTFlows: Configs
+using CTBase: Traits
 using CommonSolve: CommonSolve
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
-import CTBase.Exceptions
+using CTBase: Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_convenience_arity.jl
+++ b/test/suite/flows/test_convenience_arity.jl
@@ -6,10 +6,10 @@ Tests for the arity-checking guard on the OCP convenience constructors:
 module TestConvenienceArity
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
+using CTBase: Data
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5: Tsit5
 using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 

--- a/test/suite/flows/test_flow.jl
+++ b/test/suite/flows/test_flow.jl
@@ -1,12 +1,12 @@
 module TestFlow
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Configs
-import CTBase.Traits
-import CTBase.Strategies
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Configs
+using CTBase: Traits
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_flow_callables.jl
+++ b/test/suite/flows/test_flow_callables.jl
@@ -1,13 +1,13 @@
 module TestFlowCallables
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTFlows.Configs
-import CTBase.Traits
-import CTBase.Exceptions
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTFlows: Configs
+using CTBase: Traits
+using CTBase: Exceptions
 using CommonSolve: CommonSolve
 
 using StaticArrays: SA

--- a/test/suite/flows/test_flow_module.jl
+++ b/test/suite/flows/test_flow_module.jl
@@ -20,7 +20,7 @@ module TestFlowModule
 
 using Test: Test
 using CTFlows: CTFlows
-import CTFlows.Flows
+using CTFlows: Flows
 using CTFlows.Flows  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/flows/test_flow_routing.jl
+++ b/test/suite/flows/test_flow_routing.jl
@@ -5,14 +5,14 @@ Unit and integration tests for flow routing via CTBase.Strategies.
 module TestFlowRouting
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTFlows.Flows
-import CTBase.Differentiation
-import CTFlows.Integrators
-import CTBase.Data
-import CTFlows.Systems
-import CTBase.Traits
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTFlows: Flows
+using CTBase: Differentiation
+using CTFlows: Integrators
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Traits
 using ADTypes: ADTypes
 using OrdinaryDiffEqTsit5
 

--- a/test/suite/flows/test_gpu_routing.jl
+++ b/test/suite/flows/test_gpu_routing.jl
@@ -8,11 +8,11 @@ routing/resolution without executing on a device.
 module TestGPURouting
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTFlows.Flows
-import CTBase.Data
-import CTBase.Traits
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTFlows: Flows
+using CTBase: Data
+using CTBase: Traits
 using ADTypes: ADTypes
 using OrdinaryDiffEqTsit5
 

--- a/test/suite/flows/test_hamiltonian_getter_flows.jl
+++ b/test/suite/flows/test_hamiltonian_getter_flows.jl
@@ -4,12 +4,12 @@ using Test: Test
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
-import CTBase.Traits
-import CTBase.Data
-import CTFlows.Systems
-import CTBase.Differentiation
-import CTFlows.Flows
-import CTFlows.Integrators
+using CTBase: Traits
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Differentiation
+using CTFlows: Flows
+using CTFlows: Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_ocp_basic_flow.jl
+++ b/test/suite/flows/test_ocp_basic_flow.jl
@@ -10,12 +10,12 @@ using Test: Test
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 using StaticArrays: SA, SVector
-import CTBase.Data: Data
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTFlows.Integrators: Integrators
+using CTBase: Data
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Integrators
 using OrdinaryDiffEqTsit5: Tsit5
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/flows/test_ocp_control.jl
+++ b/test/suite/flows/test_ocp_control.jl
@@ -7,12 +7,12 @@ module TestOCPControl
 
 using Test: Test
 using StaticArrays: SA, SVector
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTFlows.Systems: Systems
+using CTBase: Data
+using CTBase: Traits
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Systems
 using OrdinaryDiffEqTsit5: Tsit5
 using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 

--- a/test/suite/flows/test_ocp_hamiltonian.jl
+++ b/test/suite/flows/test_ocp_hamiltonian.jl
@@ -12,9 +12,9 @@ module TestOCPHamiltonianFunction
 
 using Test: Test
 using CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTBase.Traits: Traits
-import CTBase.Data: Data
+using CTFlows: Flows
+using CTBase: Traits
+using CTBase: Data
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_ocp_model_traits.jl
+++ b/test/suite/flows/test_ocp_model_traits.jl
@@ -10,7 +10,7 @@ module TestOCPModelTraits
 
 using Test: Test
 using CTModels: CTModels
-import CTBase.Traits: Traits
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_ocp_pseudo_hamiltonian.jl
+++ b/test/suite/flows/test_ocp_pseudo_hamiltonian.jl
@@ -13,9 +13,9 @@ module TestOCPPseudoHamiltonianFunction
 
 using Test: Test
 using CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTBase.Traits: Traits
-import CTBase.Data: Data
+using CTFlows: Flows
+using CTBase: Traits
+using CTBase: Data
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_ocp_readouts.jl
+++ b/test/suite/flows/test_ocp_readouts.jl
@@ -9,8 +9,8 @@ integration tests (`test_ocp_control`, `test_optimal_control_flow`, `test_ocp_co
 module TestOCPReadouts
 
 using Test: Test
-import CTBase.Data: Data
-import CTFlows.Flows: Flows
+using CTBase: Data
+using CTFlows: Flows
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/flows/test_state_control_flows.jl
+++ b/test/suite/flows/test_state_control_flows.jl
@@ -6,13 +6,13 @@ StateFlowTrajectory (state + reconstructed control [+ objective from an OCP]).
 module TestStateControlFlows
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTFlows.Integrators: Integrators
+using CTBase: Data
+using CTBase: Traits
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Integrators
 using OrdinaryDiffEqTsit5: Tsit5
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/flows/test_variable_costate_flows.jl
+++ b/test/suite/flows/test_variable_costate_flows.jl
@@ -7,18 +7,18 @@ integration of the augmented state `[x; p; pv]` where `pv` is the costate of the
 module TestVariableCostateFlows
 
 using Test: Test
-import CTBase: CTBase
-import CTBase.Core
-import CTBase.Data: Data
-import CTBase.Exceptions: Exceptions
-import CTBase.Traits: Traits
-import CTFlows: CTFlows
-import CTFlows.Configs: Configs
-import CTFlows.Systems: Systems
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTFlows.Integrators: Integrators
-import CTBase.Differentiation
+using CTBase: CTBase
+using CTBase: Core
+using CTBase: Data
+using CTBase: Exceptions
+using CTBase: Traits
+using CTFlows: CTFlows
+using CTFlows: Configs
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: Integrators
+using CTBase: Differentiation
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/flows/test_variable_costate_free_time.jl
+++ b/test/suite/flows/test_variable_costate_free_time.jl
@@ -18,11 +18,11 @@ autonomous / NonFixed Hamiltonians.
 module TestVariableCostateFreeTime
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTBase.Exceptions: Exceptions
-import CTFlows.Flows: Flows
-import CTFlows.Systems: Systems
+using CTBase: Data
+using CTBase: Traits
+using CTBase: Exceptions
+using CTFlows: Flows
+using CTFlows: Systems
 using OrdinaryDiffEqTsit5: Tsit5
 using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 

--- a/test/suite/integration/test_control_and_variable.jl
+++ b/test/suite/integration/test_control_and_variable.jl
@@ -5,8 +5,8 @@ Based on OptimalControl.jl `example-control-and-variable`.
 module TestControlAndVariable
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
 

--- a/test/suite/integration/test_control_free.jl
+++ b/test/suite/integration/test_control_free.jl
@@ -5,8 +5,8 @@ via an augmented costate. Based on OptimalControl.jl `example-control-free`.
 module TestControlFree
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
 

--- a/test/suite/integration/test_double_integrator_consumption.jl
+++ b/test/suite/integration/test_double_integrator_consumption.jl
@@ -14,8 +14,8 @@ trivially — asserted for both. Multi-phase reconstruction validated via `*` co
 module TestDoubleIntegratorConsumption
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_energy.jl
+++ b/test/suite/integration/test_double_integrator_energy.jl
@@ -12,8 +12,8 @@ The smooth optimal control satisfies ∂H̃/∂u = 0 on the entire arc, so `:tot
 module TestDoubleIntegratorEnergy
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_energy_control_constraint.jl
+++ b/test/suite/integration/test_double_integrator_energy_control_constraint.jl
@@ -15,8 +15,8 @@ reconstruction validated via `*` composition.
 module TestDoubleIntegratorEnergyControlConstraint
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_energy_distance.jl
+++ b/test/suite/integration/test_double_integrator_energy_distance.jl
@@ -13,8 +13,8 @@ The smooth optimal control satisfies ∂H̃/∂u = 0 on the entire arc, so `:tot
 module TestDoubleIntegratorEnergyDistance
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_state.jl
+++ b/test/suite/integration/test_double_integrator_state.jl
@@ -16,10 +16,10 @@ boundary control). Also exercises the `*` multi-phase reconstruction with jumps
 module TestDoubleIntegratorState
 
 using Test: Test
-import CTBase.Data
-import CTModels: CTModels
-import CTFlows.Flows
-import CTFlows.Trajectories
+using CTBase: Data
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_state_first_order.jl
+++ b/test/suite/integration/test_double_integrator_state_first_order.jl
@@ -15,8 +15,8 @@ Analytic solution: `p0 = [38.4, 9.6]`, `t1 = 0.25`, `t2 = 0.75`.
 module TestDoubleIntegratorStateFirstOrder
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_double_integrator_time.jl
+++ b/test/suite/integration/test_double_integrator_time.jl
@@ -13,8 +13,8 @@ is `+1` then `-1`.
 module TestDoubleIntegratorTime
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_free_initial_time.jl
+++ b/test/suite/integration/test_free_initial_time.jl
@@ -15,8 +15,8 @@ for both. Multi-phase reconstruction validated via `*` composition.
 module TestFreeInitialTime
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_goddard.jl
+++ b/test/suite/integration/test_goddard.jl
@@ -1,16 +1,16 @@
 module TestGoddard
 
 using Test: Test
-import CTBase.Data
-import CTLie: CTLie
-import CTFlows.Flows
-import CTFlows.Trajectories
+using CTBase: Data
+using CTLie: CTLie
+using CTFlows: Flows
+using CTFlows: Trajectories
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearSolve, NonlinearProblem, SimpleNewtonRaphson, solve
 
-import CTBase: CTBase # For generated code by the @Lie macro (CTBase.Traits.*)
+using CTBase: CTBase # For generated code by the @Lie macro (CTBase.Traits.*)
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/integration/test_goddard_ocp.jl
+++ b/test/suite/integration/test_goddard_ocp.jl
@@ -11,17 +11,17 @@ exercises the `*` multi-phase reconstruction (a `CTModels.Solution`, PR 5 D3) an
 module TestGoddardOCP
 
 using Test: Test
-import CTBase.Data
-import CTBase.Traits
-import CTLie: CTLie
-import CTModels: CTModels
-import CTFlows.Flows
-import CTFlows.Trajectories
+using CTBase: Data
+using CTBase: Traits
+using CTLie: CTLie
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
 
-import CTBase: CTBase # For generated code by the @Lie macro (CTBase.Traits.*)
+using CTBase: CTBase # For generated code by the @Lie macro (CTBase.Traits.*)
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/integration/test_lqr_ricatti.jl
+++ b/test/suite/integration/test_lqr_ricatti.jl
@@ -14,8 +14,8 @@ so `:total` and `:partial` coincide — asserted strictly for both.
 module TestLqrRicatti
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_orbital_transfer_consumption.jl
+++ b/test/suite/integration/test_orbital_transfer_consumption.jl
@@ -17,8 +17,8 @@ but both are tested. Multi-phase reconstruction via `*` composition.
 module TestOrbitalTransferConsumption
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_orbital_transfer_energy.jl
+++ b/test/suite/integration/test_orbital_transfer_energy.jl
@@ -14,8 +14,8 @@ identical adjoint equations — asserted for both.
 module TestOrbitalTransferEnergy
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_orbital_transfer_time.jl
+++ b/test/suite/integration/test_orbital_transfer_time.jl
@@ -16,8 +16,8 @@ The bang control depends only on `p` (not `x`), so `:total` and `:partial` coinc
 module TestOrbitalTransferTime
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_exponential_consumption.jl
+++ b/test/suite/integration/test_simple_exponential_consumption.jl
@@ -14,8 +14,8 @@ The control is constant on each arc (0, +1), so `:total` and `:partial` coincide
 module TestSimpleExponentialConsumption
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_exponential_energy.jl
+++ b/test/suite/integration/test_simple_exponential_energy.jl
@@ -13,8 +13,8 @@ The smooth optimal control satisfies ∂H̃/∂u = 0 on the entire arc, so `:tot
 module TestSimpleExponentialEnergy
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_exponential_time.jl
+++ b/test/suite/integration/test_simple_exponential_time.jl
@@ -15,8 +15,8 @@ The bang control is piecewise constant on the arc so ∂H̃/∂u ≡ 0 trivially
 module TestSimpleExponentialTime
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_integrator_energy_free_tf.jl
+++ b/test/suite/integration/test_simple_integrator_energy_free_tf.jl
@@ -16,8 +16,8 @@ coincide — asserted strictly for both.
 module TestSimpleIntegratorEnergyFreeTf
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_integrator_lqr_free_tf.jl
+++ b/test/suite/integration/test_simple_integrator_lqr_free_tf.jl
@@ -15,8 +15,8 @@ The smooth optimal control satisfies ∂H̃/∂u = 0 on the entire arc, so `:tot
 module TestSimpleIntegratorLqrFreeTf
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_integrator_mixed_constraint.jl
+++ b/test/suite/integration/test_simple_integrator_mixed_constraint.jl
@@ -17,8 +17,8 @@ The control law `u = -x` has no explicit `p`-dependence (the constraint determin
 module TestSimpleIntegratorMixedConstraint
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_integrator_nonsmooth_turnpike.jl
+++ b/test/suite/integration/test_simple_integrator_nonsmooth_turnpike.jl
@@ -14,8 +14,8 @@ Both `:total` and `:partial` are tested — the control is constant on each arc
 module TestSimpleIntegratorNonsmoothTurnpike
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_simple_integrator_state_and_control_constraints_nonautonomous.jl
+++ b/test/suite/integration/test_simple_integrator_state_and_control_constraints_nonautonomous.jl
@@ -22,8 +22,8 @@ Multi-phase reconstruction validated via `*` composition with costate jump.
 module TestSimpleIntegratorStateControlNonautonomous
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using ForwardDiff: ForwardDiff
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve

--- a/test/suite/integration/test_singular_control.jl
+++ b/test/suite/integration/test_singular_control.jl
@@ -20,8 +20,8 @@ Shooting (5 equations, 5 unknowns [p₁₀, p₂₀, p₃₀, θ₀, tf]):
 module TestSingularControl
 
 using Test: Test
-import CTModels: CTModels
-import CTFlows.Flows
+using CTModels: CTModels
+using CTFlows: Flows
 using OrdinaryDiffEqTsit5
 using NonlinearSolve: NonlinearProblem, SimpleNewtonRaphson, solve
 

--- a/test/suite/integrators/test_integrators_shim.jl
+++ b/test/suite/integrators/test_integrators_shim.jl
@@ -1,8 +1,8 @@
 module TestIntegratorsShim
 
 using Test: Test
-import CTFlows.Integrators: Integrators
-import CTSolvers.Integrators as CTSI
+using CTFlows: Integrators
+using CTSolvers: Integrators as CTSI
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_alias_subtyping.jl
+++ b/test/suite/meta/test_alias_subtyping.jl
@@ -17,11 +17,11 @@ instead of surfacing as a mysterious dispatch bug elsewhere.
 module TestAliasSubtyping
 
 using Test: Test
-import CTBase.Data: Data
-import CTFlows.Configs
-import CTFlows.Flows
-import CTFlows.Systems
-import CTFlows.MultiPhase
+using CTBase: Data
+using CTFlows: Configs
+using CTFlows: Flows
+using CTFlows: Systems
+using CTFlows: MultiPhase
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_no_import.jl
+++ b/test/suite/meta/test_no_import.jl
@@ -1,0 +1,54 @@
+"""
+Regression guard for the Handbook rule "using, never import" (tenet 2,
+`philosophy/modules.md#using-never-import`): flags any tracked `.jl` or `.md`
+file that still uses the `import` keyword, or the forbidden dotted
+`using Pkg.Sub` form (the canonical spelling is `using Pkg: Sub`).
+"""
+
+module TestNoImport
+
+using Test: Test
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const IMPORT_RE = r"^\s*import\b"
+const DOTTED_USING_RE = r"^\s*using\s+[A-Za-z_]\w*\.[A-Za-z_]"
+
+# These 5 "module exports" test files deliberately use the dotted bare form
+# (`using CTFlows.Flows`) to verify — via `isdefined(test_module, sym)` — that the
+# module's declared exports actually land unqualified in a user's scope. This is the
+# "opt-in" pattern documented as legitimate in `philosophy/modules.md` ("using
+# MyPackage.Systems # opt-in: brings Systems exports into scope"), not a violation.
+const DOTTED_USING_EXEMPT = (
+    "test_flow_module.jl",
+    "test_trajectories_module.jl",
+    "test_configs_module.jl",
+    "test_multiphase_module.jl",
+    "test_systems_module.jl",
+)
+
+function test_no_import()
+    Test.@testset "No `import` / no dotted `using Pkg.Sub` (Handbook tenet 2)" verbose = VERBOSE showtiming =
+        SHOWTIMING begin
+        repo_root = joinpath(@__DIR__, "..", "..", "..")
+        tracked = filter(
+            f -> endswith(f, ".jl") || endswith(f, ".md"),
+            readlines(Cmd(`git ls-files`; dir=repo_root)),
+        )
+        for relpath in tracked
+            path = joinpath(repo_root, relpath)
+            check_dotted = !(basename(relpath) in DOTTED_USING_EXEMPT)
+            for line in eachline(path)
+                Test.@test !occursin(IMPORT_RE, line)
+                if check_dotted
+                    Test.@test !occursin(DOTTED_USING_RE, line)
+                end
+            end
+        end
+    end
+end
+
+end # module
+
+test_no_import() = TestNoImport.test_no_import()

--- a/test/suite/multiphase/test_calling_multiphase.jl
+++ b/test/suite/multiphase/test_calling_multiphase.jl
@@ -1,13 +1,13 @@
 module TestCallingMultiphase
 
 using Test: Test
-import CTFlows.MultiPhase
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTFlows.Flows
-import CTFlows.Configs
-import CTBase.Traits
-import CTFlows.Trajectories
+using CTFlows: MultiPhase
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTFlows: Configs
+using CTBase: Traits
+using CTFlows: Trajectories
 using CommonSolve: CommonSolve
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -59,8 +59,8 @@ struct MockIntegrationResult <: Integrators.AbstractIntegrationResult
     t::Vector{Float64}
 end
 
-import CTBase.Strategies
-import CTBase.Options
+using CTBase: Strategies
+using CTBase: Options
 
 Strategies.id(::Type{FakeIntegrator}) = :fake_integrator
 Strategies.metadata(::Type{FakeIntegrator}) = Strategies.StrategyMetadata()

--- a/test/suite/multiphase/test_concatenation.jl
+++ b/test/suite/multiphase/test_concatenation.jl
@@ -1,14 +1,14 @@
 module TestConcatenation
 
 using Test: Test
-import CTBase.Exceptions
-import CTFlows.MultiPhase
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTFlows.Flows
-import CTBase.Traits
-import CTBase.Strategies
-import CTBase.Options
+using CTBase: Exceptions
+using CTFlows: MultiPhase
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTBase: Traits
+using CTBase: Strategies
+using CTBase: Options
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/multiphase/test_concatenation_heterogeneous.jl
+++ b/test/suite/multiphase/test_concatenation_heterogeneous.jl
@@ -1,14 +1,14 @@
 module TestConcatenationHeterogeneous
 
 using Test: Test
-import CTBase.Exceptions
-import CTFlows.MultiPhase
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTFlows.Flows
-import CTBase.Traits
-import CTBase.Strategies
-import CTBase.Options
+using CTBase: Exceptions
+using CTFlows: MultiPhase
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTBase: Traits
+using CTBase: Strategies
+using CTBase: Options
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/multiphase/test_concatenation_sciml.jl
+++ b/test/suite/multiphase/test_concatenation_sciml.jl
@@ -1,12 +1,12 @@
 module TestConcatenationSciML
 
 using Test: Test
-import CTFlows.MultiPhase
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTFlows.Flows
-import CTBase.Data
-import CTFlows.Trajectories
+using CTFlows: MultiPhase
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTBase: Data
+using CTFlows: Trajectories
 
 using OrdinaryDiffEqTsit5
 using Plots

--- a/test/suite/multiphase/test_controlled_concatenation.jl
+++ b/test/suite/multiphase/test_controlled_concatenation.jl
@@ -8,12 +8,12 @@ Integration tests for the concatenation (`*`) of controlled (state) flows: a mul
 module TestControlledConcatenation
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTFlows.MultiPhase: MultiPhase
+using CTBase: Data
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: MultiPhase
 using OrdinaryDiffEqTsit5: Tsit5
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/multiphase/test_multiphase_flow.jl
+++ b/test/suite/multiphase/test_multiphase_flow.jl
@@ -1,11 +1,11 @@
 module TestMultiPhaseFlow
 
 using Test: Test
-import CTFlows.MultiPhase
-import CTFlows.Systems
-import CTFlows.Integrators
-import CTFlows.Flows
-import CTBase.Traits
+using CTFlows: MultiPhase
+using CTFlows: Systems
+using CTFlows: Integrators
+using CTFlows: Flows
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -26,8 +26,8 @@ struct FakeIntegrator <: Integrators.AbstractIntegrator
     result::Any
 end
 
-import CTBase.Strategies
-import CTBase.Options
+using CTBase: Strategies
+using CTBase: Options
 
 Strategies.id(::Type{FakeIntegrator}) = :fake_integrator
 Strategies.metadata(::Type{FakeIntegrator}) = Strategies.StrategyMetadata()

--- a/test/suite/multiphase/test_multiphase_module.jl
+++ b/test/suite/multiphase/test_multiphase_module.jl
@@ -15,7 +15,7 @@ module TestMultiPhaseModule
 
 using Test: Test
 using CTFlows: CTFlows
-import CTFlows.MultiPhase
+using CTFlows: MultiPhase
 using CTFlows.MultiPhase  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/multiphase/test_ocp_concatenation.jl
+++ b/test/suite/multiphase/test_ocp_concatenation.jl
@@ -13,12 +13,12 @@ a costate jump between phases, and the same-OCP requirement.
 module TestOCPConcatenation
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTFlows.Flows: Flows
-import CTFlows.Trajectories: Trajectories
-import CTFlows.MultiPhase: MultiPhase
+using CTBase: Data
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTFlows: Flows
+using CTFlows: Trajectories
+using CTFlows: MultiPhase
 using OrdinaryDiffEqTsit5: Tsit5
 using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 

--- a/test/suite/systems/test_abstract_system.jl
+++ b/test/suite/systems/test_abstract_system.jl
@@ -1,9 +1,9 @@
 module TestAbstractSystem
 
 using Test: Test
-import CTBase.Exceptions
-import CTFlows.Systems
-import CTBase.Traits
+using CTBase: Exceptions
+using CTFlows: Systems
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_building_systems.jl
+++ b/test/suite/systems/test_building_systems.jl
@@ -1,10 +1,10 @@
 module TestBuildingSystems
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Configs
-import CTBase.Data
-import CTBase.Traits
+using CTFlows: Systems
+using CTFlows: Configs
+using CTBase: Data
+using CTBase: Traits
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_constrained_pseudo_hamiltonian_system.jl
+++ b/test/suite/systems/test_constrained_pseudo_hamiltonian_system.jl
@@ -1,10 +1,10 @@
 module TestConstrainedPseudoHamiltonianSystem
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTBase.Differentiation: Differentiation
-import CTFlows.Systems: Systems
+using CTBase: Data
+using CTBase: Traits
+using CTBase: Differentiation
+using CTFlows: Systems
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff

--- a/test/suite/systems/test_ham_rhs_functors.jl
+++ b/test/suite/systems/test_ham_rhs_functors.jl
@@ -1,11 +1,11 @@
 module TestHamRHSFunctors
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTFlows.Systems: Systems
-import CTBase.Traits: Traits
-import CTBase.Differentiation
+using CTBase: Exceptions
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Traits
+using CTBase: Differentiation
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_hamiltonian_getter.jl
+++ b/test/suite/systems/test_hamiltonian_getter.jl
@@ -4,10 +4,10 @@ using Test: Test
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff  # triggers DifferentiationInterfaceForwardDiff (provides PushforwardFast)
-import CTBase.Traits
-import CTBase.Data
-import CTFlows.Systems
-import CTBase.Differentiation
+using CTBase: Traits
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Differentiation
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_hamiltonian_system.jl
+++ b/test/suite/systems/test_hamiltonian_system.jl
@@ -1,12 +1,12 @@
 module TestHamiltonianSystem
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTFlows.Systems: Systems
-import CTBase.Differentiation
-import CTFlows.Configs: Configs
+using CTBase: Exceptions
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Systems
+using CTBase: Differentiation
+using CTFlows: Configs
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_hamiltonian_vector_field_system.jl
@@ -1,14 +1,14 @@
 module TestHamiltonianVectorFieldSystem
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTFlows.Systems: Systems
-import CTFlows.Configs: Configs
-import CTFlows.Trajectories: Trajectories
-import StaticArrays: SA, StaticArrays
-import GPUArraysCore: GPUArraysCore
+using CTBase: Exceptions
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Systems
+using CTFlows: Configs
+using CTFlows: Trajectories
+using StaticArrays: SA, StaticArrays
+using GPUArraysCore: GPUArraysCore
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_hvf_rhs_functors.jl
+++ b/test/suite/systems/test_hvf_rhs_functors.jl
@@ -1,10 +1,10 @@
 module TestHVFRHSFunctors
 
 using Test: Test
-import CTBase.Data: Data
-import CTFlows.Systems: Systems
-import CTBase.Traits: Traits
-import StaticArrays: SA, SVector
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Traits
+using StaticArrays: SA, SVector
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_pseudo_hamiltonian_system.jl
+++ b/test/suite/systems/test_pseudo_hamiltonian_system.jl
@@ -1,10 +1,10 @@
 module TestPseudoHamiltonianSystem
 
 using Test: Test
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTBase.Differentiation: Differentiation
-import CTFlows.Systems: Systems
+using CTBase: Data
+using CTBase: Traits
+using CTBase: Differentiation
+using CTFlows: Systems
 using ADTypes: ADTypes
 using DifferentiationInterface: DifferentiationInterface
 using ForwardDiff: ForwardDiff

--- a/test/suite/systems/test_pseudo_hamiltonian_vector_field_system.jl
+++ b/test/suite/systems/test_pseudo_hamiltonian_vector_field_system.jl
@@ -1,11 +1,11 @@
 module TestPseudoHamiltonianVectorFieldSystem
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Data: Data
-import CTBase.Traits: Traits
-import CTFlows.Systems: Systems
-import CTFlows.Configs: Configs
+using CTBase: Exceptions
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Systems
+using CTFlows: Configs
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_pseudo_hvf_rhs_functors.jl
+++ b/test/suite/systems/test_pseudo_hvf_rhs_functors.jl
@@ -1,10 +1,10 @@
 module TestPseudoHVFRHSFunctors
 
 using Test: Test
-import CTBase.Data: Data
-import CTFlows.Systems: Systems
-import CTBase.Traits: Traits
-import StaticArrays: SA, SVector
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Traits
+using StaticArrays: SA, SVector
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/systems/test_rhs_functors.jl
+++ b/test/suite/systems/test_rhs_functors.jl
@@ -1,9 +1,9 @@
 module TestRhsFunctors
 
 using Test: Test
-import CTBase.Data
-import CTFlows.Systems
-import CTBase.Traits
+using CTBase: Data
+using CTFlows: Systems
+using CTBase: Traits
 using StaticArrays: StaticArrays
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/systems/test_systems_module.jl
+++ b/test/suite/systems/test_systems_module.jl
@@ -22,7 +22,7 @@ module TestSystemsModule
 
 using Test: Test
 using CTFlows: CTFlows
-import CTFlows.Systems
+using CTFlows: Systems
 using CTFlows.Systems  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/systems/test_vector_field_system.jl
+++ b/test/suite/systems/test_vector_field_system.jl
@@ -1,11 +1,11 @@
 module TestVectorFieldSystem
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Configs
-import CTBase.Data
-import CTBase.Traits
-import StaticArrays: SA, StaticArrays
+using CTFlows: Systems
+using CTFlows: Configs
+using CTBase: Data
+using CTBase: Traits
+using StaticArrays: SA, StaticArrays
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/trajectories/test_building_trajectories.jl
+++ b/test/suite/trajectories/test_building_trajectories.jl
@@ -1,12 +1,12 @@
 module TestBuildingTrajectories
 
 using Test: Test
-import CTFlows.Trajectories
-import CTFlows.Systems
-import CTFlows.Configs
-import CTBase.Data
-import CTBase.Traits: Traits
-import CTFlows.Integrators
+using CTFlows: Trajectories
+using CTFlows: Systems
+using CTFlows: Configs
+using CTBase: Data
+using CTBase: Traits
+using CTFlows: Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_hamiltonian_vector_field_trajectory.jl
@@ -1,10 +1,10 @@
 module TestHamiltonianVectorFieldTrajectory
 
 using Test: Test
-import CTFlows.Integrators: Integrators
-import CTFlows.Trajectories: Trajectories
-import CTBase.Exceptions
-import GPUArraysCore: GPUArraysCore
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Exceptions
+using GPUArraysCore: GPUArraysCore
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/trajectories/test_hamiltonian_vf_trajectory_shapes.jl
+++ b/test/suite/trajectories/test_hamiltonian_vf_trajectory_shapes.jl
@@ -1,12 +1,12 @@
 module TestHamiltonianVFTrajectoryShapes
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTBase.Data
-import CTBase.Traits
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Data
+using CTBase: Traits
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5

--- a/test/suite/trajectories/test_trajectories_module.jl
+++ b/test/suite/trajectories/test_trajectories_module.jl
@@ -14,11 +14,11 @@ module TestTrajectoriesModule
 
 using Test: Test
 using CTFlows: CTFlows
-import CTFlows.Trajectories
+using CTFlows: Trajectories
 using CTFlows.Trajectories  # For testing exported symbols
-import CTFlows.Flows: Flows
-import CTModels: CTModels
-import CTBase.Data: Data
+using CTFlows: Flows
+using CTModels: CTModels
+using CTBase: Data
 using OrdinaryDiffEqTsit5: Tsit5
 using ForwardDiff: ForwardDiff  # triggers the DI ForwardDiff extension (AutoForwardDiff)
 

--- a/test/suite/trajectories/test_vector_field_trajectory.jl
+++ b/test/suite/trajectories/test_vector_field_trajectory.jl
@@ -1,9 +1,9 @@
 module TestVectorFieldTrajectory
 
 using Test: Test
-import CTFlows.Trajectories
-import CTBase.Exceptions
-import CTFlows.Integrators
+using CTFlows: Trajectories
+using CTBase: Exceptions
+using CTFlows: Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/trajectories/test_vector_field_trajectory_shapes.jl
+++ b/test/suite/trajectories/test_vector_field_trajectory_shapes.jl
@@ -1,11 +1,11 @@
 module TestVectorFieldTrajectoryShapes
 
 using Test: Test
-import CTFlows.Systems
-import CTFlows.Flows
-import CTFlows.Integrators
-import CTFlows.Trajectories
-import CTBase.Data
+using CTFlows: Systems
+using CTFlows: Flows
+using CTFlows: Integrators
+using CTFlows: Trajectories
+using CTBase: Data
 
 using SciMLBase: SciMLBase
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5


### PR DESCRIPTION
## Summary

Enforces Handbook tenet 2 (`philosophy/modules.md#using-never-import`) across the whole repository: `import` is replaced with `using` everywhere, and the forbidden dotted `using Pkg.Sub` form is replaced with `using Pkg: Sub`. CTFlows.jl was the last ecosystem repo to enforce this (CTLie.jl already did it in [CTLie.jl#24](https://github.com/control-toolbox/CTLie.jl/pull/24)).

Closes #383.

- **src/ext**: mechanical `import`→`using` and de-dotting. `src/Integrators/Integrators.jl` re-homes the CTSolvers integrator surface (`AbstractIntegrator`, `SciML`, `merge`, …) via a module alias + explicit `const` re-bindings instead of a dotted `using`, preserving the exact same re-export behavior with no dot anywhere. Two ext files (`CTFlowsSciMLFlows`, `CTFlowsStaticArrays`) needed call-site qualification for symbols actually used from an included file, not just the manifest.
- **test**: same mechanical fix across every `test/suite/*` group. Two extension test files that imported `AbstractFlow`/`StateFlow` unqualified now import only `Flows` and qualify the `isa` checks.
- **docs**: the tutorial pages (`getting-started.md`, `flows/*.md`, `compatibility/*.md`) taught the "opt-in" convenience pattern (`using CTFlows.Flows` bringing exports into scope). Converting each `using` to the non-polluting form required qualifying every subsequent call site in each `@example`/`@setup`/`@repl` block (`Flows.Flow(...)`, `Data.VectorField(...)`, etc.) rather than keeping the export-polluting dotted form.
- **probe**: mechanical fix in `probe/cpu` and `probe/gpu`.
- **test/suite/meta/test_no_import.jl**: new regression guard (adapted from CTLie.jl's equivalent), scanning every tracked `.jl`/`.md` file for a leading `import` or the forbidden dotted `using` form. Five "module exports" test files are exempted by name — they deliberately use the dotted opt-in form to verify a submodule's declared exports actually land unqualified in a user's scope, exactly the pattern `philosophy/modules.md` documents as legitimate ("opt-in: brings Systems exports into scope").

No behavior change; this is a syntax-only migration except where noted above, where the runtime bindings/export lists are preserved exactly.

## Test plan

- [x] Full test suite: `Pkg.test()` — 97394 passed, 2 broken (pre-existing GPU skips, no CUDA hardware on this machine), 0 failed.
- [x] New `suite/meta/test_no_import.jl` guard passes repo-wide (94361 assertions, 0 failures).
- [x] Docs build (`julia --project=. docs/make.jl`) completes with 0 errors, confirming every rewritten `@example`/`@setup` block still executes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
